### PR TITLE
Workaround PULP_REDIS_PORT being accidentally set

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -203,6 +203,8 @@ objects:
             value: ${{OTEL_EXPORTER_OTLP_ENDPOINT}}
           - name: OTEL_TRACES_EXPORTER
             value: "none"
+          - name: PULP_REDIS_PORT
+            value: "6379"
     - name: content
       replicas: ${{PULP_CONTENT_REPLICAS}}
       podSpec:
@@ -251,6 +253,8 @@ objects:
             value: ${{OTEL_EXPORTER_OTLP_ENDPOINT}}
           - name: OTEL_TRACES_EXPORTER
             value: "none"
+          - name: PULP_REDIS_PORT
+            value: "6379"
     - name: worker
       replicas: ${{PULP_WORKER_REPLICAS}}
       podSpec:
@@ -300,6 +304,8 @@ objects:
             value: ${{OTEL_EXPORTER_OTLP_ENDPOINT}}
           - name: OTEL_TRACES_EXPORTER
             value: "none"
+          - name: PULP_REDIS_PORT
+            value: "6379"
     - name: otel-collector
       replicas: 1
       podSpec:


### PR DESCRIPTION
by Clowder to a tcp:// address rather than "6379".

Fixes: #28