### PR TITLE
Adds contentsources user and domain.admin role

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -74,6 +74,11 @@ objects:
       # Generate admin password
       openssl rand -base64 32 | tr -d '\n' > /tmp/password
       kubectl create secret generic pulp-admin-password --from-file /tmp/password
+      rm /tmp/password
+
+      # Generate contentsources user password
+      openssl rand -base64 32 | tr -d '\n' > /tmp/password
+      kubectl create secret generic pulp-content-sources-password --from-file /tmp/password
 
       # Create settings.py
       cat <<EOF > /tmp/settings.py
@@ -411,7 +416,13 @@ objects:
                 secretKeyRef:
                   name: pulp-admin-password
                   key: password
-                  optional: true
+                  optional: false
+            - name: CONTENT_SOURCES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: pulp-content-sources-password
+                  key: password
+                  optional: false
             - name: XDG_CONFIG_HOME
               value: "/tmp"
             - name: XDG_CACHE_HOME

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -394,6 +394,28 @@ objects:
             - name: pulp-settings
               secret:
                 secretName: pulp-settings
+      - name: create-contentsources-user
+        podSpec:
+          image: ${IMAGE}:${IMAGE_TAG}
+          command: [ '/bin/sh' ]
+          args:
+          - "-c"
+          - |
+            pulp config create --base-url http://pulp-api-svc:24817 --username admin --password "$PULP_ADMIN_PASSWORD" --domain default && \
+            pulp user create --username contentsources && \
+            pulp role create --name domain.admin --permission core.add_domain --permission core.add_headercontentguard --permission core.add_compositecontentguard --permission rpm.add_rpmrepository --permission rpm.add_rpmremote --permission rpm.add_rpmdistribution --permission rpm.add_rpmpublication && \
+            pulp user role-assignment add --username contentsources --role domain.admin --object ""
+          env:
+            - name: PULP_ADMIN_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: pulp-admin-password
+                  key: password
+                  optional: true
+            - name: XDG_CONFIG_HOME
+              value: "/tmp"
+            - name: XDG_CACHE_HOME
+              value: "/tmp"
 - apiVersion: v1
   kind: Service
   metadata:
@@ -481,6 +503,14 @@ objects:
     runOnNotReady: True
     jobs:
       - create-settings-and-ingress
+- apiVersion: cloud.redhat.com/v1alpha1
+  kind: ClowdJobInvocation
+  metadata:
+    name: create-contentsources-user
+  spec:
+    appName: pulp
+    jobs:
+      - create-contentsources-user
 parameters:
   - name: ENV_NAME
     description: Specify your (ephemeral) namespace


### PR DESCRIPTION
This patch adds a job that will:

  - create a new role called 'domain.admin'
  - create a user 'contentsources'
  - assign the 'domain.admin' role to the 'contentsources' user