### PR TITLE
Create role before creating contentsources user

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -446,8 +446,8 @@ objects:
           - "-c"
           - |
             pulp config create --base-url http://pulp-api-svc:24817 --api-root /api/pulp/ --username admin --password "$PULP_ADMIN_PASSWORD" --domain default && \
-            pulp user create --username contentsources --password "$CONTENT_SOURCES_PASSWORD" && \
             pulp role create --name domain.admin --permission core.add_domain --permission core.add_headercontentguard --permission core.add_compositecontentguard --permission rpm.add_rpmrepository --permission rpm.add_rpmremote --permission rpm.add_rpmdistribution --permission rpm.add_rpmpublication && \
+            pulp user create --username contentsources --password "$CONTENT_SOURCES_PASSWORD" && \
             pulp user role-assignment add --username contentsources --role domain.admin --object ""
           env:
             - name: PULP_ADMIN_PASSWORD


### PR DESCRIPTION
This is needed to improve the race condition where content sources authenticates succesfully the first time and when it tries to create a domain. If the role had not been assigned yet, the domain can't be created.