### PR TITLE
Patch opentelemetry-python-contrib

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -126,4 +126,7 @@ RUN chown :root /var/lib/pulp/{scripts,media,tmp,assets}
 
 RUN dnf install -y patch && dnf clean all
 
+COPY images/assets/otel-django.patch /tmp/otel-django.patch
+RUN patch -p1 -d /usr/local/lib/python3.9/site-packages/ < /tmp/otel-django.patch || /bin/true
+
 EXPOSE 80

--- a/images/assets/otel-django.patch
+++ b/images/assets/otel-django.patch
@@ -1,0 +1,13 @@
+diff --git a/opentelemetry/instrumentation/django/__init__.py b/opentelemetry/instrumentation/django/__init__.py
+index 37ac760283..b0b73168b3 100644
+--- a/opentelemetry/instrumentation/django/__init__.py
++++ b/opentelemetry/instrumentation/django/__init__.py
+@@ -327,7 +327,7 @@ def _instrument(self, **kwargs):
+         _DjangoMiddleware._active_request_counter = meter.create_up_down_counter(
+             name=MetricInstruments.HTTP_SERVER_ACTIVE_REQUESTS,
+             unit="requests",
+-            description="measures the number of concurrent HTTP requests those are currently in flight",
++            description="measures the number of concurrent HTTP requests that are currently in-flight",
+         )
+         # This can not be solved, but is an inherent problem of this approach:
+         # the order of middleware entries matters, and here you have no control


### PR DESCRIPTION
Due to an issue https://github.com/open-telemetry/opentelemetry-python-contrib/issues/2513

We can remove the patch once https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2514 is released.