### PR TITLE
Remove unneeded password argument when creating rhivos domain

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -601,7 +601,7 @@ objects:
           - "-c"
           - |
             pulp config create --base-url http://pulp-api:8000 --api-root /api/pulp/ --username admin --password "$PULP_ADMIN_PASSWORD" --domain default
-            pulp --password $PULP_ADMIN_PASSWORD domain create --name rhivos --storage-class storages.backends.s3boto3.S3Boto3Storage --storage-settings "$(python3 /tmp/domain-storage-script.py)"
+            pulp domain create --name rhivos --storage-class storages.backends.s3boto3.S3Boto3Storage --storage-settings "$(python3 /tmp/domain-storage-script.py)"
           volumeMounts:
             - name: domain-storage-config
               mountPath: /tmp/domain-storage-script.py


### PR DESCRIPTION
There's no need for it because it's already defined in the config file.