### PR TITLE
Remove the init container from migrate-db

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -498,11 +498,11 @@ objects:
           - name: pulp-settings
             secret:
               secretName: pulp-settings
-        initContainers:
-          - name: wait-on-migrations
-            image: ${IMAGE}:${IMAGE_TAG}
-            command: [ "/usr/bin/wait_on_postgres.py" ]
-            inheritEnv: True
+#        initContainers:
+#          - name: wait-on-migrations
+#            image: ${IMAGE}:${IMAGE_TAG}
+#            command: [ "/usr/bin/wait_on_postgres.py" ]
+#            inheritEnv: True
         readinessProbe:
           exec:
             command: ["stat", "/tmp/migrated"]


### PR DESCRIPTION
Temporarily removing this so the main container can run the handle-artifact-checksums command.