### PR TITLE
test-metadata task is now versioned at 0.1

### DIFF
--- a/.tekton/pulp-deploy-and-test.yaml
+++ b/.tekton/pulp-deploy-and-test.yaml
@@ -120,7 +120,7 @@ spec:
           - name: revision
             value: main
           - name: pathInRepo
-            value: common/tasks/test-metadata/test-metadata.yaml
+            value: common/tasks/test-metadata/0.1/test-metadata.yaml
       params:
         - name: SNAPSHOT
           value: $(params.SNAPSHOT)


### PR DESCRIPTION
This is needed after the change here: https://github.com/konflux-ci/konflux-qe-definitions/pull/21/