### PR TITLE
deploy: Add missing cpu limit and request

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -549,8 +549,10 @@ objects:
           resources:
             requests:
               memory: 192Mi
+              cpu: 250m
             limits:
               memory: 384Mi
+              cpu: 500m
       - name: reset-admin-password
         podSpec:
           image: ${IMAGE}:${IMAGE_TAG}


### PR DESCRIPTION
The job create-settings-and-ingress needs a cpu limit and request as well.