### PR TITLE
Adds ability to PATCH and DELETE domains

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -606,7 +606,7 @@ objects:
               user, created = User.objects.get_or_create(username='contentsources')
               password = getenv("CONTENT_SOURCES_PASSWORD")
               user.set_password(password)
-              user.is_superuser = True
+              user.is_superuser = False
               user.save()
           volumeMounts:
             - name: secret-volume


### PR DESCRIPTION
The user is only able to kick off the task, but not actually monitor the task that is
happening in the Default domain.

This also makes contentsources user non-admin again.
