### PR TITLE
Fix additional paths for http_target (last fix)

### DIFF
--- a/images/assets/patches/0006-Add-the-http-target-to-pulp-api-instrumentation.patch
+++ b/images/assets/patches/0006-Add-the-http-target-to-pulp-api-instrumentation.patch
@@ -9,25 +9,35 @@
  import functools
  import typing
  import wsgiref.util as wsgiref_util
-@@ -266,6 +268,10 @@
+@@ -266,6 +268,15 @@
  _CARRIER_KEY_PREFIX = "HTTP_"
  _CARRIER_KEY_PREFIX_LEN = len(_CARRIER_KEY_PREFIX)
  
 +# it is useful to separate the domain and uuid patterns because some URLs might not include the uuid
++assets_pattern = re.compile(r"api\/pulp\/assets\/admin\/.*")
++admin_pattern = re.compile(r"api\/pulp-admin\/.*")
++pypi_pattern = re.compile(r"api\/pulp\/pypi\/.*")
 +domain_pattern = re.compile(r"pulp\/([a-zA-Z0-9_-]{1,50})\/api\/v3\/")
 +uuid_pattern = re.compile(r"[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}")
++version_pattern = re.compile(r"{uuid}\/versions\/[0-9]+\/")
++user_pattern = re.compile(r"api\/v3\/users\/[0-9]+\/")
 +
  
  class WSGIGetter(Getter[dict]):
      def get(
-@@ -350,7 +356,10 @@
+@@ -350,7 +361,15 @@
          target = environ.get("REQUEST_URI")
      if target:
          path, query = _parse_url_query(target)
 -        _set_http_target(result, target, path, query, sem_conv_opt_in_mode)
 +        unquoted_path = urllib.parse.unquote(path)
-+        new_path = domain_pattern.sub(r"pulp/{domain}/api/v3/", unquoted_path)
++        new_path = assets_pattern.sub("api/pulp/assets/admin/{path}", unquoted_path)
++        new_path = admin_pattern.sub("api/pulp-admin/{path}", new_path)
++        new_path = pypi_pattern.sub("api/pulp/pypi/{path}", new_path)
++        new_path = domain_pattern.sub(r"pulp/{domain}/api/v3/", new_path)
 +        new_path = uuid_pattern.sub("{uuid}", new_path)
++        new_path = version_pattern.sub("{uuid}/versions/{number}/", new_path)
++        new_path = user_pattern.sub("api/v3/users/{id}/", new_path)
 +        _set_http_target(result, new_path, path, query, sem_conv_opt_in_mode)
      else:
          # old semconv v1.20.0


### PR DESCRIPTION
This addresses the remaining bugs related to processing http_target. The commit fixes paths in the following formats:
- "/api/pulp/{domain}/api/v3/repositories/rpm/rpm/{uuid}/versions/4/"
- "/api/pulp/{domain}/api/v3/users/11/"
- "/api/pulp-admin/service/domainorg/54/change/"
- "/api/pulp/assets/admin/css/widgets.css"
- "/api/pulp/pypi/decko-python-content-test/python/simple/"