### PR TITLE
Add a custom metrics middleware for pulp-content

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -200,7 +200,6 @@ objects:
           apiPath: pulp
       podSpec:
         image: ${IMAGE}:${IMAGE_TAG}
-        # command: ['/usr/local/lib/pulp/bin/opentelemetry-instrument', '--service_name', 'pulp-api', '--exporter_otlp_endpoint', 'http://pulp-otel-collector:10000', '--exporter_otlp_insecure', 'true', 'pulpcore-api', '-b', '0.0.0.0:8000', '--timeout', '90', '--workers', '${PULP_API_GUNICORN_WORKERS}', '--access-logfile', '-']
         command: ['pulpcore-api', '-b', '0.0.0.0:8000', '--timeout', '90', '--workers', '${PULP_API_GUNICORN_WORKERS}', '--access-logfile', '-']
         volumeMounts:
         - name: secret-volume
@@ -325,7 +324,7 @@ objects:
           apiPath: pulp-content
       podSpec:
         image: ${IMAGE}:${IMAGE_TAG}
-        command: ['/usr/local/lib/pulp/bin/opentelemetry-instrument', '--service_name', 'pulp-content', '--exporter_otlp_endpoint', 'http://pulp-otel-collector:10000', '--exporter_otlp_insecure', 'true', 'pulpcore-content', '-b', '0.0.0.0:8000', '--access-logfile', '-']
+        command: ['pulpcore-content', '-b', '0.0.0.0:8000', '--access-logfile', '-']
         volumeMounts:
           - name: secret-volume
             mountPath: "/etc/pulp/keys"

--- a/pulp_service/pulp_service/app/content.py
+++ b/pulp_service/pulp_service/app/content.py
@@ -1,0 +1,69 @@
+import time
+
+from aiohttp import web
+from frozenlist import FrozenList
+
+from opentelemetry import metrics
+from opentelemetry.metrics import set_meter_provider
+from opentelemetry.sdk.metrics import MeterProvider
+from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
+from opentelemetry.exporter.otlp.proto.http.metric_exporter import (
+    OTLPMetricExporter,
+)
+from opentelemetry.sdk.resources import Resource
+
+from pulpcore.app.util import get_worker_name
+from pulpcore.plugin.content import app
+
+from pulp_service.app.util import normalize_status
+
+
+exporter = OTLPMetricExporter()
+reader = PeriodicExportingMetricReader(exporter)
+resource = Resource(attributes={"service.name": "pulp-content"})
+provider = MeterProvider(metric_readers=[reader], resource=resource)
+
+set_meter_provider(provider)
+meter = metrics.get_meter("pulp.metrics")
+
+request_duration_histogram = meter.create_histogram(
+    name="content.request_duration",
+    description="Tracks the duration of HTTP requests",
+    unit="ms"
+)
+
+
+@web.middleware
+async def metrics_middleware(request, handler):
+    start_time = time.time()
+
+    try:
+        response = await handler(request)
+        status_code = response.status
+    except web.HTTPException as exc:
+        status_code = exc.status
+        response = exc
+
+    duration_ms = (time.time() - start_time) * 1000
+
+    request_duration_histogram.record(
+        duration_ms,
+        attributes={
+            "http.method": request.method,
+            "http.status_code": normalize_status(status_code),
+            "http.route": _get_view_func(request),
+            "worker.name": get_worker_name(),
+        },
+    )
+
+    return response
+
+
+def _get_view_func(request):
+    try:
+        return request.match_info.handler.__name__
+    except AttributeError:
+        return "unknown"
+
+
+app._middlewares = FrozenList([metrics_middleware, *app.middlewares])

--- a/pulp_service/pulp_service/app/util.py
+++ b/pulp_service/pulp_service/app/util.py
@@ -1,0 +1,13 @@
+def normalize_status(status):
+    if 100 <= status < 200:
+        return "1xx"
+    elif 200 <= status < 300:
+        return "2xx"
+    elif 300 <= status < 400:
+        return "3xx"
+    elif 400 <= status < 500:
+        return "4xx"
+    elif 500 <= status < 600:
+        return "5xx"
+    else:
+        return ""


### PR DESCRIPTION
In this commit, the `pulp_http_server_custom_request_duration_milliseconds_*` metric was split into two `pulp_content_request_duration_milliseconds_*` and `pulp_api_request_duration_milliseconds_*` metrics.

Even though these metrics are self-explanatory, it is still recommended to specify "service.name". Otherwise, "exported_job" on the collector's side will be set to "unknown_service".