### PR TITLE
Update the dashboard to show the latest custom metrics

### DIFF
--- a/deploy/dashboards/grafana-dashboard-pulp.configmap.yaml
+++ b/deploy/dashboards/grafana-dashboard-pulp.configmap.yaml
@@ -81,7 +81,7 @@ data:
           },
           "gridPos": {
             "h": 5,
-            "w": 5,
+            "w": 6,
             "x": 0,
             "y": 1
           },
@@ -197,7 +197,7 @@ data:
           },
           "gridPos": {
             "h": 8,
-            "w": 7,
+            "w": 10,
             "x": 0,
             "y": 7
           },
@@ -221,12 +221,12 @@ data:
                 "uid": "${datasource}"
               },
               "disableTextWrap": false,
-              "editorMode": "builder",
-              "expr": "histogram_quantile(0.99, sum by(le) (rate(pulp_http_server_duration_milliseconds_bucket{exported_job=\"pulp-content\"}[$__rate_interval])))",
+              "editorMode": "code",
+              "expr": "histogram_quantile(0.99, sum by(le) (increase(pulp_content_request_duration_milliseconds_bucket[30m])))",
               "fullMetaSearch": false,
               "includeNullMetadata": false,
               "instant": false,
-              "interval": "2m",
+              "interval": "1m",
               "legendFormat": "P99",
               "range": true,
               "refId": "A",
@@ -238,13 +238,13 @@ data:
                 "uid": "${datasource}"
               },
               "disableTextWrap": false,
-              "editorMode": "builder",
-              "expr": "histogram_quantile(0.95, sum by(le) (rate(pulp_http_server_duration_milliseconds_bucket{exported_job=\"pulp-content\"}[$__rate_interval])))",
+              "editorMode": "code",
+              "expr": "histogram_quantile(0.95, sum by(le) (increase(pulp_content_request_duration_milliseconds_bucket[30m])))",
               "fullMetaSearch": false,
               "hide": false,
               "includeNullMetadata": false,
               "instant": false,
-              "interval": "2m",
+              "interval": "1m",
               "legendFormat": "P95",
               "range": true,
               "refId": "B",
@@ -256,20 +256,20 @@ data:
                 "uid": "${datasource}"
               },
               "disableTextWrap": false,
-              "editorMode": "builder",
-              "expr": "histogram_quantile(0.5, sum by(le) (rate(pulp_http_server_duration_milliseconds_bucket{exported_job=\"pulp-content\"}[$__rate_interval])))",
+              "editorMode": "code",
+              "expr": "histogram_quantile(0.90, sum by(le) (increase(pulp_content_request_duration_milliseconds_bucket[30m])))",
               "fullMetaSearch": false,
               "hide": false,
               "includeNullMetadata": false,
               "instant": false,
-              "interval": "2m",
+              "interval": "1m",
               "legendFormat": "P90",
               "range": true,
               "refId": "C",
               "useBackend": false
             }
           ],
-          "title": "[Content] Latency Percentiles (2m step)",
+          "title": "[Content] Latency Percentiles",
           "type": "timeseries"
         },
         {
@@ -308,7 +308,7 @@ data:
                 "spanNulls": false,
                 "stacking": {
                   "group": "A",
-                  "mode": "none"
+                  "mode": "normal"
                 },
                 "thresholdsStyle": {
                   "mode": "off"
@@ -333,8 +333,8 @@ data:
           },
           "gridPos": {
             "h": 8,
-            "w": 7,
-            "x": 7,
+            "w": 10,
+            "x": 10,
             "y": 7
           },
           "id": 17,
@@ -357,37 +357,19 @@ data:
                 "uid": "${datasource}"
               },
               "disableTextWrap": false,
-              "editorMode": "builder",
-              "expr": "sum(rate(pulp_http_server_duration_milliseconds_count{exported_job=\"pulp-content\", http_status_code!=\"5..\"}[$__rate_interval]))",
+              "editorMode": "code",
+              "expr": "sum by (http_status_code)(increase(pulp_content_request_duration_milliseconds_count[30m]))",
               "fullMetaSearch": false,
               "includeNullMetadata": true,
               "instant": false,
-              "interval": "2m",
-              "legendFormat": "[2xx, 3xx, 4xx]",
+              "interval": "1m",
+              "legendFormat": "__auto",
               "range": true,
               "refId": "A",
               "useBackend": false
-            },
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${datasource}"
-              },
-              "disableTextWrap": false,
-              "editorMode": "builder",
-              "expr": "rate(pulp_http_server_duration_milliseconds_count{exported_job=\"pulp-content\", http_status_code=\"5..\"}[$__rate_interval])",
-              "fullMetaSearch": false,
-              "hide": false,
-              "includeNullMetadata": false,
-              "instant": false,
-              "interval": "2m",
-              "legendFormat": "__auto",
-              "range": true,
-              "refId": "B",
-              "useBackend": false
             }
           ],
-          "title": "[Content] Request rate of [2xx,3xx,4xx] against 5xx (2min step)",
+          "title": "[Content] Request rate of [2xx, 3xx, 4xx, 5xx]",
           "type": "timeseries"
         },
         {
@@ -469,7 +451,7 @@ data:
           },
           "gridPos": {
             "h": 8,
-            "w": 7,
+            "w": 10,
             "x": 0,
             "y": 16
           },
@@ -493,12 +475,12 @@ data:
                 "uid": "${datasource}"
               },
               "disableTextWrap": false,
-              "editorMode": "builder",
-              "expr": "histogram_quantile(0.99, sum by(le) (rate(pulp_http_server_duration_milliseconds_bucket{exported_job=\"pulp-api\"}[5m])))",
+              "editorMode": "code",
+              "expr": "histogram_quantile(0.99, sum by(le) (increase(pulp_api_request_duration_milliseconds_bucket[30m])))",
               "fullMetaSearch": false,
               "includeNullMetadata": false,
               "instant": false,
-              "interval": "2m",
+              "interval": "1m",
               "legendFormat": "P99",
               "range": true,
               "refId": "A",
@@ -510,13 +492,13 @@ data:
                 "uid": "${datasource}"
               },
               "disableTextWrap": false,
-              "editorMode": "builder",
-              "expr": "histogram_quantile(0.95, sum by(le) (rate(pulp_http_server_duration_milliseconds_bucket{exported_job=\"pulp-api\"}[5m])))",
+              "editorMode": "code",
+              "expr": "histogram_quantile(0.95, sum by(le) (increase(pulp_api_request_duration_milliseconds_bucket[30m])))",
               "fullMetaSearch": false,
               "hide": false,
               "includeNullMetadata": false,
               "instant": false,
-              "interval": "2m",
+              "interval": "1m",
               "legendFormat": "P95",
               "range": true,
               "refId": "B",
@@ -528,20 +510,20 @@ data:
                 "uid": "${datasource}"
               },
               "disableTextWrap": false,
-              "editorMode": "builder",
-              "expr": "histogram_quantile(0.9, sum by(le) (rate(pulp_http_server_duration_milliseconds_bucket{exported_job=\"pulp-api\"}[5m])))",
+              "editorMode": "code",
+              "expr": "histogram_quantile(0.90, sum by(le) (increase(pulp_api_request_duration_milliseconds_bucket[30m])))",
               "fullMetaSearch": false,
               "hide": false,
               "includeNullMetadata": false,
               "instant": false,
-              "interval": "2m",
+              "interval": "1m",
               "legendFormat": "P90",
               "range": true,
               "refId": "C",
               "useBackend": false
             }
           ],
-          "title": "[API] Latency Percentiles (2m step)",
+          "title": "[API] Latency Percentiles",
           "type": "timeseries"
         },
         {
@@ -549,6 +531,7 @@ data:
             "type": "prometheus",
             "uid": "${datasource}"
           },
+          "description": "",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -580,7 +563,7 @@ data:
                 "spanNulls": false,
                 "stacking": {
                   "group": "A",
-                  "mode": "none"
+                  "mode": "normal"
                 },
                 "thresholdsStyle": {
                   "mode": "off"
@@ -605,8 +588,8 @@ data:
           },
           "gridPos": {
             "h": 8,
-            "w": 7,
-            "x": 7,
+            "w": 10,
+            "x": 10,
             "y": 16
           },
           "id": 16,
@@ -629,37 +612,19 @@ data:
                 "uid": "${datasource}"
               },
               "disableTextWrap": false,
-              "editorMode": "builder",
-              "expr": "sum(rate(pulp_http_server_duration_milliseconds_count{exported_job=\"pulp-api\", http_status_code!=\"5..\"}[$__rate_interval]))",
+              "editorMode": "code",
+              "expr": "sum by (http_status_code)(increase(pulp_api_request_duration_milliseconds_count[30m]))",
               "fullMetaSearch": false,
               "includeNullMetadata": true,
               "instant": false,
-              "interval": "2m",
-              "legendFormat": "[2xx, 3xx, 4xx]",
+              "interval": "1m",
+              "legendFormat": "__auto",
               "range": true,
               "refId": "A",
               "useBackend": false
-            },
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${datasource}"
-              },
-              "disableTextWrap": false,
-              "editorMode": "builder",
-              "expr": "sum(rate(pulp_http_server_duration_milliseconds_count{exported_job=\"pulp-api\", http_status_code=\"5..\"}[$__rate_interval]))",
-              "fullMetaSearch": false,
-              "hide": false,
-              "includeNullMetadata": false,
-              "instant": false,
-              "interval": "2m",
-              "legendFormat": "5xx requests",
-              "range": true,
-              "refId": "B",
-              "useBackend": false
             }
           ],
-          "title": "[API] Request rate of [2xx,3xx,4xx] against 5xx (2min step)",
+          "title": "[API] Request rate of [2xx, 3xx, 4xx, 5xx]",
           "type": "timeseries"
         },
         {
@@ -737,7 +702,7 @@ data:
           },
           "gridPos": {
             "h": 8,
-            "w": 7,
+            "w": 10,
             "x": 0,
             "y": 25
           },
@@ -761,8 +726,9 @@ data:
                 "uid": "${datasource}"
               },
               "editorMode": "code",
-              "expr": "sum by (domain_name) (increase(pulp_artifacts_size_counter_Bytes_total[1h]))",
+              "expr": "topk(5, sum by (domain_name) (increase(pulp_artifacts_size_counter_Bytes_total[30m])))",
               "instant": false,
+              "interval": "1m",
               "legendFormat": "__auto",
               "range": true,
               "refId": "A"
@@ -833,8 +799,8 @@ data:
           },
           "gridPos": {
             "h": 8,
-            "w": 7,
-            "x": 7,
+            "w": 10,
+            "x": 10,
             "y": 25
           },
           "id": 21,
@@ -857,7 +823,8 @@ data:
                 "uid": "${datasource}"
               },
               "editorMode": "code",
-              "expr": "sum by (domain_name) (pulp_space_usage_bytes)",
+              "expr": "topk(5, sum by (domain_name) (pulp_space_usage_bytes))",
+              "interval": "",
               "legendFormat": "{{domain_name}}",
               "range": true,
               "refId": "A"
@@ -926,8 +893,8 @@ data:
             "overrides": []
           },
           "gridPos": {
-            "h": 8,
-            "w": 7,
+            "h": 7,
+            "w": 10,
             "x": 0,
             "y": 33
           },
@@ -951,14 +918,15 @@ data:
                 "uid": "${datasource}"
               },
               "editorMode": "code",
-              "expr": "pulp_tasks_longest_unblocked_time_seconds",
+              "expr": "sum(pulp_tasks_longest_unblocked_time_seconds)",
               "instant": false,
-              "legendFormat": "{{exported_job}}",
+              "interval": "",
+              "legendFormat": "task",
               "range": true,
               "refId": "A"
             }
           ],
-          "title": "Longest Waiting Task",
+          "title": "Longest Unblocked Task Wait Time",
           "type": "timeseries"
         },
         {
@@ -1021,9 +989,9 @@ data:
             "overrides": []
           },
           "gridPos": {
-            "h": 8,
-            "w": 7,
-            "x": 7,
+            "h": 7,
+            "w": 10,
+            "x": 10,
             "y": 33
           },
           "id": 26,
@@ -1046,9 +1014,9 @@ data:
                 "uid": "${datasource}"
               },
               "editorMode": "code",
-              "expr": "pulp_tasks_unblocked_queue",
+              "expr": "sum(pulp_tasks_unblocked_queue)",
               "instant": false,
-              "legendFormat": "{{exported_job}}",
+              "legendFormat": "tasks",
               "range": true,
               "refId": "A"
             }
@@ -1062,7 +1030,7 @@ data:
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 41
+            "y": 40
           },
           "id": 28,
           "panels": [],
@@ -1132,7 +1100,7 @@ data:
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 42
+            "y": 41
           },
           "id": 27,
           "options": {
@@ -1250,6 +1218,6 @@ data:
       "timezone": "",
       "title": "Pulp Metrics",
       "uid": "e50bb9f2-372c-4e94-aa61-fe1f1554812c",
-      "version": 1,
+      "version": 2,
       "weekStart": ""
     }


### PR DESCRIPTION
Also, queries for the existing graphs were improved. The min step was downscaled from 2m to 1m and the usual rate(interval[5m]) was replaced by increase(interval[30m]). Finally, the graphs monitoring the domains' utilization are now displaying only the top 5 domains sorted by usage.