### PR TITLE
Add `OTEL_METRIC_EXPORT_` env vars to content pods

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -376,6 +376,10 @@ objects:
             value: ${{OTEL_EXPORTER_OTLP_PROTOCOL}}
           - name: OTEL_EXPORTER_OTLP_ENDPOINT
             value: ${{OTEL_EXPORTER_OTLP_ENDPOINT}}
+          - name: OTEL_METRIC_EXPORT_INTERVAL
+            value: ${OTEL_METRIC_EXPORT_INTERVAL}
+          - name: OTEL_METRIC_EXPORT_TIMEOUT
+            value: ${OTEL_METRIC_EXPORT_TIMEOUT}
           - name: OTEL_TRACES_EXPORTER
             value: "none"
           - name: PULP_REDIS_PORT


### PR DESCRIPTION
Update the METRIC_EXPORT interval to get a more accurate output (for example, a burst of thousands of requests in a matter of 5~10 seconds not being visible in graphs).