### PR TITLE
[PULP-213] Add PULP_USE_UVLOOP envvar to activate uvloop in the content-app

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -143,6 +143,9 @@ RUN patch -p1 -d /usr/local/lib/pulp/lib/python${PYTHON_VERSION}/site-packages <
 COPY images/assets/patches/0019-Adds-LabelsMixin-to-ReadOnlyContentViewSet.patch /tmp/
 RUN patch -p1 -d /usr/local/lib/pulp/lib/python${PYTHON_VERSION}/site-packages < /tmp/0019-Adds-LabelsMixin-to-ReadOnlyContentViewSet.patch
 
+COPY images/assets/patches/0020-Add-uvloop-as-the-the-Gunicorn-worker-eventloop.patch /tmp/
+RUN patch -p1 -d /usr/local/lib/pulp/lib/python${PYTHON_VERSION}/site-packages < /tmp/0020-Add-uvloop-as-the-the-Gunicorn-worker-eventloop.patch
+
 RUN mkdir /licenses
 COPY LICENSE /licenses/LICENSE
 

--- a/images/assets/patches/0020-Add-uvloop-as-the-the-Gunicorn-worker-eventloop.patch
+++ b/images/assets/patches/0020-Add-uvloop-as-the-the-Gunicorn-worker-eventloop.patch
@@ -1,0 +1,33 @@
+From c5eff869698b792044eeecafc23cea63da7160c3 Mon Sep 17 00:00:00 2001
+From: Pedro Brochado <pedropsb95@gmail.com>
+Date: Thu, 14 Nov 2024 03:53:56 -0300
+Subject: [PATCH] Add uvloop as the the Gunicorn worker eventloop
+
+---
+ pulpcore/content/entrypoint.py | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/pulpcore/content/entrypoint.py b/pulpcore/content/entrypoint.py
+index 1179f782f..a654d977d 100644
+--- a/pulpcore/content/entrypoint.py
++++ b/pulpcore/content/entrypoint.py
+@@ -1,11 +1,15 @@
+ import click
+ from pulpcore.app.pulpcore_gunicorn_application import PulpcoreGunicornApplication
++import os
+ 
+ 
+ class PulpcoreContentApplication(PulpcoreGunicornApplication):
+     def load_app_specific_config(self):
++        worker_class = "aiohttp.GunicornWebWorker"
++        if os.getenv("PULP_USE_UVLOOP"):
++            worker_class = "aiohttp.GunicornUVLoopWebWorker"
+         self.set_option("default_proc_name", "pulpcore-content", enforced=True)
+-        self.set_option("worker_class", "aiohttp.GunicornWebWorker", enforced=True)
++        self.set_option("worker_class", worker_class, enforced=True)
+ 
+     def load(self):
+         import pulpcore.content
+-- 
+2.48.1
+

--- a/pulp_service/requirements.txt
+++ b/pulp_service/requirements.txt
@@ -10,3 +10,4 @@ pulp-cli-gem
 sentry-sdk
 app-common-python
 oras==0.2.24
+uvloop==0.21.0


### PR DESCRIPTION
Experiement with `uvloop`: https://github.com/pulp/pulpcore/issues/6021

Setting `PULP_USE_UVLOOP` to anything will enable it, while not having is set uses the regular worker.
