### PR TITLE
Fix handler code when content length is not known

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -143,6 +143,9 @@ RUN patch -p1 -d /usr/local/lib/pulp/lib/python${PYTHON_VERSION}/site-packages <
 COPY images/assets/patches/0020-Add-uvloop-as-the-the-Gunicorn-worker-eventloop.patch /tmp/
 RUN patch -p1 -d /usr/local/lib/pulp/lib/python${PYTHON_VERSION}/site-packages < /tmp/0020-Add-uvloop-as-the-the-Gunicorn-worker-eventloop.patch
 
+COPY images/assets/patches/0021-Fix-handler-code-when-content-length-is-not-known.patch /tmp/
+RUN patch -p1 -d /usr/local/lib/pulp/lib/python${PYTHON_VERSION}/site-packages < /tmp/0021-Fix-handler-code-when-content-length-is-not-known.patch
+
 RUN mkdir /licenses
 COPY LICENSE /licenses/LICENSE
 

--- a/images/assets/patches/0021-Fix-handler-code-when-content-length-is-not-known.patch
+++ b/images/assets/patches/0021-Fix-handler-code-when-content-length-is-not-known.patch
@@ -1,0 +1,30 @@
+From f447f67223415437dfe9ac870d8bdbe9b4aaad80 Mon Sep 17 00:00:00 2001
+From: git-hyagi <45576767+git-hyagi@users.noreply.github.com>
+Date: Wed, 26 Mar 2025 15:36:39 -0300
+Subject: [PATCH] Fix handler code when content length is not known
+
+This commit fixes an issue in telemetry when the  content-length
+is unknown and an the artifact size is `None`.
+---
+ pulpcore/content/handler.py | 5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/pulpcore/content/handler.py b/pulpcore/content/handler.py
+index 58766e261..fec806c83 100644
+--- a/pulpcore/content/handler.py
++++ b/pulpcore/content/handler.py
+@@ -1314,8 +1314,9 @@ class Handler:
+             response.headers["X-PULP-ARTIFACT-SIZE"] = content_length
+             artifacts_size_counter.add(content_length)
+         else:
+-            response.headers["X-PULP-ARTIFACT-SIZE"] = str(size)
+-            artifacts_size_counter.add(size)
++            if size:
++                response.headers["X-PULP-ARTIFACT-SIZE"] = str(size)
++                artifacts_size_counter.add(size)
+ 
+         if save_artifact and remote.policy != Remote.STREAMED:
+             content_artifacts = await asyncio.shield(
+-- 
+2.46.2
+


### PR DESCRIPTION
This commit fixes an issue in telemetry when the  content-length is unknown and an the artifact size is `None`