### PR TITLE
Add some keywords to log entries to parse it easily

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -363,7 +363,7 @@ objects:
           apiPath: pulp-content
       podSpec:
         image: ${IMAGE}:${IMAGE_TAG}
-        command: ['pulpcore-content', '-b', '0.0.0.0:8000', '--access-logfile', '-', '--access-logformat', '%a %t "%r" %s %b "%{Referer}i" "%{User-Agent}i" "%{X-PULP-CACHE}o" "%{X-PULP-ARTIFACT-SIZE}o" "%{X-RH-ORG-ID}o"']
+        command: ['pulpcore-content', '-b', '0.0.0.0:8000', '--access-logfile', '-', '--access-logformat', '%a %t "%r" %s %b "%{Referer}i" "%{User-Agent}i" cache:"%{X-PULP-CACHE}o" artifact_size:"%{X-PULP-ARTIFACT-SIZE}o" rh_org_id:"%{X-RH-ORG-ID}o"']
         volumeMounts:
           - name: secret-volume
             mountPath: "/etc/pulp/keys"

--- a/deploy/dashboards/grafana-dashboard-pulp.configmap.yaml
+++ b/deploy/dashboards/grafana-dashboard-pulp.configmap.yaml
@@ -1548,7 +1548,7 @@ data:
                 "uid": "P1A97A9592CB7F392"
               },
               "dimensions": {},
-              "expression": "filter @logStream like /pulp-${cluster:text}_pulp-content/ |\nfilter message like /\\/api\\/pulp-content\\/.*?\\/.*?\\/.*? HTTP.*/ |\nparse message /(?<host>.*?) (?<date>\\[.*?\\]) \"(?<method>.*?) \\/api\\/pulp-content\\/(?<domain>.*?)\\/.*? (?<HttpVersion>.*?)\" \\d+ \\d+ \".*?\" \".*?\" \"(HIT|MISS)\" \"(?<ArtifactSize>\\d+)\"( \"(?<OrgId>.*?)\")?$/ |\nstats sum(ArtifactSize) as requested_artifact_size by domain,bin(5m)\n\n# limit defines the max number of events (in the below lines, at max 5 log messages will be queried)\n# since we cannot define a limit based on the number of different domains, doing a sort | limit would not be useful in this scenario and would just generate more load\n#|sort requested_artifact_size desc\n#|limit 5",
+              "expression": "filter @logStream like /pulp-${cluster:text}_pulp-content/ |\nfilter message like /\\/api\\/pulp-content\\/.*?\\/.*?\\/.*? HTTP.*/ |\nparse message 'artifact_size:"*" as ArtifactSize |\nparse message /\\/api\\/pulp-content\\/(?<domain>.*?)\\/.*? |\nstats sum(ArtifactSize) as requested_artifact_size by domain,bin(5m)\n\n# limit defines the max number of events (in the below lines, at max 5 log messages will be queried)\n# since we cannot define a limit based on the number of different domains, doing a sort | limit would not be useful in this scenario and would just generate more load\n#|sort requested_artifact_size desc\n#|limit 5",
               "hide": false,
               "id": "",
               "label": "",


### PR DESCRIPTION
- **Set some keywords to easily parse logs when it's needed.**
- **Change the query to use the new parseable artifact_size info.**
