### PR TITLE
Increase the timeout value, the period of checking and the failure threshold.

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -504,7 +504,7 @@ objects:
             command:
               - "/usr/bin/wait_on_postgres.py"
           initialDelaySeconds: 10 
-          periodSeconds: 15
+          periodSeconds: 25
           timeoutSeconds: 20
           failureThreshold: 5
         terminationGracePeriodSeconds: 3660

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -503,9 +503,10 @@ objects:
           exec:
             command:
               - "/usr/bin/wait_on_postgres.py"
-          initialDelaySeconds: 3
-          periodSeconds: 10
-          timeoutSeconds: 10
+          initialDelaySeconds: 10 
+          periodSeconds: 15
+          timeoutSeconds: 20
+          failureThreshold: 5
         terminationGracePeriodSeconds: 3660
         sidecars:
           - name: otel-collector


### PR DESCRIPTION
This PR increases some properties of the readinessProbe for pulp-worker app:
- timeoutSeconds
- periodSeconds
- failureThreshold

## Summary by Sourcery

Enhancements:
- Increase readiness probe initialDelaySeconds from 3s to 10s, periodSeconds from 10s to 15s, and timeoutSeconds from 10s to 20s, and add a failureThreshold of 5 for the pulp-worker app