### PR TITLE
List domains alphabetically on the DomainOrg form of django admin.

### DIFF
--- a/pulp_service/pulp_service/app/admin.py
+++ b/pulp_service/pulp_service/app/admin.py
@@ -92,6 +92,10 @@ class DomainOrgAdmin(admin.ModelAdmin):
     list_editable = ["user", "org_id"]
     list_filter = ["user", "org_id"]
 
+    def formfield_for_foreignkey(self, db_field, request, **kwargs):
+        if db_field.name == "domain":
+            kwargs["queryset"] = Domain.objects.order_by("name")
+        return super().formfield_for_foreignkey(db_field, request, **kwargs)
 
 class DomainAdmin(admin.ModelAdmin):
     list_display = ["name", "description", "storage_class"]


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Sort the DomainOrgForm domain dropdown by name for easier lookup