### PR TITLE
Add some logging statements on wait_for_postgres script

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -589,7 +589,7 @@ objects:
             secret:
               secretName: pulp-settings
         initContainers:
-          - name: wait-on-migrations
+          - name: wait-on-postgres
             image: ${IMAGE}:${IMAGE_TAG}
             command: [ "/usr/bin/wait_on_postgres.py" ]
             inheritEnv: True

--- a/images/assets/wait_on_postgres.py
+++ b/images/assets/wait_on_postgres.py
@@ -2,21 +2,29 @@
 
 import sys
 import time
+import logging
 from django.db import connection, utils
+
+logger = logging.getLogger(__name__)
 
 if __name__ == "__main__":
 
+    logging.basicConfig(level=logging.INFO)
     print("Waiting on postgresql to start...")
+    logger.info("Waiting on postgresql to start...")
     for dummy in range(100):
         try:
             connection.ensure_connection()
             break
-        except utils.OperationalError:
+        except utils.OperationalError as exp:
+            logger.warning("Connection failed. Trying again...", exc_info=True)
             time.sleep(3)
 
     else:
+        logger.error("Unable to reach postgres.")
         print("Unable to reach postgres.")
         sys.exit(1)
 
+    logger.info("Postgres started.")
     print("Postgres started.")
     sys.exit(0)


### PR DESCRIPTION
## Summary by Sourcery

Instrument the PostgreSQL readiness script with structured logging and align the deployment initContainer naming

Enhancements:
- Add Python logging to wait_on_postgres.py with INFO, WARNING, and ERROR messages during startup retries
- Rename the initContainer from 'wait-on-migrations' to 'wait-on-postgres' in clowdapp.yaml
- Include a commented-out debug container section for troubleshooting in the deployment config