### PR TITLE
Add a debug init container for debug purposes

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -593,6 +593,10 @@ objects:
             image: ${IMAGE}:${IMAGE_TAG}
             command: [ "/usr/bin/wait_on_postgres.py" ]
             inheritEnv: True
+          - name: debug
+            image: ${IMAGE}:${IMAGE_TAG}
+            command: [ "tail -f /dev/null" ]
+            inheritEnv: True
         readinessProbe:
           exec:
             command: ["stat", "/tmp/migrated"]


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Introduce a "debug" init container in clowdapp.yaml that runs `tail -f /dev/null` with inherited environment variables to facilitate debugging sessions