### PR TITLE
Update konflux configs

### DIFF
--- a/.tekton/pulp-pull-request.yaml
+++ b/.tekton/pulp-pull-request.yaml
@@ -378,6 +378,56 @@ spec:
       workspaces:
       - name: workspace
         workspace: workspace
+    - name: sast-shell-check
+      params:
+        - name: image-digest
+          value: $(tasks.build-container.results.IMAGE_DIGEST)
+        - name: image-url
+          value: $(tasks.build-container.results.IMAGE_URL)
+      runAfter:
+        - build-container
+      taskRef:
+        params:
+          - name: name
+            value: sast-shell-check
+          - name: bundle
+            value: quay.io/konflux-ci/tekton-catalog/task-sast-shell-check:0.1@sha256:18d594df21cb92cbc409065b25a863492ea7209e2a34045ced69a24a68ca41d8
+          - name: kind
+            value: task
+        resolver: bundles
+      when:
+        - input: $(params.skip-checks)
+          operator: in
+          values:
+            - "false"
+      workspaces:
+        - name: workspace
+          workspace: workspace
+    - name: sast-unicode-check
+      params:
+        - name: image-digest
+          value: $(tasks.build-container.results.IMAGE_DIGEST)
+        - name: image-url
+          value: $(tasks.build-container.results.IMAGE_URL)
+      runAfter:
+        - build-container
+      taskRef:
+        params:
+          - name: name
+            value: sast-unicode-check
+          - name: bundle
+            value: quay.io/konflux-ci/tekton-catalog/task-sast-unicode-check:0.2@sha256:4d5bf6549e42184e462ab7ccfba0153954c65214aa82f319a3215e94e068cded
+          - name: kind
+            value: task
+        resolver: bundles
+      when:
+        - input: $(params.skip-checks)
+          operator: in
+          values:
+            - "false"
+      workspaces:
+        - name: workspace
+          workspace: workspace
     - name: clamav-scan
       params:
       - name: image-digest

--- a/.tekton/pulp-pull-request.yaml
+++ b/.tekton/pulp-pull-request.yaml
@@ -450,28 +450,6 @@ spec:
         operator: in
         values:
         - "false"
-    - name: sbom-json-check
-      params:
-      - name: IMAGE_URL
-        value: $(tasks.build-container.results.IMAGE_URL)
-      - name: IMAGE_DIGEST
-        value: $(tasks.build-container.results.IMAGE_DIGEST)
-      runAfter:
-      - build-container
-      taskRef:
-        params:
-        - name: name
-          value: sbom-json-check
-        - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-sbom-json-check:0.2@sha256:09b9895fb4195c18cd7529049f89b497021d14137bc0a3f7d747a4291d4a1ace
-        - name: kind
-          value: task
-        resolver: bundles
-      when:
-      - input: $(params.skip-checks)
-        operator: in
-        values:
-        - "false"
     - name: apply-tags
       params:
       - name: IMAGE

--- a/.tekton/pulp-push.yaml
+++ b/.tekton/pulp-push.yaml
@@ -375,6 +375,56 @@ spec:
       workspaces:
       - name: workspace
         workspace: workspace
+    - name: sast-shell-check
+      params:
+        - name: image-digest
+          value: $(tasks.build-container.results.IMAGE_DIGEST)
+        - name: image-url
+          value: $(tasks.build-container.results.IMAGE_URL)
+      runAfter:
+        - build-container
+      taskRef:
+        params:
+          - name: name
+            value: sast-shell-check
+          - name: bundle
+            value: quay.io/konflux-ci/tekton-catalog/task-sast-shell-check:0.1@sha256:18d594df21cb92cbc409065b25a863492ea7209e2a34045ced69a24a68ca41d8
+          - name: kind
+            value: task
+        resolver: bundles
+      when:
+        - input: $(params.skip-checks)
+          operator: in
+          values:
+            - "false"
+      workspaces:
+        - name: workspace
+          workspace: workspace
+    - name: sast-unicode-check
+      params:
+        - name: image-digest
+          value: $(tasks.build-container.results.IMAGE_DIGEST)
+        - name: image-url
+          value: $(tasks.build-container.results.IMAGE_URL)
+      runAfter:
+        - build-container
+      taskRef:
+        params:
+          - name: name
+            value: sast-unicode-check
+          - name: bundle
+            value: quay.io/konflux-ci/tekton-catalog/task-sast-unicode-check:0.2@sha256:4d5bf6549e42184e462ab7ccfba0153954c65214aa82f319a3215e94e068cded
+          - name: kind
+            value: task
+        resolver: bundles
+      when:
+        - input: $(params.skip-checks)
+          operator: in
+          values:
+            - "false"
+      workspaces:
+        - name: workspace
+          workspace: workspace
     - name: clamav-scan
       params:
       - name: image-digest

--- a/.tekton/pulp-push.yaml
+++ b/.tekton/pulp-push.yaml
@@ -447,28 +447,6 @@ spec:
         operator: in
         values:
         - "false"
-    - name: sbom-json-check
-      params:
-      - name: IMAGE_URL
-        value: $(tasks.build-container.results.IMAGE_URL)
-      - name: IMAGE_DIGEST
-        value: $(tasks.build-container.results.IMAGE_DIGEST)
-      runAfter:
-      - build-container
-      taskRef:
-        params:
-        - name: name
-          value: sbom-json-check
-        - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-sbom-json-check:0.2@sha256:09b9895fb4195c18cd7529049f89b497021d14137bc0a3f7d747a4291d4a1ace
-        - name: kind
-          value: task
-        resolver: bundles
-      when:
-      - input: $(params.skip-checks)
-        operator: in
-        values:
-        - "false"
     - name: apply-tags
       params:
       - name: IMAGE


### PR DESCRIPTION
These changes should fix the following errors in Konflux `Release` pipeline execution:
```
✕ [Violation] tasks.required_tasks_found
  ImageRef: quay.io/redhat-user-workloads/pulp-services-tenant/pulp/pulp@sha256:65b8fe3f7664292ebf4f2cef4998c3db688a1ef13ee1a848eff2c8a4976f97f9
  Reason: One of "sast-shell-check", "sast-shell-check-oci-ta" tasks is missing
  Terms: sast-shell-check, sast-shell-check-oci-ta
  Title: All required tasks were included in the pipeline
  Description: Ensure that the set of required tasks are included in the PipelineRun attestation. To exclude this rule add one or
  more of "tasks.required_tasks_found:sast-shell-check", "tasks.required_tasks_found:sast-shell-check-oci-ta" to the `exclude`
  section of the policy configuration.
  Solution: Make sure all required tasks are in the build pipeline. The required task list is contained as
  https://conforma.dev/docs/ec-cli/configuration.html#_data_sources under the key 'required-tasks'.

✕ [Violation] tasks.required_tasks_found
  ImageRef: quay.io/redhat-user-workloads/pulp-services-tenant/pulp/pulp@sha256:65b8fe3f7664292ebf4f2cef4998c3db688a1ef13ee1a848eff2c8a4976f97f9
  Reason: One of "sast-unicode-check", "sast-unicode-check-oci-ta" tasks is missing
  Terms: sast-unicode-check, sast-unicode-check-oci-ta
  Title: All required tasks were included in the pipeline
  Description: Ensure that the set of required tasks are included in the PipelineRun attestation. To exclude this rule add one or
  more of "tasks.required_tasks_found:sast-unicode-check", "tasks.required_tasks_found:sast-unicode-check-oci-ta" to the `exclude`
  section of the policy configuration.
  Solution: Make sure all required tasks are in the build pipeline. The required task list is contained as
  https://conforma.dev/docs/ec-cli/configuration.html#_data_sources under the key 'required-tasks'.

✕ [Violation] test.no_failed_tests
  ImageRef: quay.io/redhat-user-workloads/pulp-services-tenant/pulp/pulp@sha256:65b8fe3f7664292ebf4f2cef4998c3db688a1ef13ee1a848eff2c8a4976f97f9
  Reason: The Task "sbom-json-check" from the build Pipeline reports a failed test
  Term: sbom-json-check
  Title: No tests failed
  Description: Produce a violation if any non-informative tests have their result set to "FAILED". The result type is configurable
  by the "failed_tests_results" key, and the list of informative tests is configurable by the "informative_tests" key in the rule
  data. To exclude this rule add "test.no_failed_tests:sbom-json-check" to the `exclude` section of the policy configuration.
  Solution: There is a test that failed. Make sure that any task in the build pipeline with a result named 'TEST_OUTPUT' does not
  fail. More information about the test should be available in the logs for the build Pipeline.
```

## Summary by Sourcery

Update Konflux Tekton pipeline configurations to add missing SAST checks and fix task misconfigurations in both pull-request and push pipelines.

New Features:
- Include `sast-shell-check` and `sast-unicode-check` tasks in both PR and push pipelines

Bug Fixes:
- Correct the `clamav-scan` task parameters and bundle references
- Remove the misconfigured `sbom-json-check` references from the pipeline

Enhancements:
- Reorder tasks to satisfy required policy checks and ensure proper workspace binding