### PR TITLE
Set default containers for api and content pods

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -218,6 +218,9 @@ objects:
           enabled: true
           apiPath: pulp
       podSpec:
+        metadata:
+          annotations:
+            "kubectl.kubernetes.io/default-container": pulp-api
         image: ${IMAGE}:${IMAGE_TAG}
         command: ['pulpcore-api', '-b', '0.0.0.0:8000', '--timeout', '90', '--workers', '${PULP_API_GUNICORN_WORKERS}', '--access-logfile', '-', '--access-logformat', '(pulp [%({correlation-id}o)s]: %(h)s %(l)s %(u)s %(t)s "%(r)s" %(s)s %(b)s "%(f)s" "%(a)s" %(M)s)']
         volumeMounts:
@@ -364,6 +367,9 @@ objects:
           enabled: true
           apiPath: pulp-content
       podSpec:
+        metadata:
+          annotations:
+            "kubectl.kubernetes.io/default-container": pulp-content
         image: ${IMAGE}:${IMAGE_TAG}
         command: ['pulpcore-content', '-b', '0.0.0.0:8000', '--access-logfile', '-', '--access-logformat', '%a %t "%r" %s %b "%{Referer}i" "%{User-Agent}i" cache:"%{X-PULP-CACHE}o" artifact_size:"%{X-PULP-ARTIFACT-SIZE}o" rh_org_id:"%{X-RH-ORG-ID}o"']
         volumeMounts:


### PR DESCRIPTION
ref: https://issues.redhat.com/browse/PULP-585

## Summary by Sourcery

Annotate pulp API and content pods with kubectl default-container annotations

Enhancements:
- Add kubectl.kubernetes.io/default-container annotation to pulp-api pod
- Add kubectl.kubernetes.io/default-container annotation to pulp-content pod