### PR TITLE
Adjust the task used in tests and the dispatch method.

### DIFF
--- a/pulp_service/pulp_service/app/tasks/util.py
+++ b/pulp_service/pulp_service/app/tasks/util.py
@@ -1,5 +1,8 @@
+import time
 from datetime import timedelta
 from functools import wraps
+
+from django.db import connections
 
 from pulpcore.app.models import TaskSchedule
 from pulpcore.plugin.models import Distribution
@@ -42,4 +45,6 @@ def except_catch_and_raise(queue):
 
 
 def no_op_task():
-    pass
+    with connections["default"].cursor() as cursor:
+        cursor.execute("SELECT 1")
+    time.sleep(0.3) # This task will not take less than 300ms to execute

--- a/pulp_service/pulp_service/app/viewsets.py
+++ b/pulp_service/pulp_service/app/viewsets.py
@@ -199,7 +199,6 @@ class TaskIngestionDispatcherView(APIView):
     authentication_classes = []
     permission_classes = []
 
-
     def get(self, request=None, timeout=25):
         if not settings.TEST_TASK_INGESTION:
             raise PermissionError("Access denied.")
@@ -211,7 +210,7 @@ class TaskIngestionDispatcherView(APIView):
         while datetime.now() < start_time + timeout:
             dispatch(
                 'pulp_service.app.tasks.util.no_op_task',
-                exclusive_resources=str(uuid4())
+                exclusive_resources=[str(uuid4())]
             )
                 
             task_count = task_count + 1


### PR DESCRIPTION
## Summary by Sourcery

Adjust the no_op_task to perform a database query with a minimum execution duration and update the TaskIngestionDispatcher to pass exclusive resources as a list of UUIDs.

Enhancements:
- Make no_op_task execute a SELECT 1 query and sleep for at least 300ms
- Change exclusive_resources in dispatch call from a string to a list of UUIDs