### PR TITLE
Revert "Change the push and pull-request pipelines to add new tags an…

### DIFF
--- a/.tekton/pulp-pull-request.yaml
+++ b/.tekton/pulp-pull-request.yaml
@@ -7,8 +7,8 @@ metadata:
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-target-branch: "[main]"
-    pipelinesascode.tekton.dev/on-event: "[pull_request]"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
+      == "main"
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: pulp
@@ -454,8 +454,6 @@ spec:
       params:
       - name: IMAGE
         value: $(tasks.build-container.results.IMAGE_URL)
-      - name: ADDITIONAL_TAGS
-        value: ["on-pr-{{pull_request_number}}"]
       runAfter:
       - build-container
       taskRef:

--- a/.tekton/pulp-push.yaml
+++ b/.tekton/pulp-push.yaml
@@ -6,8 +6,8 @@ metadata:
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-target-branch: "[main, internal]"
-    pipelinesascode.tekton.dev/on-event: "[push]"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
+      == "main"
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: pulp
@@ -451,8 +451,6 @@ spec:
       params:
       - name: IMAGE
         value: $(tasks.build-container.results.IMAGE_URL)
-      - name: ADDITIONAL_TAGS
-        value: ["$(tasks.clone-repository.results.short-commit)"]
       runAfter:
       - build-container
       taskRef:


### PR DESCRIPTION
…d also build the internal branch (#544)"

This reverts commit 0fee170952fcad2012262f3574712888861e5fc4.

## Summary by Sourcery

Revert the specialized tag behavior and internal branch build by updating Tekton pipeline configs to use CEL-based triggers and removing extra tag parameters

Enhancements:
- Consolidate pipeline trigger settings into single CEL expressions for pull-request and push pipelines
- Remove ADDITIONAL_TAGS parameters from both pull-request and push build tasks