### PR TITLE
Reapply FeatureService PR

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -347,7 +347,7 @@ objects:
             value: ${{PULP_PYPI_API_HOSTNAME}}
           - name: PULP_USE_PYPI_API_HOSTNAME_AS_CONTENT_ORIGIN
             value: "true"
-          - name: PULP_SUBSCRIPTION_API_CERT
+          - name: PULP_FEATURE_SERVICE_API_CERT
             value: "/etc/pulp/certs/subscription-api-mock-cert.pem"
           - name: PULP_USE_X_FORWARDED_HOST
             value: ${PULP_USE_X_FORWARDED_HOST}
@@ -474,7 +474,7 @@ objects:
             value: ${PULP_DOMAIN_ENABLED}
           - name: PULP_ALLOWED_CONTENT_CHECKSUMS
             value: ${PULP_ALLOWED_CONTENT_CHECKSUMS}
-          - name: PULP_SUBSCRIPTION_API_CERT
+          - name: PULP_FEATURE_SERVICE_API_CERT
             value: "/etc/pulp/certs/subscription-api-mock-cert.pem"
           - name: PULP_TOKEN_AUTH_DISABLED
             value: ${PULP_TOKEN_AUTH_DISABLED}

--- a/pulp_service/pulp_service/app/models.py
+++ b/pulp_service/pulp_service/app/models.py
@@ -54,18 +54,20 @@ class FeatureContentGuard(HeaderContentGuard, AutoAddObjPermsMixin):
 
     def _check_for_feature(self, account_id):
         cert_context = ssl.create_default_context(ssl.Purpose.SERVER_AUTH)
-        cert_context.load_cert_chain(certfile=settings.SUBSCRIPTION_API_CERT)
+        cert_context.load_cert_chain(certfile=settings.FEATURE_SERVICE_API_CERT)
 
         account_id_query_param = f"accountId={account_id}"
         features_query_param = "&".join(
             f"features={feature}" for feature in self.features
         )
-        subscription_api_url = f"{settings.SUBSCRIPTION_API_URL}?{account_id_query_param}&{features_query_param}"
+        feature_service_api_url = (
+            f"{settings.FEATURE_SERVICE_API_URL}?{account_id_query_param}&{features_query_param}"
+        )
 
         async def fetch_feature():
             async with aiohttp.ClientSession() as session:
                 async with session.get(
-                    subscription_api_url, ssl=cert_context, raise_for_status=True
+                    feature_service_api_url, ssl=cert_context, raise_for_status=True
                 ) as response:
                     return await response.json()
 
@@ -92,7 +94,7 @@ class FeatureContentGuard(HeaderContentGuard, AutoAddObjPermsMixin):
         features_available = {
             feature["name"]
             for feature in response["features"]
-            if feature["entitled"] is True
+            if feature["isEntitled"] is True
         }
         return features_available == set(self.features)
 

--- a/pulp_service/pulp_service/app/settings.py
+++ b/pulp_service/pulp_service/app/settings.py
@@ -5,8 +5,8 @@ Check `Plugin Writer's Guide`_ for more details.
     https://docs.pulpproject.org/pulpcore/plugins/plugin-writer/index.html
 """
 
-SUBSCRIPTION_API_URL = "https://subscription.stage.api.redhat.com/svcrest/subscription/v5/featureStatus"
-SUBSCRIPTION_API_CERT = ""
+FEATURE_SERVICE_API_URL = "https://feature.stage.api.redhat.com/features/v1/featureStatus"
+FEATURE_SERVICE_API_CERT = ""
 AUTHENTICATION_HEADER_DEBUG = False
 INSTALLED_APPS = "@merge django.contrib.admin.apps.SimpleAdminConfig"
 TEST_TASK_INGESTION = False


### PR DESCRIPTION
This reverts commit a2121ee58bc04796269cc3e73b82832d94c2c34f.

## Summary by Sourcery

Reapply the FeatureService integration by replacing Subscription API references with the new FeatureService endpoints and credentials, update entitlement field parsing, and align deployment environment variables accordingly.

Enhancements:
- Switch FeatureContentGuard to load certificates and fetch from FEATURE_SERVICE_API_URL using FEATURE_SERVICE_API_CERT instead of the Subscription API
- Rename entitlement JSON field check from "entitled" to "isEntitled"
- Update settings to define FEATURE_SERVICE_API_URL and FEATURE_SERVICE_API_CERT in place of Subscription API settings

Deployment:
- Rename environment variable PULP_SUBSCRIPTION_API_CERT to PULP_FEATURE_SERVICE_API_CERT in deployment manifests