### PR TITLE
Add a check for a Response type object

### DIFF
--- a/pulp_service/pulp_service/app/content.py
+++ b/pulp_service/pulp_service/app/content.py
@@ -21,7 +21,7 @@ async def add_rh_org_id_resp_header(request, handler):
     rh_identity_header_json = json.loads(rh_identity_header_decoded)
 
     # we need to check if the entire path exists because non-entitlement certs have a diff structure
-    if "identity" in rh_identity_header_json and "org_id" in rh_identity_header_json["identity"]:
+    if isinstance(response, web.Response) and "identity" in rh_identity_header_json and "org_id" in rh_identity_header_json["identity"]:
         response.headers["X-RH-ORG-ID"] = rh_identity_header_json["identity"]["org_id"]
 
     return response


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Ensure X-RH-ORG-ID header is only added when response is an instance of web.Response