### PR TITLE
Adds TaskProfilerMiddleware

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -146,6 +146,9 @@ RUN patch -p1 -d /usr/local/lib/pulp/lib/python${PYTHON_VERSION}/site-packages <
 COPY images/assets/patches/0023-Replaces-use-of-HStoreField-with-a-custom-PulpLabels.patch /tmp/
 RUN patch -p1 -d /usr/local/lib/pulp/lib/python${PYTHON_VERSION}/site-packages < /tmp/0023-Replaces-use-of-HStoreField-with-a-custom-PulpLabels.patch
 
+COPY images/assets/patches/0024-Add-X-TASK-DIAGNOSTICS-header-support.patch /tmp/
+RUN patch -p1 -d /usr/local/lib/pulp/lib/python${PYTHON_VERSION}/site-packages < /tmp/0024-Add-X-TASK-DIAGNOSTICS-header-support.patch
+
 RUN mkdir /licenses
 COPY LICENSE /licenses/LICENSE
 

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -907,7 +907,7 @@ parameters:
     value: "/api/pulp/assets/"
   - name: PULP_MIDDLEWARE
     description: List of Middleware
-    value: "@merge ['pulp_service.app.middleware.ProfilerMiddleware', 'pulp_service.app.middleware.OCIStorageMiddleware', 'pulp_service.app.middleware.RhEdgeHostMiddleware']"
+    value: "@merge ['pulp_service.app.middleware.TaskProfilerMiddleware', 'pulp_service.app.middleware.ProfilerMiddleware', 'pulp_service.app.middleware.OCIStorageMiddleware', 'pulp_service.app.middleware.RhEdgeHostMiddleware']"
   - name: PULP_PYPI_API_HOSTNAME
     description: The hostname used to form the distribution's `base_url`.
     value: "http://pulp-content:8000"

--- a/images/assets/patches/0024-Add-X-TASK-DIAGNOSTICS-header-support.patch
+++ b/images/assets/patches/0024-Add-X-TASK-DIAGNOSTICS-header-support.patch
@@ -1,0 +1,66 @@
+From f9c10f816bc01f38c5c912a37c0e75f8a1fe6895 Mon Sep 17 00:00:00 2001
+From: Dennis Kliban <dkliban@redhat.com>
+Date: Tue, 24 Jun 2025 16:17:08 -0400
+Subject: [PATCH] Add X-TASK-DIAGNOSTICS header support
+
+This allows individual tasks to be profiled. The value must be one of "memory", "pyinstrument", "memray".
+---
+ pulpcore/tasking/_util.py | 4 ++++
+ pulpcore/tasking/tasks.py | 8 ++++++++
+ 2 files changed, 12 insertions(+)
+
+diff --git a/pulpcore/tasking/_util.py b/pulpcore/tasking/_util.py
+index cdadfb8f5..4f72a7261 100644
+--- a/pulpcore/tasking/_util.py
++++ b/pulpcore/tasking/_util.py
+@@ -127,10 +127,14 @@ def perform_task(task_pk, task_working_dir_rel_path):
+     set_domain(task.pulp_domain)
+     os.chdir(task_working_dir_rel_path)
+ 
++    original_task_diagnostics = list(settings.TASK_DIAGNOSTICS)
++    if task.enc_kwargs and "task_diagnostics" in task.enc_kwargs:
++        settings.TASK_DIAGNOSTICS = task.enc_kwargs["task_diagnostics"]
+     if settings.TASK_DIAGNOSTICS:
+         _execute_task_and_profile(task)
+     else:
+         execute_task(task)
++    settings.TASK_DIAGNOSTICS = original_task_diagnostics
+ 
+ 
+ def _execute_task_and_profile(task):
+diff --git a/pulpcore/tasking/tasks.py b/pulpcore/tasking/tasks.py
+index fabe8f737..c95988a40 100644
+--- a/pulpcore/tasking/tasks.py
++++ b/pulpcore/tasking/tasks.py
+@@ -30,6 +30,7 @@ from pulpcore.tasking.kafka import send_task_notification
+ 
+ _logger = logging.getLogger(__name__)
+ 
++from pulp_service.app.middleware import x_task_diagnostics_var
+ 
+ def _validate_and_get_resources(resources):
+     resource_set = set()
+@@ -53,6 +54,8 @@ def wakeup_worker():
+ 
+ 
+ def execute_task(task):
++    if task.enc_kwargs:
++        task.enc_kwargs.pop("task_diagnostics", None)
+     # This extra stack is needed to isolate the current_task ContextVar
+     contextvars.copy_context().run(_execute_task, task)
+ 
+@@ -197,6 +200,11 @@ def dispatch(
+         ValueError: When `resources` is an unsupported type.
+     """
+ 
++    task_diagnostics = x_task_diagnostics_var.get(None)
++    if task_diagnostics:
++        kwargs["task_diagnostics"] = [task_diagnostics]
++        x_task_diagnostics_var.set(None)
++
+     # Can't run short tasks immediately if running from thread pool
+     immediate = immediate and not running_from_thread_pool()
+     assert deferred or immediate, "A task must be at least `deferred` or `immediate`."
+-- 
+2.49.0
+

--- a/pulp_service/pulp_service/app/middleware.py
+++ b/pulp_service/pulp_service/app/middleware.py
@@ -17,6 +17,7 @@ from pulpcore.plugin.util import extract_pk, get_artifact_url, resolve_prn
 _logger = logging.getLogger(__name__)
 repository_name_var = ContextVar('repository_name')
 x_quay_auth_var = ContextVar('x_quay_auth')
+x_task_diagnostics_var = ContextVar('x_profile_task')
 
 
 class ProfilerMiddleware(MiddlewareMixin):
@@ -64,6 +65,15 @@ class ProfilerMiddleware(MiddlewareMixin):
 
         return response
 
+
+class TaskProfilerMiddleware(MiddlewareMixin):
+    def process_view(self, request, callback, callback_args, callback_kwargs):
+        if 'HTTP_X_TASK_DIAGNOSTICS' in request.META:
+            x_task_diagnostics_var.set(request.META['HTTP_X_TASK_DIAGNOSTICS'])
+
+    def process_response(self, request, response):
+        x_task_diagnostics_var.set(None)
+        return response
 
 class OCIStorageMiddleware(MiddlewareMixin):
     def process_view(self, request, callback, callback_args, callback_kwargs):

--- a/pulp_service/requirements.txt
+++ b/pulp_service/requirements.txt
@@ -1,4 +1,4 @@
-pulpcore==3.80.0
+pulpcore==3.80.1
 pulp-rpm==3.30.0
 pulp-gem==0.7.1
 pulp-ostree==2.4.6
@@ -13,3 +13,5 @@ app-common-python
 oras==0.2.24
 uvloop==0.21.0
 jsonschema
+memray
+pyinstrument


### PR DESCRIPTION
Requests that come in with X-TASK-DIAGNOSTICS header will cause tasks to be profiled. The value for the header needs to be one of "memory", "pyinstrument", or "memray".

## Summary by Sourcery

Add TaskProfilerMiddleware to capture X-TASK-DIAGNOSTICS header for task profiling, install required profiling libraries, and update build and deployment configurations to support it.

New Features:
- Introduce TaskProfilerMiddleware to read HTTP_X_TASK_DIAGNOSTICS and store its value in a context variable.

Enhancements:
- Add x_task_diagnostics_var context variable for task profiling metadata.

Build:
- Add memray and pyinstrument to requirements.txt.
- Copy and apply a patch in the Dockerfile to enable X-TASK-DIAGNOSTICS header support.

Deployment:
- Register TaskProfilerMiddleware in the PULP_MIDDLEWARE list in clowdapp.yaml.