### PR TITLE
Use labels to count ContentSources domains

### DIFF
--- a/pulp_service/pulp_service/app/tasks/domain_metrics.py
+++ b/pulp_service/pulp_service/app/tasks/domain_metrics.py
@@ -7,7 +7,7 @@ from opentelemetry.sdk.resources import Resource
 from pulpcore.plugin.models import Domain, Repository
 
 
-CONTENT_SOURCE_DESCRIPTION = "content-sources"
+CONTENT_SOURCES_LABEL_NAME = "contentsources"
 RHEL_AI_DOMAIN_NAME = "rhel-ai"
 
 
@@ -31,7 +31,7 @@ def content_sources_domains_count():
 
 def _get_content_sources_domains_count(options):
     content_sources_domains = Domain.objects.filter(
-        description__contains=CONTENT_SOURCE_DESCRIPTION
+        pulp_labels__contains={CONTENT_SOURCES_LABEL_NAME: "true"},
     )
     content_sources_domains_count = content_sources_domains.count()
     yield Observation(content_sources_domains_count)


### PR DESCRIPTION
ref: https://issues.redhat.com/browse/PULP-627

## Summary by Sourcery

Enhancements:
- Filter content sources domains using a boolean label instead of parsing the description