### PR TITLE
Update ContentSourceDomainFilter with pulp_labels

### DIFF
--- a/pulp_service/pulp_service/app/admin.py
+++ b/pulp_service/pulp_service/app/admin.py
@@ -10,6 +10,7 @@ from .models import DomainOrg
 import re
 
 from pulpcore.plugin.models import Domain
+from pulp_service.app.constants import CONTENT_SOURCES_LABEL_NAME
 
 USERNAME_PATTERN = r'^[\w.@+=/-]+$'
 USERNAME_ERROR_MSG = "Username can only contain letters, numbers, and these special characters: @, ., +, -, =, /, _"
@@ -78,11 +79,11 @@ class ContentSourceDomainFilter(admin.SimpleListFilter):
     def queryset(self, request, queryset):
         if self.value() == "cs-domains":
             return queryset.filter(
-                description__contains="content-sources"
+                pulp_labels__contains={CONTENT_SOURCES_LABEL_NAME: "true"},
             )
         if self.value() == "non-cs-domains":
             return queryset.exclude(
-                description__contains="content-sources"
+                pulp_labels__contains={CONTENT_SOURCES_LABEL_NAME: "true"},
             )
         return queryset
 

--- a/pulp_service/pulp_service/app/constants.py
+++ b/pulp_service/pulp_service/app/constants.py
@@ -39,3 +39,6 @@ NPM_PACKAGE_LOCK_SCHEMA = {
 
 # timeout when waiting on tasks scan thread queue to avoid indefinite blocking.
 VULNERABILITY_TASK_THREAD_TIMEOUT = 60
+
+CONTENT_SOURCES_LABEL_NAME = "contentsources"
+RHEL_AI_DOMAIN_NAME = "rhel-ai"

--- a/pulp_service/pulp_service/app/tasks/domain_metrics.py
+++ b/pulp_service/pulp_service/app/tasks/domain_metrics.py
@@ -5,10 +5,7 @@ from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
 from opentelemetry.sdk.resources import Resource
 
 from pulpcore.plugin.models import Domain, Repository
-
-
-CONTENT_SOURCES_LABEL_NAME = "contentsources"
-RHEL_AI_DOMAIN_NAME = "rhel-ai"
+from pulp_service.app.constants import CONTENT_SOURCES_LABEL_NAME, RHEL_AI_DOMAIN_NAME
 
 
 def _create_meter(service_name):


### PR DESCRIPTION
## Summary by Sourcery

Centralize domain-related constants and enhance the domain filter to use pulp_labels for identifying content sources.

Enhancements:
- Centralize CONTENT_SOURCES_LABEL_NAME and RHEL_AI_DOMAIN_NAME in a constants module
- Replace hardcoded label and domain names in domain_metrics and admin code with imports from the new constants
- Update ContentSourceDomainFilter to filter domains by pulp_labels instead of description