### PR TITLE
Define a custom operationId for TaskViewSet class

### DIFF
--- a/pulp_service/pulp_service/app/viewsets.py
+++ b/pulp_service/pulp_service/app/viewsets.py
@@ -11,7 +11,7 @@ from django.db import transaction
 from django.db.models.query import QuerySet
 from django.shortcuts import redirect
 
-from drf_spectacular.utils import extend_schema
+from drf_spectacular.utils import extend_schema, extend_schema_view
 
 from rest_framework import status
 from rest_framework.exceptions import APIException
@@ -132,6 +132,10 @@ class DebugAuthenticationHeadersView(APIView):
         return Response(data=json_header_value)
 
 
+@extend_schema_view(
+    get=extend_schema(operation_id="admin_tasks"),
+    list=extend_schema(operation_id="admin_tasks"),
+)
 class TaskViewSet(TaskViewSet):
 
     LOCKED_ROLES = {}


### PR DESCRIPTION
drf_spectacular defines the `operationId` (an OpenAPI field) based on the view name.
Since the `TaskViewSet` has the same name as a pulpcore class, drf_spectacular was setting:
* `"operationId": "tasks_list_2"` for `"/api/pulp/{pulp_domain}/api/v3/tasks/"` path
* `"operationId": "tasks_list"` for `"/api/pulp/admin/tasks/"` path and pulp-cli was looking for an operation_id called "tasks_list".

This commit will define a new operation_id for pulp_service TaskViewSet class.

ref: https://issues.redhat.com/browse/PULP-588

## Summary by Sourcery

Bug Fixes:
- Set operation_id to 'admin_tasks' on TaskViewSet's get and list methods to resolve duplicate operationId conflicts