### PR TITLE
Define FeatureService certificates from variables

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -243,8 +243,8 @@ objects:
             secret:
               secretName: subscription-api-cert
               items:
-              - key: pulp-services-non-prod.pem
-                path: pulp-services-non-prod.pem
+              - key: ${{PULP_FEATURE_SERVICE_API_CERT}}
+                path: ${{PULP_FEATURE_SERVICE_API_CERT}}
         initContainers:
           - name: wait-on-migrations
             image: ${IMAGE}:${IMAGE_TAG}
@@ -347,8 +347,8 @@ objects:
             value: ${{PULP_PYPI_API_HOSTNAME}}
           - name: PULP_USE_PYPI_API_HOSTNAME_AS_CONTENT_ORIGIN
             value: "true"
-          - name: PULP_FEATURE_SERVICE_API_CERT
-            value: "/etc/pulp/certs/pulp-services-non-prod.pem"
+          - name: PULP_FEATURE_SERVICE_API_CERT_PATH
+            value: ${{PULP_FEATURE_SERVICE_API_CERT_PATH}}
           - name: PULP_USE_X_FORWARDED_HOST
             value: ${PULP_USE_X_FORWARDED_HOST}
           - name: PULP_SECURE_PROXY_SSL_HEADER
@@ -392,8 +392,8 @@ objects:
             secret:
               secretName: subscription-api-cert
               items:
-              - key: pulp-services-non-prod.pem
-                path: pulp-services-non-prod.pem
+              - key: ${{PULP_FEATURE_SERVICE_API_CERT}}
+                path: ${{PULP_FEATURE_SERVICE_API_CERT}}
         initContainers:
           - name: wait-on-migrations
             image: ${IMAGE}:${IMAGE_TAG}
@@ -474,8 +474,8 @@ objects:
             value: ${PULP_DOMAIN_ENABLED}
           - name: PULP_ALLOWED_CONTENT_CHECKSUMS
             value: ${PULP_ALLOWED_CONTENT_CHECKSUMS}
-          - name: PULP_FEATURE_SERVICE_API_CERT
-            value: "/etc/pulp/certs/pulp-services-non-prod.pem"
+          - name: PULP_FEATURE_SERVICE_API_CERT_PATH
+            value:  ${{PULP_FEATURE_SERVICE_API_CERT_PATH}}
           - name: PULP_TOKEN_AUTH_DISABLED
             value: ${PULP_TOKEN_AUTH_DISABLED}
           - name: PULP_USE_UVLOOP
@@ -926,3 +926,7 @@ parameters:
   - name: PULP_TEST_TASK_INGESTION 
     description: Enable the Task Ingestion test endpoint
     value: "false"
+  - name: PULP_FEATURE_SERVICE_API_CERT_PATH
+    value: "/etc/pulp/certs/pulp-services-non-prod.pem"
+  - name: PULP_FEATURE_SERVICE_API_CERT
+    value: "pulp-services-non-prod.pem"

--- a/pulp_service/pulp_service/app/models.py
+++ b/pulp_service/pulp_service/app/models.py
@@ -54,7 +54,7 @@ class FeatureContentGuard(HeaderContentGuard, AutoAddObjPermsMixin):
 
     def _check_for_feature(self, account_id):
         cert_context = ssl.create_default_context(ssl.Purpose.SERVER_AUTH)
-        cert_context.load_cert_chain(certfile=settings.FEATURE_SERVICE_API_CERT)
+        cert_context.load_cert_chain(certfile=settings.FEATURE_SERVICE_API_CERT_PATH)
 
         account_id_query_param = f"accountId={account_id}"
         features_query_param = "&".join(

--- a/pulp_service/pulp_service/app/settings.py
+++ b/pulp_service/pulp_service/app/settings.py
@@ -6,7 +6,7 @@ Check `Plugin Writer's Guide`_ for more details.
 """
 
 FEATURE_SERVICE_API_URL = "https://feature.stage.api.redhat.com/features/v1/featureStatus"
-FEATURE_SERVICE_API_CERT = ""
+FEATURE_SERVICE_API_CERT_PATH = ""
 AUTHENTICATION_HEADER_DEBUG = False
 INSTALLED_APPS = "@merge django.contrib.admin.apps.SimpleAdminConfig"
 TEST_TASK_INGESTION = False


### PR DESCRIPTION
The name of the certificates in prod will be different and, since the OCP template used in prod is the same, we will need these vars to set different values in prod.

## Summary by Sourcery

Parameterize the feature service API certificate in both deployment and application code by introducing variables for certificate name and path, and updating references accordingly.

Enhancements:
- Update FeatureContentGuard to load the certificate from the FEATURE_SERVICE_API_CERT_PATH setting.

Deployment:
- Add PULP_FEATURE_SERVICE_API_CERT and PULP_FEATURE_SERVICE_API_CERT_PATH parameters to clowdapp.yaml and replace hard-coded certificate names and paths with these variables.