### PR TITLE
Allow FEATURE_SERVICE_API_URL config via OCP template

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -349,6 +349,8 @@ objects:
             value: "true"
           - name: PULP_FEATURE_SERVICE_API_CERT_PATH
             value: ${{PULP_FEATURE_SERVICE_API_CERT_PATH}}
+          - name: PULP_FEATURE_SERVICE_API_URL
+            value: ${{PULP_FEATURE_SERVICE_API_URL}}
           - name: PULP_USE_X_FORWARDED_HOST
             value: ${PULP_USE_X_FORWARDED_HOST}
           - name: PULP_SECURE_PROXY_SSL_HEADER
@@ -475,7 +477,9 @@ objects:
           - name: PULP_ALLOWED_CONTENT_CHECKSUMS
             value: ${PULP_ALLOWED_CONTENT_CHECKSUMS}
           - name: PULP_FEATURE_SERVICE_API_CERT_PATH
-            value:  ${{PULP_FEATURE_SERVICE_API_CERT_PATH}}
+            value: ${{PULP_FEATURE_SERVICE_API_CERT_PATH}}
+          - name: PULP_FEATURE_SERVICE_API_URL
+            value: ${{PULP_FEATURE_SERVICE_API_URL}}
           - name: PULP_TOKEN_AUTH_DISABLED
             value: ${PULP_TOKEN_AUTH_DISABLED}
           - name: PULP_USE_UVLOOP
@@ -930,3 +934,6 @@ parameters:
     value: "/etc/pulp/certs/pulp-services-non-prod.pem"
   - name: PULP_FEATURE_SERVICE_API_CERT
     value: "pulp-services-non-prod.pem"
+  - name: PULP_FEATURE_SERVICE_API_URL
+    description: FeatureServices API URL to list the features from an owner
+    value: "https://feature.stage.api.redhat.com/features/v1/featureStatus"


### PR DESCRIPTION
## Summary by Sourcery

Expose the feature service API URL as a configurable parameter in the OpenShift template

Enhancements:
- Add PULP_FEATURE_SERVICE_API_URL environment variable to the application deployment specs in clowdapp.yaml
- Introduce PULP_FEATURE_SERVICE_API_URL parameter with description and default value in the OCP template parameters