### PR TITLE
Remove readinessProbe from worker pods

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -511,14 +511,6 @@ objects:
               - "-c"
               - "/usr/bin/wait_on_postgres.py && /usr/bin/wait_on_database_migrations.sh"
             inheritEnv: True
-        readinessProbe:
-          exec:
-            command:
-              - "/usr/bin/wait_on_postgres.py"
-          initialDelaySeconds: 10 
-          periodSeconds: 25
-          timeoutSeconds: 20
-          failureThreshold: 5
         terminationGracePeriodSeconds: 3660
         sidecars:
           - name: otel-collector


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Remove the exec-based readinessProbe block from worker pod spec in deploy/clowdapp.yaml.