### PR TITLE
Add back a no-op readinessProbe for pulpcore workers

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -511,6 +511,14 @@ objects:
               - "-c"
               - "/usr/bin/wait_on_postgres.py && /usr/bin/wait_on_database_migrations.sh"
             inheritEnv: True
+        readinessProbe:
+          exec:
+            command:
+              - "/bin/true"
+          initialDelaySeconds: 10
+          periodSeconds: 25
+          timeoutSeconds: 20
+          failureThreshold: 5
         terminationGracePeriodSeconds: 3660
         sidecars:
           - name: otel-collector


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Add an exec-based readinessProbe that runs `exit 0` with specified delays and thresholds to pulpcore worker spec in deploy/clowdapp.yaml