### PR TITLE
Revert "Remove usage of deprecated django storage settings (#581)"

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -47,9 +47,8 @@ objects:
     name: domain-storage-map
   data:
     domain-storage-script: |
-      from django.conf import settings
-      s = settings.storages.default.options
-      config = f"{{\"access_key\": \"{s.access_key}\", \"secret_key\": \"{s.secret_key}\", \"bucket_name\": \"{s.bucket_name}\", \"region_name\": \"us-east-1\", \"default_acl\": \"private\"}}"
+      from django.conf import settings as s
+      config = f"{{\"access_key\": \"{s.AWS_ACCESS_KEY_ID}\", \"secret_key\": \"{s.AWS_SECRET_ACCESS_KEY}\", \"bucket_name\": \"{s.AWS_STORAGE_BUCKET_NAME}\", \"region_name\": \"us-east-1\", \"default_acl\": \"private\"}}"
       print(config)
 - apiVersion: v1
   kind: ConfigMap
@@ -127,24 +126,16 @@ objects:
       REDIS_HOST =  "$(cat /cdapp/cdappconfig.json | jq -r '.inMemoryDb.hostname')"
       REDIS_PORT =  "$(cat /cdapp/cdappconfig.json | jq -r '.inMemoryDb.port')"
       REDIS_PASSWORD = ""
-      STORAGES = {
-          "default": {
-              "BACKEND": "storages.backends.s3boto3.S3Boto3Storage",
-              "OPTIONS": {
-                  "endpoint_url": "http://${S3_HOSTNAME}:9000",
-                  "region_name": "east",
-                  "access_key": "$S3_ACCESS_KEY_ID",
-                  "secret_key": "$S3_SECRET_ACCESS_KEY",
-                  "bucket_name": "$S3_BUCKET_NAME",
-                  "default_acl": "@none None",
-                  "signature_version": "s3v4",
-                  "addressing_style": "path",
-              },
-          },
-          "staticfiles": {
-              "BACKEND": "django.contrib.staticfiles.storage.StaticFilesStorage",
-          },
-      }
+      AWS_S3_ENDPOINT_URL = "http://${S3_HOSTNAME}:9000"
+      AWS_S3_REGION_NAME = "east"
+      AWS_ACCESS_KEY_ID = '$S3_ACCESS_KEY_ID'
+      AWS_SECRET_ACCESS_KEY = '$S3_SECRET_ACCESS_KEY'
+      AWS_STORAGE_BUCKET_NAME = '$S3_BUCKET_NAME'
+      AWS_DEFAULT_ACL = "@none None"
+      S3_USE_SIGV4 = True
+      AWS_S3_SIGNATURE_VERSION = "s3v4"
+      AWS_S3_ADDRESSING_STYLE = "path"
+      DEFAULT_FILE_STORAGE = "storages.backends.s3boto3.S3Boto3Storage"
       MEDIA_ROOT = ""
       SECRET_KEY = secrets.token_urlsafe(50)
       CONTENT_ORIGIN = "https://$HOST"
@@ -314,13 +305,15 @@ objects:
             value: ${{PULP_DB_ENCRYPTION_KEY}}
           - name: PULP_CACHE_ENABLED
             value: ${PULP_CACHE_ENABLED}
-          - name: PULP_STORAGES__default__OPTIONS__default_acl
+          - name: PULP_AWS_DEFAULT_ACL
             value: ${{PULP_AWS_DEFAULT_ACL}}
-          - name: PULP_STORAGES__default__OPTIONS__signature_version
+          - name: PULP_S3_USE_SIGV4
+            value: ${PULP_S3_USE_SIGV4}
+          - name: PULP_AWS_S3_SIGNATURE_VERSION
             value: ${{PULP_AWS_S3_SIGNATURE_VERSION}}
-          - name: PULP_STORAGES__default__OPTIONS__addressing_style
+          - name: PULP_AWS_S3_ADDRESSING_STYLE
             value: ${{PULP_AWS_S3_ADDRESSING_STYLE}}
-          - name: PULP_STORAGES__default__BACKEND
+          - name: PULP_DEFAULT_FILE_STORAGE
             value: ${{PULP_DEFAULT_FILE_STORAGE}}
           - name: PULP_MEDIA_ROOT
             value: ${{PULP_MEDIA_ROOT}}
@@ -463,13 +456,15 @@ objects:
             value: ${{PULP_DB_ENCRYPTION_KEY}}
           - name: PULP_CACHE_ENABLED
             value: ${PULP_CACHE_ENABLED}
-          - name: PULP_STORAGES__default__OPTIONS__default_acl
+          - name: PULP_AWS_DEFAULT_ACL
             value: ${{PULP_AWS_DEFAULT_ACL}}
-          - name: PULP_STORAGES__default__OPTIONS__signature_version
+          - name: PULP_S3_USE_SIGV4
+            value: ${PULP_S3_USE_SIGV4}
+          - name: PULP_AWS_S3_SIGNATURE_VERSION
             value: ${{PULP_AWS_S3_SIGNATURE_VERSION}}
-          - name: PULP_STORAGES__default__OPTIONS__addressing_style
+          - name: PULP_AWS_S3_ADDRESSING_STYLE
             value: ${{PULP_AWS_S3_ADDRESSING_STYLE}}
-          - name: PULP_STORAGES__default__BACKEND
+          - name: PULP_DEFAULT_FILE_STORAGE
             value: ${{PULP_DEFAULT_FILE_STORAGE}}
           - name: PULP_MEDIA_ROOT
             value: ${{PULP_MEDIA_ROOT}}
@@ -558,13 +553,15 @@ objects:
             value: ${{PULP_DB_ENCRYPTION_KEY}}
           - name: PULP_CACHE_ENABLED
             value: ${PULP_CACHE_ENABLED}
-          - name: PULP_STORAGES__default__OPTIONS__default_acl
+          - name: PULP_AWS_DEFAULT_ACL
             value: ${{PULP_AWS_DEFAULT_ACL}}
-          - name: PULP_STORAGES__default__OPTIONS__signature_version
+          - name: PULP_S3_USE_SIGV4
+            value: ${PULP_S3_USE_SIGV4}
+          - name: PULP_AWS_S3_SIGNATURE_VERSION
             value: ${{PULP_AWS_S3_SIGNATURE_VERSION}}
-          - name: PULP_STORAGES__default__OPTIONS__addressing_style
+          - name: PULP_AWS_S3_ADDRESSING_STYLE
             value: ${{PULP_AWS_S3_ADDRESSING_STYLE}}
-          - name: PULP_STORAGES__default__BACKEND
+          - name: PULP_DEFAULT_FILE_STORAGE
             value: ${{PULP_DEFAULT_FILE_STORAGE}}
           - name: PULP_MEDIA_ROOT
             value: ${{PULP_MEDIA_ROOT}}
@@ -877,6 +874,9 @@ parameters:
   - name: PULP_AWS_DEFAULT_ACL
     description: AWS default ACL
     value: "@none None"
+  - name: PULP_S3_USE_SIGV4
+    description: S3 using SIGV4
+    value: "true"
   - name: PULP_AWS_S3_SIGNATURE_VERSION
     description: S3 Signature version
     value: "s3v4"


### PR DESCRIPTION
This reverts commit 7775beb342ee99b5b74a8a4dca70a00ffdb4143f.

## Summary by Sourcery

Revert the removal of deprecated Django storage settings by updating the ClowdApp deployment manifest to use direct AWS_* environment variables, streamlining S3 configuration, and renaming Pulp storage-related variables.

Enhancements:
- Replace the STORAGES dictionary with AWS_S3_* environment variables and DEFAULT_FILE_STORAGE in clowdapp.yaml
- Update the storage initialization script to use settings.AWS_* attributes instead of settings.storages.default.options
- Rename Pulp storage environment variables from PULP_STORAGES__* to PULP_AWS_* naming and introduce PULP_S3_USE_SIGV4 parameter