### PR TITLE
Adds statsd configuration to pulp-api app

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -14,6 +14,7 @@ objects:
           protocols:
             http:
               endpoint: 0.0.0.0:10000
+        statsd:
       processors:
         batch:
         memory_limiter:
@@ -231,7 +232,7 @@ objects:
           annotations:
             "kubectl.kubernetes.io/default-container": pulp-api
         image: ${IMAGE}:${IMAGE_TAG}
-        command: ['pulpcore-api', '-b', '0.0.0.0:8000', '--timeout', '90', '--workers', '${PULP_API_GUNICORN_WORKERS}', '--access-logfile', '-', '--access-logformat', '(pulp [%({correlation-id}o)s]: %(h)s %(l)s %(u)s %(t)s "%(r)s" %(s)s %(b)s "%(f)s" "%(a)s" %(M)s)']
+        command: ['pulpcore-api', '-b', '0.0.0.0:8000', '--timeout', '90', '--workers', '${PULP_API_GUNICORN_WORKERS}', '--statsd-host=localhost:8125', '--statsd-prefix=pulp-api.app', '--access-logfile', '-', '--access-logformat', '(pulp [%({correlation-id}o)s]: %(h)s %(l)s %(u)s %(t)s "%(r)s" %(s)s %(b)s "%(f)s" "%(a)s" %(M)s)']
         volumeMounts:
         - name: secret-volume
           mountPath: "/etc/pulp/keys"


### PR DESCRIPTION
## Summary by Sourcery

Enable StatsD metrics collection in the pulp-api application by updating the Clowd deployment manifest and gunicorn startup command.

Enhancements:
- Add a statsd protocol block to the pulp-api Clowd deployment configuration
- Include --statsd-host and --statsd-prefix flags in the pulpcore-api startup command