### PR TITLE
specify the auth and permision classes for the createdomainview

### DIFF
--- a/pulp_service/pulp_service/app/viewsets.py
+++ b/pulp_service/pulp_service/app/viewsets.py
@@ -18,6 +18,7 @@ from rest_framework.exceptions import APIException
 from rest_framework.response import Response
 from rest_framework.views import APIView
 from rest_framework.mixins import DestroyModelMixin, ListModelMixin, RetrieveModelMixin
+from rest_framework.authentication import BasicAuthentication
 
 from pulpcore.plugin.viewsets import OperationPostponedResponse, SingleArtifactContentUploadViewSet
 from pulpcore.plugin.viewsets import ContentGuardViewSet, NamedModelViewSet, RolesMixin, TaskViewSet, LabelsMixin
@@ -26,7 +27,8 @@ from pulpcore.plugin.tasking import dispatch
 from pulpcore.app.models import Domain
 from pulpcore.app.serializers import DomainSerializer
 
-from pulp_service.app.authentication import RHServiceAccountCertAuthentication
+from pulp_service.app.authentication import RHServiceAccountCertAuthentication, JSONHeaderRemoteAuthentication
+from pulp_service.app.authorization import DomainBasedPermission
 from pulp_service.app.models import FeatureContentGuard
 from pulp_service.app.models import VulnerabilityReport as VulnReport
 from pulp_service.app.serializers import (
@@ -238,6 +240,8 @@ class RPMUploadViewSet(SingleArtifactContentUploadViewSet, LabelsMixin):
 
 
 class CreateDomainView(APIView):
+    authentication_classes = [BasicAuthentication, RHServiceAccountCertAuthentication, JSONHeaderRemoteAuthentication]
+    permission_classes = [DomainBasedPermission]
     """
     Custom endpoint to create domains with service-specific logic.
     """


### PR DESCRIPTION
The authentication and permission classes have to be specified, of the signal doesn't get the userid

## Summary by Sourcery

Specify authentication and permission classes on the CreateDomainView to ensure the request user ID is available in the view and downstream signals.

Bug Fixes:
- Add BasicAuthentication, RHServiceAccountCertAuthentication, and JSONHeaderRemoteAuthentication to CreateDomainView authentication_classes
- Assign DomainBasedPermission to CreateDomainView permission_classes to enforce domain-based access control