### PR TITLE
Add a new test dispatching tasks with overlapping exclusive resources.

### DIFF
--- a/pulp_service/pulp_service/app/urls.py
+++ b/pulp_service/pulp_service/app/urls.py
@@ -9,6 +9,7 @@ from .viewsets import (
     RedirectCheck,
     TaskViewSet,
     TaskIngestionDispatcherView,
+    TaskIngestionRandomResourceLockDispatcherView,
 )
 
 
@@ -20,5 +21,6 @@ urlpatterns = [
     path("api/pulp/debug_auth_header/", DebugAuthenticationHeadersView.as_view()),
     path("api/pulp/admin/tasks/", TaskViewSet.as_view({"get": "list"})),
     path("api/pulp/test/tasks/", TaskIngestionDispatcherView.as_view()),
+    path("api/pulp/test/random_lock_tasks/", TaskIngestionRandomResourceLockDispatcherView.as_view()),
     path("api/pulp/create-domain/", CreateDomainView.as_view()),
 ]

--- a/pulp_service/pulp_service/app/viewsets.py
+++ b/pulp_service/pulp_service/app/viewsets.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import random
 
 from base64 import b64decode
 from binascii import Error as Base64DecodeError
@@ -211,6 +212,32 @@ class TaskIngestionDispatcherView(APIView):
             dispatch(
                 'pulp_service.app.tasks.util.no_op_task',
                 exclusive_resources=[str(uuid4())]
+            )
+                
+            task_count = task_count + 1
+
+        return Response({"tasks_executed": task_count})
+
+
+class TaskIngestionRandomResourceLockDispatcherView(APIView):
+    authentication_classes = []
+    permission_classes = []
+
+    def get(self, request=None, timeout=25):
+        if not settings.TEST_TASK_INGESTION:
+            raise PermissionError("Access denied.")
+
+
+        exclusive_resources_list = [str(uuid4()) for _ in range(3)]
+
+        task_count = 0
+        start_time = datetime.now()
+        timeout = timedelta(seconds=timeout)
+
+        while datetime.now() < start_time + timeout:
+            dispatch(
+                'pulp_service.app.tasks.util.no_op_task',
+                exclusive_resources=[random.choice(exclusive_resources_list)]
             )
                 
             task_count = task_count + 1

--- a/tools/pulp_benchmark/pulp_benchmark/plugins/test_task_random_exclusive_resource_insertion.py
+++ b/tools/pulp_benchmark/pulp_benchmark/plugins/test_task_random_exclusive_resource_insertion.py
@@ -1,0 +1,55 @@
+# pulp_benchmark/plugins/test_task_insertion.py
+import asyncio
+import logging
+import time
+from typing import Optional
+
+import click
+
+# Import both async and sync logic
+from ..client_async import run_concurrent_requests as run_concurrent_async
+from ..client_sync import run_concurrent_requests_sync
+
+@click.command()
+@click.option("--timeout", type=int, default=30, show_default=True, help="Timeout for each task-creation request.")
+@click.option("--max-workers", type=int, default=50, show_default=True, help="Number of concurrent requests/threads.")
+@click.option("--run-until", type=int, help="Keep creating tasks until this total is reached.")
+@click.pass_context
+def test_task_random_exclusive_resource_insertion(ctx, timeout: int, max_workers: int, run_until: Optional[int]):
+    """Run the task insertion load test."""
+    client_type = ctx.obj['client_type']
+    api_root = ctx.obj['api_root']
+    test_url = f"{api_root}/pulp/test/random_lock_tasks/"
+    
+    logging.info(f"Starting task insertion test on {test_url} using '{client_type}' client with {max_workers} workers.")
+    
+    start_time = time.monotonic()
+    tasks_processed = 0
+    
+    # --- Logic to choose client ---
+    if client_type == 'async':
+        async def run_logic():
+            nonlocal tasks_processed
+            if run_until:
+                while tasks_processed < run_until:
+                    tasks_processed += await run_concurrent_async(test_url, timeout, max_workers)
+                    logging.info(f"Total tasks processed so far: {tasks_processed}")
+            else:
+                tasks_processed = await run_concurrent_async(test_url, timeout, max_workers)
+        asyncio.run(run_logic())
+    else: # 'sync' client
+        if run_until:
+            while tasks_processed < run_until:
+                tasks_processed += run_concurrent_requests_sync(test_url, timeout, max_workers)
+                logging.info(f"Total tasks processed so far: {tasks_processed}")
+        else:
+            tasks_processed = run_concurrent_requests_sync(test_url, timeout, max_workers)
+
+    elapsed_time = time.monotonic() - start_time
+    
+    if tasks_processed > 0 and elapsed_time > 0:
+        rate = tasks_processed / elapsed_time
+        logging.info(f"Finished insertion test in {elapsed_time:.2f} seconds.")
+        logging.info(f"Total tasks processed: {tasks_processed}. Average rate: {rate:.2f} tasks/s.")
+    else:
+        logging.warning("No tasks were processed during the test.")


### PR DESCRIPTION
## Summary by Sourcery

Add an API endpoint to dispatch no-op tasks with randomly chosen exclusive resource locks, register its route, and provide a benchmark script for load testing this behavior.

New Features:
- Introduce TaskIngestionRandomResourceLockDispatcherView to repeatedly dispatch no-op tasks with random exclusive resource locks under a test flag
- Register the new `/api/pulp/test/random_lock_tasks/` route for triggering the random-lock task dispatcher
- Add a pulp_benchmark plugin command `test_task_random_exclusive_resource_insertion` to load-test the new endpoint with configurable concurrency, timeouts, and logging