### PR TITLE
Remove CPU Limit for API, Content and Worker pods.

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -877,13 +877,13 @@ parameters:
     value: "250m"
   - name: PULP_API_CPU_LIMIT
     description: Limit of CPU use by API pods
-    value: "1000m"
+    value: "8000m"
   - name: PULP_CONTENT_CPU_LIMIT
     description: Limit of CPU use by Content pods
-    value: "500m"
+    value: "8000m"
   - name: PULP_WORKER_CPU_LIMIT
     description: Limit of CPU use by Worker pods
-    value: "500m"
+    value: "8000m"
   - name: PULP_API_MEMORY_REQUEST
     description: Amount of memory to request for API pods
     value: "256Mi"

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -877,13 +877,13 @@ parameters:
     value: "250m"
   - name: PULP_API_CPU_LIMIT
     description: Limit of CPU use by API pods
-    value: "8000m"
+    value: "4000m"
   - name: PULP_CONTENT_CPU_LIMIT
     description: Limit of CPU use by Content pods
-    value: "8000m"
+    value: "4000m"
   - name: PULP_WORKER_CPU_LIMIT
     description: Limit of CPU use by Worker pods
-    value: "8000m"
+    value: "4000m"
   - name: PULP_API_MEMORY_REQUEST
     description: Amount of memory to request for API pods
     value: "256Mi"


### PR DESCRIPTION
## Summary by Sourcery

Deployment:
- Remove CPU limit definitions for API, Content, and Worker pods in clowdapp.yaml