### PR TITLE
Set a new otel-configuration to aggregate pulp_api metrics and reduce worker_name label usage

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -63,6 +63,9 @@ objects:
             receivers: [otlp]
             processors: 
             - memory_limiter
+            - filter/filter_pulp_api_request_duration
+            - attributes/remove_worker_name
+            - batch/api_aggregation
             exporters: [prometheus]
         
           metrics/main:

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -62,19 +62,15 @@ objects:
           metrics/aggregation:
             receivers: [otlp]
             processors: 
-              - memory_limiter
-              - filter/filter_pulp_api_request_duration:
-              - attributes/remove_worker_name
-              - batch/api_aggregation
-              - groupbyattrs/api_aggregation
+            - memory_limiter
             exporters: [prometheus]
         
           metrics/main:
             receivers: [otlp]
             processors: 
-              - memory_limiter
-              - filter/exclude_pulp_api
-              - batch
+            - memory_limiter
+            - filter/exclude_pulp_api
+            - batch
             exporters: [prometheus]
 - apiVersion: v1
   kind: ConfigMap

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -16,40 +16,29 @@ objects:
               endpoint: 0.0.0.0:10000
 
       processors:
-        filter/include_pulp_api:
+        filter/filter_pulp_api_request_duration:
           metrics:
-            # This OTTL expression will drop any metric that is *not* one of your histogram components.
-            # This is how you "include" only specific metrics in a pipeline.
-            metrics:
-            - 'not (MetricName == "pulp_api_request_duration_milliseconds_sum" or MetricName == "pulp_api_request_duration_milliseconds_count" or MetricName == "pulp_api_request_duration_milliseconds_bucket")'
+            metric:
+            - 'not (name == "api.request_duration")'
 
         filter/exclude_pulp_api:
           metrics:
-            # This OTTL expression will drop your histogram metrics from the main pipeline.
-            metrics:
-            - 'MetricName == "pulp_api_request_duration_milliseconds_sum" or MetricName == "pulp_api_request_duration_milliseconds_count" or MetricName == "pulp_api_request_duration_milliseconds_bucket"'
+            metric:
+            - 'name == "api.request_duration"'
 
         attributes/remove_worker_name:
           actions:
-          - key: worker_name
+          - key: worker.name
             action: delete
 
         interval/aggregate_metrics:
           interval: 30s
-
+        
         batch:
         
         memory_limiter:
-          check_interval: 1s
+          check_interval: 2s
           limit_mib: 200
-        
-        transform:
-          error_mode: ignore
-          metric_statements:
-            - context: metric
-              statements:
-                - set(description, "Duration of HTTP server requests.") where name == "http.server.duration"
-                - set(description, "Number of active HTTP server requests.") where name == "http.server.active_requests"
         
       exporters:
         prometheus:
@@ -69,19 +58,17 @@ objects:
             receivers: [otlp]
             processors: 
               - memory_limiter
-              - filter/include_pulp_api
-              - transform
+              - filter/filter_pulp_api_request_duration:
               - attributes/remove_worker_name
               - interval/aggregate_metrics
               - batch
             exporters: [prometheus]
         
-          metrics:
+          metrics/main:
             receivers: [otlp]
             processors: 
               - memory_limiter
               - filter/exclude_pulp_api
-              - transform
               - batch
             exporters: [prometheus]
 - apiVersion: v1

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -16,6 +16,11 @@ objects:
               endpoint: 0.0.0.0:10000
 
       processors:
+
+        memory_limiter:
+          check_interval: 2s
+          limit_mib: 200
+
         filter/filter_pulp_api_request_duration:
           metrics:
             metric:
@@ -31,14 +36,14 @@ objects:
           - key: worker.name
             action: delete
 
-        interval/aggregate_metrics:
-          interval: 30s
-        
+        batch/api_aggregation:
+          timeout: 14s
+
+        groupbyattrs/api_aggregation:
+          keys:
+          - api.request_duration
+
         batch:
-        
-        memory_limiter:
-          check_interval: 2s
-          limit_mib: 200
         
       exporters:
         prometheus:
@@ -60,8 +65,8 @@ objects:
               - memory_limiter
               - filter/filter_pulp_api_request_duration:
               - attributes/remove_worker_name
-              - interval/aggregate_metrics
-              - batch
+              - batch/api_aggregation
+              - groupbyattrs/api_aggregation
             exporters: [prometheus]
         
           metrics/main:

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -14,11 +14,35 @@ objects:
           protocols:
             http:
               endpoint: 0.0.0.0:10000
+
       processors:
+        filter/include_pulp_api:
+          metrics:
+            # This OTTL expression will drop any metric that is *not* one of your histogram components.
+            # This is how you "include" only specific metrics in a pipeline.
+            metrics:
+            - 'not (MetricName == "pulp_api_request_duration_milliseconds_sum" or MetricName == "pulp_api_request_duration_milliseconds_count" or MetricName == "pulp_api_request_duration_milliseconds_bucket")'
+
+        filter/exclude_pulp_api:
+          metrics:
+            # This OTTL expression will drop your histogram metrics from the main pipeline.
+            metrics:
+            - 'MetricName == "pulp_api_request_duration_milliseconds_sum" or MetricName == "pulp_api_request_duration_milliseconds_count" or MetricName == "pulp_api_request_duration_milliseconds_bucket"'
+
+        attributes/remove_worker_name:
+          actions:
+          - key: worker_name
+            action: delete
+
+        interval/aggregate_metrics:
+          interval: 30s
+
         batch:
+        
         memory_limiter:
           check_interval: 1s
-          limit_mib: 400
+          limit_mib: 200
+        
         transform:
           error_mode: ignore
           metric_statements:
@@ -26,20 +50,39 @@ objects:
               statements:
                 - set(description, "Duration of HTTP server requests.") where name == "http.server.duration"
                 - set(description, "Number of active HTTP server requests.") where name == "http.server.active_requests"
+        
       exporters:
         prometheus:
           endpoint: "0.0.0.0:9000"
           namespace: pulp
           metric_expiration: 60m
+        
       extensions:
         health_check:
           endpoint: 0.0.0.0:13133
+        
       service:
         extensions: [health_check]
         pipelines:
+        
+          metrics/aggregation:
+            receivers: [otlp]
+            processors: 
+              - memory_limiter
+              - filter/include_pulp_api
+              - transform
+              - attributes/remove_worker_name
+              - interval/aggregate_metrics
+              - batch
+            exporters: [prometheus]
+        
           metrics:
             receivers: [otlp]
-            processors: [transform, memory_limiter, batch]
+            processors: 
+              - memory_limiter
+              - filter/exclude_pulp_api
+              - transform
+              - batch
             exporters: [prometheus]
 - apiVersion: v1
   kind: ConfigMap

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -66,6 +66,7 @@ objects:
             - filter/filter_pulp_api_request_duration
             - attributes/remove_worker_name
             - batch/api_aggregation
+            - groupbyattrs/api_aggregation
             exporters: [prometheus]
         
           metrics/main:


### PR DESCRIPTION
## Summary by Sourcery

Introduce a new OTEL aggregation pipeline for pulp_api request_duration metrics while dropping the worker_name label and segregating the raw and aggregated flows, and adjust memory limit settings.

New Features:
- Add filter/filter_pulp_api_request_duration and filter/exclude_pulp_api processors to route pulp_api request_duration metrics.
- Introduce attributes/remove_worker_name processor to drop the worker_name label from metrics.
- Add interval/aggregate_metrics processor to batch metrics over a 30-second window.

Enhancements:
- Lower memory_limiter limit to 200MiB and increase check interval to 2s.
- Remove legacy transform processor and metric statements.
- Split the existing metrics pipeline into metrics/aggregation (for aggregated metrics) and metrics/main (for raw metrics).