### PR TITLE
Updates some graphs and introduce a new variable.

### DIFF
--- a/deploy/dashboards/grafana-dashboard-pulp.configmap.yaml
+++ b/deploy/dashboards/grafana-dashboard-pulp.configmap.yaml
@@ -35,7 +35,7 @@ data:
       "editable": true,
       "fiscalYearStartMonth": 0,
       "graphTooltip": 2,
-      "id": 1026001,
+      "id": 886202,
       "links": [],
       "panels": [
         {
@@ -60,7 +60,43 @@ data:
           "fieldConfig": {
             "defaults": {
               "color": {
-                "mode": "thresholds"
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineStyle": {
+                  "fill": "solid"
+                },
+                "lineWidth": 2,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "dashed"
+                }
               },
               "mappings": [],
               "thresholds": {
@@ -70,35 +106,56 @@ data:
                     "color": "green"
                   },
                   {
+                    "color": "#EAB839",
+                    "value": 70
+                  },
+                  {
                     "color": "red",
                     "value": 80
                   }
                 ]
-              }
+              },
+              "unit": "pods"
             },
-            "overrides": []
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "pulp-content"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "purple",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              }
+            ]
           },
           "gridPos": {
-            "h": 5,
-            "w": 6,
+            "h": 9,
+            "w": 10,
             "x": 0,
             "y": 1
           },
           "id": 22,
           "options": {
-            "minVizHeight": 75,
-            "minVizWidth": 75,
-            "orientation": "auto",
-            "reduceOptions": {
+            "legend": {
               "calcs": [
-                "lastNotNull"
+                "last"
               ],
-              "fields": "",
-              "values": false
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
             },
-            "showThresholdLabels": false,
-            "showThresholdMarkers": true,
-            "sizing": "auto"
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
           },
           "pluginVersion": "11.6.3",
           "targets": [
@@ -116,7 +173,162 @@ data:
             }
           ],
           "title": "Number of Pods Per App",
-          "type": "gauge"
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "dashed+area"
+                }
+              },
+              "fieldMinMax": false,
+              "mappings": [],
+              "max": 1800000000,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "#EAB839",
+                    "value": 614000000
+                  },
+                  {
+                    "color": "semi-dark-red",
+                    "value": 1536000000
+                  }
+                ]
+              },
+              "unit": "decbytes"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Max Memory Usage"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "yellow",
+                      "mode": "fixed"
+                    }
+                  },
+                  {
+                    "id": "displayName",
+                    "value": "Max memory usage"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Average memory usage"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "green",
+                      "mode": "fixed"
+                    }
+                  },
+                  {
+                    "id": "displayName",
+                    "value": "Average memory usage"
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 9,
+            "w": 10,
+            "x": 10,
+            "y": 1
+          },
+          "id": 45,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "11.6.3",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "expr": "max(container_memory_usage_bytes{namespace=~\"pulp-${cluster:text}\", pod=~\".*api.*\"})\n\n",
+              "legendFormat": "Max Memory Usage",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "expr": "avg(container_memory_usage_bytes{namespace=~\"pulp-${cluster:text}\", pod=~\".*api.*\"})\n",
+              "hide": false,
+              "instant": false,
+              "legendFormat": "Average memory usage",
+              "range": true,
+              "refId": "B"
+            }
+          ],
+          "title": "pulp-api worker pods memory consumption",
+          "type": "timeseries"
         },
         {
           "datasource": {
@@ -179,10 +391,10 @@ data:
             "overrides": []
           },
           "gridPos": {
-            "h": 5,
-            "w": 6,
-            "x": 6,
-            "y": 1
+            "h": 7,
+            "w": 10,
+            "x": 0,
+            "y": 10
           },
           "id": 31,
           "options": {
@@ -254,167 +466,12 @@ data:
           "type": "timeseries"
         },
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisBorderShow": false,
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "barWidthFactor": 0.6,
-                "drawStyle": "line",
-                "fillOpacity": 0,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "insertNulls": false,
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "auto",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "dashed+area"
-                }
-              },
-              "fieldMinMax": false,
-              "mappings": [],
-              "max": 4500000000,
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green"
-                  },
-                  {
-                    "color": "#EAB839",
-                    "value": 2000000000
-                  },
-                  {
-                    "color": "semi-dark-red",
-                    "value": 4096000000
-                  }
-                ]
-              },
-              "unit": "decbytes"
-            },
-            "overrides": [
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Max Memory Usage"
-                },
-                "properties": [
-                  {
-                    "id": "color",
-                    "value": {
-                      "fixedColor": "yellow",
-                      "mode": "fixed"
-                    }
-                  },
-                  {
-                    "id": "displayName",
-                    "value": "Max memory usage"
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Average memory usage"
-                },
-                "properties": [
-                  {
-                    "id": "color",
-                    "value": {
-                      "fixedColor": "green",
-                      "mode": "fixed"
-                    }
-                  },
-                  {
-                    "id": "displayName",
-                    "value": "Average memory usage"
-                  }
-                ]
-              }
-            ]
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 0,
-            "y": 6
-          },
-          "id": 45,
-          "options": {
-            "legend": {
-              "calcs": [],
-              "displayMode": "list",
-              "placement": "bottom",
-              "showLegend": true
-            },
-            "tooltip": {
-              "hideZeros": false,
-              "mode": "single",
-              "sort": "none"
-            }
-          },
-          "pluginVersion": "11.6.3",
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${datasource}"
-              },
-              "editorMode": "code",
-              "expr": "max(container_memory_usage_bytes{namespace=~\"pulp-${cluster:text}\", pod=~\".*api.*\"})\n\n",
-              "legendFormat": "Max Memory Usage",
-              "range": true,
-              "refId": "A"
-            },
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${datasource}"
-              },
-              "editorMode": "code",
-              "expr": "avg(container_memory_usage_bytes{namespace=~\"pulp-${cluster:text}\", pod=~\".*api.*\"})\n",
-              "hide": false,
-              "instant": false,
-              "legendFormat": "Average memory usage",
-              "range": true,
-              "refId": "B"
-            }
-          ],
-          "title": "pulp-api worker pods memory consumption",
-          "type": "timeseries"
-        },
-        {
           "collapsed": false,
           "gridPos": {
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 14
+            "y": 17
           },
           "id": 13,
           "panels": [],
@@ -489,7 +546,7 @@ data:
             "h": 8,
             "w": 10,
             "x": 0,
-            "y": 15
+            "y": 18
           },
           "id": 6,
           "options": {
@@ -514,7 +571,7 @@ data:
               },
               "disableTextWrap": false,
               "editorMode": "code",
-              "expr": "histogram_quantile(0.99, sum by(le) (rate(pulp_api_request_duration_milliseconds_bucket[$__rate_interval]) * $__interval_ms / 1000))",
+              "expr": "histogram_quantile(0.99, sum by(le) (rate(pulp_api_request_duration_milliseconds_bucket{http_target=~\"$endpoint\"}[$__rate_interval]) * $__interval_ms / 1000))",
               "fullMetaSearch": false,
               "includeNullMetadata": false,
               "instant": false,
@@ -531,7 +588,7 @@ data:
               },
               "disableTextWrap": false,
               "editorMode": "code",
-              "expr": "histogram_quantile(0.95, sum by(le) (rate(pulp_api_request_duration_milliseconds_bucket[$__rate_interval]) * $__interval_ms / 1000))",
+              "expr": "histogram_quantile(0.95, sum by(le) (rate(pulp_api_request_duration_milliseconds_bucket{http_target=~\"${endpoint}\"}[$__rate_interval]) * $__interval_ms / 1000))",
               "fullMetaSearch": false,
               "hide": false,
               "includeNullMetadata": false,
@@ -549,7 +606,7 @@ data:
               },
               "disableTextWrap": false,
               "editorMode": "code",
-              "expr": "histogram_quantile(0.90, sum by(le) (rate(pulp_api_request_duration_milliseconds_bucket[$__rate_interval]) * $__interval_ms / 1000))",
+              "expr": "histogram_quantile(0.90, sum by(le) (rate(pulp_api_request_duration_milliseconds_bucket{http_target=~\"${endpoint}\"}[$__rate_interval]) * $__interval_ms / 1000))",
               "fullMetaSearch": false,
               "hide": false,
               "includeNullMetadata": false,
@@ -631,7 +688,7 @@ data:
             "h": 8,
             "w": 10,
             "x": 10,
-            "y": 15
+            "y": 18
           },
           "id": 9,
           "options": {
@@ -808,7 +865,7 @@ data:
             "h": 7,
             "w": 20,
             "x": 0,
-            "y": 23
+            "y": 26
           },
           "id": 32,
           "options": {
@@ -991,7 +1048,7 @@ data:
             "h": 9,
             "w": 10,
             "x": 0,
-            "y": 30
+            "y": 33
           },
           "id": 43,
           "options": {
@@ -1103,7 +1160,7 @@ data:
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 39
+            "y": 42
           },
           "id": 12,
           "panels": [],
@@ -1237,7 +1294,7 @@ data:
             "h": 10,
             "w": 10,
             "x": 0,
-            "y": 40
+            "y": 43
           },
           "id": 16,
           "options": {
@@ -1474,7 +1531,7 @@ data:
             "h": 10,
             "w": 10,
             "x": 10,
-            "y": 40
+            "y": 43
           },
           "id": 17,
           "options": {
@@ -1596,7 +1653,7 @@ data:
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 50
+            "y": 53
           },
           "id": 19,
           "panels": [],
@@ -1667,7 +1724,7 @@ data:
             "h": 8,
             "w": 10,
             "x": 0,
-            "y": 51
+            "y": 54
           },
           "id": 23,
           "options": {
@@ -1766,7 +1823,7 @@ data:
             "h": 8,
             "w": 10,
             "x": 10,
-            "y": 51
+            "y": 54
           },
           "id": 21,
           "options": {
@@ -1891,7 +1948,7 @@ data:
             "h": 9,
             "w": 20,
             "x": 0,
-            "y": 59
+            "y": 62
           },
           "id": 42,
           "options": {
@@ -2013,7 +2070,7 @@ data:
             "h": 7,
             "w": 20,
             "x": 0,
-            "y": 68
+            "y": 71
           },
           "hideTimeOverride": false,
           "id": 30,
@@ -2132,7 +2189,7 @@ data:
             "h": 7,
             "w": 10,
             "x": 0,
-            "y": 75
+            "y": 78
           },
           "id": 25,
           "options": {
@@ -2230,7 +2287,7 @@ data:
             "h": 7,
             "w": 10,
             "x": 10,
-            "y": 75
+            "y": 78
           },
           "id": 26,
           "options": {
@@ -2270,7 +2327,7 @@ data:
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 82
+            "y": 85
           },
           "id": 28,
           "panels": [],
@@ -2342,7 +2399,7 @@ data:
             "h": 8,
             "w": 10,
             "x": 0,
-            "y": 83
+            "y": 86
           },
           "id": 27,
           "options": {
@@ -2490,7 +2547,7 @@ data:
             "h": 8,
             "w": 10,
             "x": 10,
-            "y": 83
+            "y": 86
           },
           "id": 29,
           "options": {
@@ -2679,7 +2736,7 @@ data:
             "h": 9,
             "w": 20,
             "x": 0,
-            "y": 91
+            "y": 94
           },
           "id": 38,
           "options": {
@@ -2795,7 +2852,7 @@ data:
             "h": 10,
             "w": 8,
             "x": 0,
-            "y": 100
+            "y": 103
           },
           "id": 37,
           "options": {
@@ -2882,7 +2939,7 @@ data:
             "h": 10,
             "w": 12,
             "x": 8,
-            "y": 100
+            "y": 103
           },
           "id": 40,
           "options": {
@@ -3031,7 +3088,7 @@ data:
             "h": 10,
             "w": 20,
             "x": 0,
-            "y": 110
+            "y": 113
           },
           "id": 39,
           "options": {
@@ -3194,6 +3251,36 @@ data:
                     }
                   }
                 ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Tasks executed by pulp-api"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "green",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Tasks executed by pulp-worker"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "orange",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
               }
             ]
           },
@@ -3201,7 +3288,7 @@ data:
             "h": 10,
             "w": 20,
             "x": 0,
-            "y": 120
+            "y": 123
           },
           "id": 41,
           "options": {
@@ -3338,7 +3425,7 @@ data:
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 130
+            "y": 133
           },
           "id": 44,
           "options": {
@@ -3398,7 +3485,7 @@ data:
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 138
+            "y": 141
           },
           "id": 33,
           "panels": [],
@@ -3469,7 +3556,7 @@ data:
             "h": 7,
             "w": 6,
             "x": 0,
-            "y": 139
+            "y": 142
           },
           "id": 34,
           "options": {
@@ -3567,7 +3654,7 @@ data:
             "h": 7,
             "w": 6,
             "x": 6,
-            "y": 139
+            "y": 142
           },
           "id": 35,
           "options": {
@@ -3667,6 +3754,31 @@ data:
             "refresh": 1,
             "regex": "/crc${cluster}0[12]ue1\\.pulp-${cluster:text}/",
             "type": "query"
+          },
+          {
+            "allValue": ".*",
+            "allowCustomValue": false,
+            "current": {
+              "text": "All",
+              "value": "$__all"
+            },
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${datasource}"
+            },
+            "definition": "label_values(pulp_api_request_duration_milliseconds_count,http_target)",
+            "includeAll": true,
+            "label": "API Endpoint",
+            "name": "endpoint",
+            "options": [],
+            "query": {
+              "qryType": 1,
+              "query": "label_values(pulp_api_request_duration_milliseconds_count,http_target)",
+              "refId": "PrometheusVariableQueryEditor-VariableQuery"
+            },
+            "refresh": 1,
+            "regex": "",
+            "type": "query"
           }
         ]
       },
@@ -3674,9 +3786,20 @@ data:
         "from": "now-30m",
         "to": "now"
       },
-      "timepicker": {},
+      "timepicker": {
+        "refresh_intervals": [
+          "30s",
+          "1m",
+          "5m",
+          "15m",
+          "30m",
+          "1h",
+          "2h",
+          "1d"
+        ]
+      },
       "timezone": "",
       "title": "Pulp Metrics",
       "uid": "e50bb9f2-372c-4e94-aa61-fe1f1554812c",
-      "version": 5
+      "version": 61763
     }


### PR DESCRIPTION
## Summary by Sourcery

Update the Pulp Grafana dashboard by converting key graphs to timeseries, enhancing visual styling, adding a new variable, and adjusting panel layout.

New Features:
- Add 'endpoint' template variable to filter API request duration metrics by HTTP target
- Configure timepicker with custom refresh intervals

Enhancements:
- Replace "Number of Pods Per App" gauge with a styled timeseries panel featuring dashed thresholds, increased line width, and legend display
- Introduce additional threshold steps and color overrides for specific series (e.g., pulp-content and task execution series)
- Reintroduce and relocate the DB Free Storage Space panel using mixed (CloudWatch) datasources
- Bump dashboard UID, ID, and version to reflect updated configuration

Chores:
- Recalculate grid positions of panels to accommodate new and moved panels