### PR TITLE
new version of pulp_python

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -1107,4 +1107,4 @@ parameters:
     value: "20160"
   - name: PULP_PYTHON_GROUP_UPLOADS
     description: Enable group uploads for Python packages
-    value: "false"
+    value: "true"

--- a/pulp_service/requirements.txt
+++ b/pulp_service/requirements.txt
@@ -2,7 +2,7 @@ pulpcore==3.84.0
 pulp-rpm==3.31.2
 pulp-gem==0.7.1
 pulp-ostree==2.4.6
-pulp-python==3.13.1
+pulp-python==3.17.1
 pulp-npm==0.3.3
 pulp-container==2.25.0
 pulp-maven==0.10.1


### PR DESCRIPTION
Updating to the latest pulp_python. It comes with a fix for the group uploads

## Summary by Sourcery

Update pulp-python package to version 3.17.1 and enable group uploads for Python packages.

Enhancements:
- Bump pulp-python dependency from 3.13.1 to 3.17.1
- Enable PULP_PYTHON_GROUP_UPLOADS by default in deployment configuration