### PR TITLE
Empty commit to trigger a redeploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,4 +9,3 @@ bonfire deploy-env -n $(oc project | grep -oE 'ephemeral-......') --template-fil
 
 pulp-clowdenv.yaml is not used and not tested at this time.
 
-


### PR DESCRIPTION
## Summary by Sourcery

Chores:
- Remove redundant blank line from README.md to prompt a redeployment