### PR TITLE
Move clamav-scan task to the deploy-and-test pipeline.

### DIFF
--- a/.tekton/pulp-deploy-and-test.yaml
+++ b/.tekton/pulp-deploy-and-test.yaml
@@ -102,6 +102,10 @@ spec:
       type: string
       default: pypi-token
       description: "Secret with the token to push bindings to PyPI"
+    - name: IMAGE_URL
+      type: string
+      default: ""
+      description: "Image URL"
 
   results:
     - name: ARTIFACTS_URL
@@ -147,6 +151,28 @@ spec:
           value: "dummy"
         - name: test-name
           value: $(context.pipelineRun.name)
+
+    - name: clamav-scan
+      params:
+      # - name: image-digest
+      #   value: $(params.SNAPSHOT.components[0].containerImage)
+      - name: image-url
+        value: $(params.SNAPSHOT.components[0])
+      taskRef:
+        params:
+        - name: name
+          value: clamav-scan
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-clamav-scan:0.3@sha256:b0bd59748cda4a7abf311e4f448e6c1d00c6b6d8c0ecc1c2eb33e08dc0e0b802
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - 'false'
+
     - name: reserve-namespace
       when:
         - input: '$(tasks.test-metadata.results.test-event-type)'
@@ -170,6 +196,7 @@ spec:
             value: tasks/reserve-namespace.yaml
       runAfter:
         - test-metadata
+
     - name: deploy-application
       when:
         - input: '$(tasks.test-metadata.results.test-event-type)'
@@ -200,6 +227,7 @@ spec:
           value: "$(params.DEPLOY_FRONTENDS)"
       runAfter:
         - reserve-namespace
+        - clamav-scan
       taskRef:
         resolver: git
         params:

--- a/.tekton/pulp-pull-request.yaml
+++ b/.tekton/pulp-pull-request.yaml
@@ -427,28 +427,28 @@ spec:
       workspaces:
       - name: workspace
         workspace: workspace
-    - name: clamav-scan
-      params:
-      - name: image-digest
-        value: $(tasks.build-container.results.IMAGE_DIGEST)
-      - name: image-url
-        value: $(tasks.build-container.results.IMAGE_URL)
-      runAfter:
-      - build-container
-      taskRef:
-        params:
-        - name: name
-          value: clamav-scan
-        - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-clamav-scan:0.3@sha256:b0bd59748cda4a7abf311e4f448e6c1d00c6b6d8c0ecc1c2eb33e08dc0e0b802
-        - name: kind
-          value: task
-        resolver: bundles
-      when:
-      - input: $(params.skip-checks)
-        operator: in
-        values:
-        - 'false'
+    # - name: clamav-scan
+    #   params:
+    #   - name: image-digest
+    #     value: $(tasks.build-container.results.IMAGE_DIGEST)
+    #   - name: image-url
+    #     value: $(tasks.build-container.results.IMAGE_URL)
+    #   runAfter:
+    #   - build-container
+    #   taskRef:
+    #     params:
+    #     - name: name
+    #       value: clamav-scan
+    #     - name: bundle
+    #       value: quay.io/konflux-ci/tekton-catalog/task-clamav-scan:0.3@sha256:b0bd59748cda4a7abf311e4f448e6c1d00c6b6d8c0ecc1c2eb33e08dc0e0b802
+    #     - name: kind
+    #       value: task
+    #     resolver: bundles
+    #   when:
+    #   - input: $(params.skip-checks)
+    #     operator: in
+    #     values:
+    #     - 'false'
     - name: apply-tags
       params:
       - name: ADDITIONAL_TAGS


### PR DESCRIPTION
## Summary by Sourcery

Relocate the clamav-scan Tekton task from the pull-request pipeline to the deploy-and-test pipeline, update its image-url parameter binding to use the built snapshot image, and enforce its execution before application deployment.

Enhancements:
- Disable the clamav-scan step in the pull-request pipeline by commenting it out
- Add and configure the clamav-scan step in the deploy-and-test pipeline with updated image-url parameter
- Ensure deploy-application runs after clamav-scan to block deployment when skip-checks is false