### PR TITLE
Expose Group model in Django admin

### DIFF
--- a/pulp_service/pulp_service/app/admin.py
+++ b/pulp_service/pulp_service/app/admin.py
@@ -1,6 +1,6 @@
-from django.contrib.auth.models import User
-from django.contrib.auth.admin import UserAdmin
-from django.contrib.auth.forms import UserCreationForm, UserChangeForm
+from django.contrib.auth.admin import UserAdmin, GroupAdmin
+from django.contrib.auth.forms import UserChangeForm, UserCreationForm
+from django.contrib.auth.models import Group, User
 from django.contrib import admin
 
 from django import forms
@@ -63,6 +63,10 @@ class PulpUserAdmin(UserAdmin):
     add_form = PulpUserCreationForm
 
 
+class PulpGroupAdmin(GroupAdmin):
+    exclude = ('permissions',)
+
+
 class PulpAdminSite(admin.AdminSite):
     site_header = "Pulp administration"
 
@@ -107,5 +111,6 @@ admin_site = PulpAdminSite(name="myadmin")
 
 admin_site.register(DomainOrg, DomainOrgAdmin)
 #We are replacing the default UserAdmin with our PulpUserAdmin
-admin_site.register(User, PulpUserAdmin) 
+admin_site.register(User, PulpUserAdmin)
+admin_site.register(Group, PulpGroupAdmin) 
 admin_site.register(Domain, DomainAdmin)


### PR DESCRIPTION
Exposes the Group model in the Django admin interface,
allowing administrators to manage user groups.

The permissions field has been excluded from the Group
admin page to simplify the interface, as permissions are
not typically managed at this level in this application.

Co-Authored-By: google-gemini-pro2.5
