### PR TITLE
Reapply "Add clamav scan (#654)" (#655)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -143,6 +143,9 @@ RUN patch -p1 -d /usr/local/lib/pulp/lib/python${PYTHON_VERSION}/site-packages <
 COPY images/assets/patches/0024-Update-FileContent-filter-with-NAME_FILTER_OPTIONS.patch /tmp/
 RUN patch -p1 -d /usr/local/lib/pulp/lib/python${PYTHON_VERSION}/site-packages < /tmp/0024-Update-FileContent-filter-with-NAME_FILTER_OPTIONS.patch
 
+COPY images/assets/patches/0025-clamAV.patch /tmp/
+RUN patch -p1 -d /usr/local/lib/pulp/lib/python${PYTHON_VERSION}/site-packages < /tmp/0025-clamAV.patch
+
 RUN mkdir /licenses
 COPY LICENSE /licenses/LICENSE
 

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -246,6 +246,21 @@ objects:
         sleep 1d
       done
 
+- apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    name: clamav-conf
+  data:
+    clamd.conf: |
+      LogFile /var/log/clamav/clamd.log
+      LogTime yes
+      LocalSocket /tmp/clamd.sock
+      User clamav
+      StreamMaxLength ${CLAMAV_STREAM_MAX_LENGTH}
+      MaxFileSize ${CLAMAV_MAX_FILE_SIZE}
+      MaxScanSize ${CLAMAV_MAX_SCAN_SIZE}
+      TCPSocket ${CLAMAV_TCP_SOCKET}
+
 - apiVersion: cloud.redhat.com/v1alpha1
   kind: ClowdApp
   metadata:
@@ -409,6 +424,15 @@ objects:
             value: ${PULP_TEST_TASK_INGESTION}
           - name: PULP_PYTHON_GROUP_UPLOADS
             value: ${PULP_PYTHON_GROUP_UPLOADS}
+          - name: NAMESPACE
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: metadata.namespace
+          - name: PULP_CLAMAV_HOST
+            value: ${PULP_CLAMAV_SVC_NAME}.$(NAMESPACE).svc
+          - name: PULP_CLAMAV_PORT
+            value: ${PULP_CLAMAV_SVC_PORT}
 
     - name: content
       replicas: ${{PULP_CONTENT_REPLICAS}}
@@ -530,6 +554,15 @@ objects:
             value: ${PULP_TOKEN_AUTH_DISABLED}
           - name: PULP_USE_UVLOOP
             value: ${PULP_USE_UVLOOP}
+          - name: NAMESPACE
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: metadata.namespace
+          - name: PULP_CLAMAV_HOST
+            value: ${PULP_CLAMAV_SVC_NAME}.$(NAMESPACE).svc
+          - name: PULP_CLAMAV_PORT
+            value: ${PULP_CLAMAV_SVC_PORT}
 
     - name: worker
       replicas: ${{PULP_WORKER_REPLICAS}}
@@ -740,6 +773,71 @@ objects:
                     value: 5
                     periodSeconds: 30
 
+    - name: clamav
+      replicas: ${{CLAMAV_REPLICAS}}
+      webServices:
+        private:
+          appProtocol: tcp
+          enabled: true
+      podSpec:
+        image: ${CLAMAV_IMAGE}:${CLAMAV_IMAGE_TAG}
+        command:
+          - /bin/sh
+        args:
+          - -c
+          - /init-unprivileged  
+        env:
+          - name: CLAMD_CONF_StreamMaxLength
+            value: ${CLAMAV_STREAM_MAX_LENGTH}
+          - name: CLAMD_CONF_MaxFileSize
+            value: ${CLAMAV_MAX_FILE_SIZE}
+          - name: CLAMD_CONF_MaxScanSize
+            value: ${CLAMAV_MAX_SCAN_SIZE}
+          - name: CLAMD_CONF_TCPSocket
+            value: ${CLAMAV_TCP_SOCKET}
+        readinessProbe:
+          exec:
+            command:
+              - clamdscan
+              - "--ping"
+              - "1"
+          initialDelaySeconds: 20
+          periodSeconds: 25
+          timeoutSeconds: 20
+          failureThreshold: 5
+        livenessProbe:
+          exec:
+            command:
+              - clamdscan
+              - "--ping"
+              - "1"
+          initialDelaySeconds: 20
+          periodSeconds: 25
+          timeoutSeconds: 20
+          failureThreshold: 5
+        resources:
+          requests:
+            cpu: ${{CLAMAV_CPU_REQUEST}}
+            memory: ${{CLAMAV_MEMORY_REQUEST}}
+          limits:
+            cpu: ${{CLAMAV_CPU_LIMIT}}
+            memory: ${{CLAMAV_MEMORY_LIMIT}}
+        volumes:
+          - name: lib
+            emptyDir: {}
+          - name: log
+            emptyDir: {}
+          - name: clamav-conf
+            configMap:
+              name: clamav-conf
+        volumeMounts:
+          - name: lib
+            mountPath: /var/lib/clamav
+          - name: log
+            mountPath: /var/log/clamav
+          - name: clamav-conf
+            mountPath: /etc/clamav/clamd.conf
+            subPath: clamd.conf
 
     - name: migrate-db
       replicas: 1
@@ -1131,3 +1229,42 @@ parameters:
   - name: PULP_TASK_DIAGNOSTICS
     description: List of profilers available for task diagnostics
     value: "['memory', 'memray', 'pyinstrument']"
+  - name: CLAMAV_REPLICAS
+    description: Number of ClamAV replicas 
+    value: "1"
+  - name: CLAMAV_IMAGE
+    description: Specify which ClamAV container image the operator will deploy.
+    value: docker.io/clamav/clamav
+  - name: CLAMAV_IMAGE_TAG
+    description: Specify the tag or hash for the ClamAV image deployed by the operator.
+    value: "1.4.3"
+  - name: CLAMAV_STREAM_MAX_LENGTH
+    description: This option allows you to specify the upper limit for data size that will be transfered to remote daemon when scanning a single file.
+    value: 2G
+  - name: CLAMAV_MAX_FILE_SIZE
+    description: Files larger than this limit won't be scanned.
+    value: 2G
+  - name: CLAMAV_MAX_SCAN_SIZE
+    description: Sets the maximum amount of data to be scanned for each input file.
+    value: 2G
+  - name: CLAMAV_CPU_REQUEST
+    description: Amount of CPU to request for ClamAV container
+    value: "1"
+  - name: CLAMAV_MEMORY_REQUEST
+    description: Amount of memory to request for ClamAV container
+    value: 3Gi
+  - name: CLAMAV_CPU_LIMIT
+    description: Limit of CPU use by ClamAV container
+    value: "2"
+  - name: CLAMAV_MEMORY_LIMIT
+    description: Limit of memory use by ClamAV container
+    value: 4Gi
+  - name: CLAMAV_TCP_SOCKET
+    description: TCP port number the daemon will listen on. DO NOT MODIFY THIS. As of now, it seems like clowder only accepts/configures port 10000 for the "private services".
+    value: "10000"
+  - name: PULP_CLAMAV_SVC_NAME
+    description: ClamAV service name. This variable will be used by Pulp to define the TCP host to connect to ClamAV.
+    value: pulp-clamav
+  - name: PULP_CLAMAV_SVC_PORT
+    description: ClamAV service port. This variable will be used by Pulp to define the TCP port to connect to ClamAV.
+    value: "10000"

--- a/images/assets/patches/0025-clamAV.patch
+++ b/images/assets/patches/0025-clamAV.patch
@@ -1,0 +1,258 @@
+From 81ad2ad53e2fd6aff47048d064edae6397557af6 Mon Sep 17 00:00:00 2001
+From: git-hyagi <45576767+git-hyagi@users.noreply.github.com>
+Date: Fri, 29 Aug 2025 16:41:58 -0300
+Subject: [PATCH] Extend dwloader to push data stream through clamAV
+
+---
+ pulpcore/app/settings.py          |  4 +++
+ pulpcore/content/handler.py       | 23 ++++++++++++++++-
+ pulpcore/download/base.py         | 41 +++++++++++++++++++++++++++++++
+ pulpcore/exceptions/__init__.py   |  1 +
+ pulpcore/exceptions/validation.py | 19 ++++++++++++++
+ pulpcore/plugin/exceptions.py     |  2 ++
+ 6 files changed, 89 insertions(+), 1 deletion(-)
+
+diff --git a/pulpcore/app/settings.py b/pulpcore/app/settings.py
+index e5dfb1b1a..e3fc93dc0 100644
+--- a/pulpcore/app/settings.py
++++ b/pulpcore/app/settings.py
+@@ -413,6 +413,10 @@ VULN_REPORT_TASK_LIMITER = 10
+ # Replaces asyncio event loop with uvloop
+ UVLOOP_ENABLED = False
+ 
++# ClamAV default config
++CLAMAV_HOST = None
++CLAMAV_PORT = None
++
+ # HERE STARTS DYNACONF EXTENSION LOAD (Keep at the very bottom of settings.py)
+ # Read more at https://www.dynaconf.com/django/
+ 
+diff --git a/pulpcore/content/handler.py b/pulpcore/content/handler.py
+index 7e30e32cc..5699c3b6e 100644
+--- a/pulpcore/content/handler.py
++++ b/pulpcore/content/handler.py
+@@ -16,6 +16,7 @@ from aiohttp.web_exceptions import (
+     HTTPFound,
+     HTTPMovedPermanently,
+     HTTPNotFound,
++    HTTPPreconditionFailed,
+     HTTPRequestRangeNotSatisfiable,
+ )
+ from yarl import URL
+@@ -59,8 +60,9 @@ from pulpcore.app.util import (  # noqa: E402: module level not at top of file
+ )
+ 
+ from pulpcore.exceptions import (  # noqa: E402
+-    UnsupportedDigestValidationError,
+     DigestValidationError,
++    UnsupportedDigestValidationError,
++    MalwareError,
+ )
+ from pulpcore.metrics import artifacts_size_counter  # noqa: E402
+ 
+@@ -934,6 +936,11 @@ class Handler:
+                             url=url, r=ce.message
+                         )
+                         raise Error(reason=reason)
++                    except RuntimeError:
++                        # raise HTTPPreconditionFailed if digest validation failed or 
++                        # found a virus in artifact
++                        raise HTTPPreconditionFailed()
++
+ 
+         if not any([repository, repo_version, publication, distro.remote]):
+             reason = _(
+@@ -1311,6 +1318,10 @@ class Handler:
+         downloader.handle_data = handle_data
+         original_finalize = downloader.finalize
+         downloader.finalize = finalize
++        if repository:
++            scan_repo = repository.pulp_labels.get("malware_scanning", "false")
++            if scan_repo.lower() == "true":
++                downloader.scan_repository = True
+         try:
+             download_result = await downloader.run(
+                 extra_data={"disable_retry_list": (DigestValidationError,)}
+@@ -1333,6 +1344,16 @@ class Handler:
+                 "Learn more on <https://pulpproject.org/pulpcore/docs/user/learn/"
+                 "on-demand-downloading/#on-demand-and-streamed-limitations>"
+             )
++        except MalwareError:
++            # remote_artifact.failed_at = timezone.now()
++            # await remote_artifact.asave()
++            close_tcp_connection(request.transport._sock)
++            raise RuntimeError(
++                f"Pulp tried streaming {remote_artifact.url!r} to "
++                "the client, but it identified a virus in it.\n\n"
++                "We can't remove the data already sent so we are "
++                "forcing the connection to close.\n"
++            )
+ 
+         if save_artifact and remote.policy != Remote.STREAMED:
+             content_artifacts = await asyncio.shield(
+diff --git a/pulpcore/download/base.py b/pulpcore/download/base.py
+index 114e65fa6..da6eb8961 100644
+--- a/pulpcore/download/base.py
++++ b/pulpcore/download/base.py
+@@ -1,6 +1,7 @@
+ from gettext import gettext as _
+ 
+ import asyncio
++from clamav_client import clamd
+ from collections import namedtuple
+ import concurrent.futures
+ from concurrent.futures import ThreadPoolExecutor, ALL_COMPLETED
+@@ -8,6 +9,7 @@ import logging
+ import os
+ import tempfile
+ from pathlib import Path
++import struct
+ from urllib.parse import urlsplit
+ 
+ from django.conf import settings
+@@ -18,6 +20,7 @@ from pulpcore.exceptions import (
+     SizeValidationError,
+     TimeoutException,
+     UnsupportedDigestValidationError,
++    MalwareError,
+ )
+ 
+ 
+@@ -115,6 +118,9 @@ class BaseDownloader:
+                     ).format(self.url, Artifact.DIGEST_FIELDS, set(self.expected_digests))
+                 )
+ 
++        self.initialize_clamav_socket_stream()
++        self.scan_repository = False
++
+     def _ensure_writer_has_open_file(self):
+         """
+         Create a temporary file on demand.
+@@ -159,6 +165,7 @@ class BaseDownloader:
+         self._ensure_writer_has_open_file()
+         self._writer.write(data)
+         self._record_size_and_digests_for_data(data)
++        self._send_chunk_to_clamav(data)
+ 
+     async def finalize(self):
+         """
+@@ -182,6 +189,7 @@ class BaseDownloader:
+         self._writer = None
+         self.validate_digests()
+         self.validate_size()
++        self.run_malware_scan()
+         log.debug(f"Downloaded file from {self.url}")
+ 
+     def fetch(self, extra_data=None):
+@@ -211,6 +219,12 @@ class BaseDownloader:
+         concurrent.futures.wait(futures, timeout=None, return_when=ALL_COMPLETED)
+         self._size += len(data)
+ 
++    def _send_chunk_to_clamav(self, data):
++        if not self.scan_repository:
++            return
++        size = struct.pack(b"!L", len(data))
++        self.clamd_client.clamd_socket.send(size + data)
++
+     @property
+     def artifact_attributes(self):
+         """
+@@ -252,6 +266,25 @@ class BaseDownloader:
+             if actual_size != expected_size:
+                 raise SizeValidationError(actual_size, expected_size, url=self.url)
+ 
++    def run_malware_scan(self):
++        if not self.scan_repository:
++            return
++        try:
++            self.clamd_client.clamd_socket.send(struct.pack(b"!L", 0))
++            result = self.clamd_client._recv_response()
++            if len(result) > 0:
++                if result == "INSTREAM size limit exceeded. ERROR":
++                    log.warning(
++                        f"Failed to scan {self.url}. File size exceeded the "
++                        "supported ClamAV limits."
++                    )
++                filename, reason, status = self.clamd_client._parse_response(result)
++                log.info(f"ClamAV Scan results: {filename} {status} {reason}")
++                if status == "FOUND":
++                    raise MalwareError(url=self.url, virus=reason)
++        finally:
++            self.clamd_client._close_socket()
++
+     async def run(self, extra_data=None):
+         """
+         Run the downloader with concurrency restriction.
+@@ -307,3 +340,11 @@ class BaseDownloader:
+             :meth:`~pulpcore.plugin.download.BaseDownloader.finalize`.
+         """
+         raise NotImplementedError("Subclasses must define a _run() method that returns a coroutine")
++
++    def initialize_clamav_socket_stream(self):
++        clamav_host = settings.CLAMAV_HOST
++        clamav_port = settings.CLAMAV_PORT or 3310
++        if clamav_host:
++            self.clamd_client = clamd.ClamdNetworkSocket(host=clamav_host, port=clamav_port)
++            self.clamd_client._init_socket()
++            self.clamd_client._send_command("INSTREAM")
+diff --git a/pulpcore/exceptions/__init__.py b/pulpcore/exceptions/__init__.py
+index 55d875dcb..f18625761 100644
+--- a/pulpcore/exceptions/__init__.py
++++ b/pulpcore/exceptions/__init__.py
+@@ -13,4 +13,5 @@ from .validation import (
+     ValidationError,
+     MissingDigestValidationError,
+     UnsupportedDigestValidationError,
++    MalwareError,
+ )
+diff --git a/pulpcore/exceptions/validation.py b/pulpcore/exceptions/validation.py
+index d5fcb23ad..43b923d7b 100644
+--- a/pulpcore/exceptions/validation.py
++++ b/pulpcore/exceptions/validation.py
+@@ -61,6 +61,25 @@ class SizeValidationError(ValidationError):
+             return msg.format(expected=self.expected, actual=self.actual)
+ 
+ 
++class MalwareError(ValidationError):
++    """
++    Raised when a virus is found in file.
++    """
++
++    def __init__(self, virus, *args, url=None, **kwargs):
++        super().__init__("PLP0005")
++        self.url = url
++        self.virus = virus
++
++    def __str__(self):
++        if self.url:
++            msg = _("ClamAV detected a virus ({signature}) in {url}.")
++            return msg.format(signature=self.virus, url=self.url)
++        else:
++            msg = _("ClamAV detected a virus ({signature})")
++            return msg.format(signature=self.virus)
++
++
+ class MissingDigestValidationError(Exception):
+     """
+     Raised when attempting to save() an Artifact with an incomplete set of checksums.
+diff --git a/pulpcore/plugin/exceptions.py b/pulpcore/plugin/exceptions.py
+index 59870dc62..b8362afe7 100644
+--- a/pulpcore/plugin/exceptions.py
++++ b/pulpcore/plugin/exceptions.py
+@@ -6,6 +6,7 @@ from pulpcore.exceptions import (
+     MissingDigestValidationError,
+     TimeoutException,
+     UnsupportedDigestValidationError,
++    MalwareError,
+ )
+ 
+ 
+@@ -17,4 +18,5 @@ __all__ = [
+     "MissingDigestValidationError",
+     "TimeoutException",
+     "UnsupportedDigestValidationError",
++    "MalwareError",
+ ]
+-- 
+2.46.2
+

--- a/pulp_service/requirements.txt
+++ b/pulp_service/requirements.txt
@@ -15,3 +15,4 @@ uvloop==0.21.0
 jsonschema
 memray
 pyinstrument
+clamav-client>=0.7.1,<1.0


### PR DESCRIPTION
This reverts commit fe39ba8d5276de1db643c88ff5ac92c5b83e8d50.

## Summary by Sourcery

Reintroduce ClamAV scanning support by deploying a dedicated ClamAV service in the ClowdApp template, updating Pulp components with connection settings, and adding necessary patches and dependencies.

New Features:
- Add ConfigMap for ClamAV configuration and integrate a ‘clamav’ container in the ClowdApp manifest with readiness and liveness probes, volume mounts, and resource requests/limits.
- Inject ClamAV host and port environment variables into Pulp service and worker components for remote scanning.
- Extend the operator parameters with ClamAV settings for image, replicas, ports, and scan limits.
- Include a post-install patch and add the clamav-client dependency to the Pulp service to enable ClamAV integration.