### PR TITLE
Set worker replica default to 2

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -1028,7 +1028,7 @@ parameters:
     value: "0" # setting to 0 because we are using an ingress as a reverse proxy
   - name: PULP_WORKER_REPLICAS
     description: Number of pulp workers
-    value: "1"
+    value: "2"
   - name: PULP_WORKER_AUXILIARY_REPLICAS
     description: Number of pulp auxiliary workers
     value: "1"


### PR DESCRIPTION
## Summary by Sourcery

Deployment:
- Increase PULP_WORKER_REPLICAS default from 1 to 2 in clowdapp deployment