### PR TITLE
Restrict domain and domainorg add permissions and fix User field requirement

### DIFF
--- a/pulp_service/pulp_service/app/admin.py
+++ b/pulp_service/pulp_service/app/admin.py
@@ -382,8 +382,31 @@ class DomainOrgAdmin(admin.ModelAdmin):
 
 
 class DomainAdmin(admin.ModelAdmin):
-    list_display = ["name", "description", "storage_class"]
-    list_filter = ["name", "description", "storage_class", ContentSourceDomainFilter]
+    list_display = ["name", "description", "storage_class", "domain_orgs_display"]
+    list_filter = ["description", "storage_class", ContentSourceDomainFilter]
+    search_fields = ["name"]
+
+    def domain_orgs_display(self, obj):
+        """Display related DomainOrg entries for this domain."""
+        domain_orgs = obj.domain_orgs.all()
+        if not domain_orgs:
+            return "-"
+
+        org_info = []
+        for domain_org in domain_orgs:
+            parts = []
+            if domain_org.org_id:
+                parts.append(f"Org: {domain_org.org_id}")
+            if domain_org.user:
+                parts.append(f"User: {domain_org.user.username}")
+            if domain_org.group:
+                parts.append(f"Group: {domain_org.group.name}")
+            if parts:
+                org_info.append(" | ".join(parts))
+
+        return "; ".join(org_info) if org_info else "-"
+
+    domain_orgs_display.short_description = "Domain Organizations"
 
     def get_queryset(self, request):
         """


### PR DESCRIPTION
- Remove add permissions for DomainOrg entries for non-superusers
- Add custom DomainOrgForm to make User field optional in admin forms
- Domain add permissions were already restricted to superusers

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>

## Summary by Sourcery

Tighten admin permissions by allowing only superusers to add DomainOrg entries and update the admin form to make the user field optional.

Enhancements:
- Restrict DomainOrg add permission to superusers
- Add custom admin form to make DomainOrg.user optional