### PR TITLE
Patch pulpcore content to print content-headers if basic auth request

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -146,6 +146,9 @@ RUN patch -p1 -d /usr/local/lib/pulp/lib/python${PYTHON_VERSION}/site-packages <
 COPY images/assets/patches/0025-clamAV.patch /tmp/
 RUN patch -p1 -d /usr/local/lib/pulp/lib/python${PYTHON_VERSION}/site-packages < /tmp/0025-clamAV.patch
 
+COPY images/assets/patches/0026-Print-content-request.headers-if-basic-auth-request.patch /tmp/
+RUN patch -p1 -d /usr/local/lib/pulp/lib/python${PYTHON_VERSION}/site-packages < /tmp/0026-Print-content-request.headers-if-basic-auth-request.patch
+
 RUN mkdir /licenses
 COPY LICENSE /licenses/LICENSE
 

--- a/images/assets/patches/0026-Print-content-request.headers-if-basic-auth-request.patch
+++ b/images/assets/patches/0026-Print-content-request.headers-if-basic-auth-request.patch
@@ -1,0 +1,25 @@
+From e9c6c866148569aad8349dadc79cde39faf5a0c7 Mon Sep 17 00:00:00 2001
+From: git-hyagi <45576767+git-hyagi@users.noreply.github.com>
+Date: Mon, 22 Sep 2025 12:42:32 -0300
+Subject: [PATCH] Print content request.headers if basic auth request
+
+---
+ pulpcore/content/authentication.py | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/pulpcore/content/authentication.py b/pulpcore/content/authentication.py
+index 016c2990c..88dbb5dff 100644
+--- a/pulpcore/content/authentication.py
++++ b/pulpcore/content/authentication.py
+@@ -39,6 +39,8 @@ async def authenticate(request, handler):
+             try:
+                 domain = validate_domain(request)
+                 fake_view.perform_authentication(drf_request)
++                if 'Authorization' in request.headers:
++                    log.info("####### Authorization header present!")
+             except (InterfaceError, DatabaseError):
+                 Handler._reset_db_connection()
+                 domain = validate_domain(request)
+-- 
+2.46.2
+


### PR DESCRIPTION
## Summary by Sourcery

Add a new pulpcore patch to print content-request.headers for basic auth flows and integrate it into the Docker build

Enhancements:
- Log content-request.headers when processing basic auth requests in pulpcore

Build:
- Update Dockerfile to include and apply the 0026 patch for printing content headers on basic auth requests