### PR TITLE
Use the PULP_DB_ENCRYPTION_KEY envvar on the job.

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -1010,6 +1010,9 @@ objects:
               value: "/tmp"
             - name: XDG_CACHE_HOME
               value: "/tmp"
+            - name: PULP_DB_ENCRYPTION_KEY
+              value: ${{PULP_DB_ENCRYPTION_KEY}}
+
 
 - apiVersion: cloud.redhat.com/v1alpha1
   kind: ClowdJobInvocation
@@ -1039,7 +1042,7 @@ objects:
 - apiVersion: cloud.redhat.com/v1alpha1
   kind: ClowdJobInvocation
   metadata:
-    name: set-contentsources-group-to-cs-domains-1
+    name: set-contentsources-group-to-cs-domains-2
   spec:
     appName: pulp
     jobs:


### PR DESCRIPTION
## Summary by Sourcery

Add the PULP_DB_ENCRYPTION_KEY environment variable to the job container and bump the ClowdJobInvocation resource name to trigger a new invocation.

Deployment:
- Add PULP_DB_ENCRYPTION_KEY env var to the job container in clowdapp.yaml
- Update ClowdJobInvocation metadata name from set-contentsources-group-to-cs-domains-1 to set-contentsources-group-to-cs-domains-2