### PR TITLE
Remove the ContentSources migration task/job.

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -980,39 +980,6 @@ objects:
               value: "/tmp"
             - name: XDG_CACHE_HOME
               value: "/tmp"
-      - name: set-contentsources-group-to-cs-domains
-        podSpec:
-          image: ${IMAGE}:${IMAGE_TAG}
-          command: [ 'pulpcore-manager' ]
-          args:
-            - "shell"
-            - "-c"
-            - |
-              from pulpcore.app.models import Group
-              from pulp_service.app.models import DomainOrg
-              cs_group = Group.objects.get(name="contentsources")
-              domain_orgs = DomainOrg.objects.filter(domains__pulp_labels__contains={"contentsources": "true"}).update(group=cs_group, user=None)
-          volumeMounts:
-            - name: secret-volume
-              mountPath: "/etc/pulp/keys"
-            - name: pulp-settings
-              mountPath: "/etc/pulp/settings.py"
-              subPath: "settings.py"
-          volumes:
-            - name: secret-volume
-              secret:
-                secretName: pulp-db-fields-encryption
-            - name: pulp-settings
-              secret:
-                secretName: pulp-settings
-          env:
-            - name: XDG_CONFIG_HOME
-              value: "/tmp"
-            - name: XDG_CACHE_HOME
-              value: "/tmp"
-            - name: PULP_DB_ENCRYPTION_KEY
-              value: ${{PULP_DB_ENCRYPTION_KEY}}
-
 
 - apiVersion: cloud.redhat.com/v1alpha1
   kind: ClowdJobInvocation
@@ -1039,16 +1006,6 @@ objects:
     appName: pulp
     jobs:
       - create-contentsources-user
-- apiVersion: cloud.redhat.com/v1alpha1
-  kind: ClowdJobInvocation
-  metadata:
-    name: set-contentsources-group-to-cs-domains-3
-  spec:
-    appName: pulp
-    jobs:
-      - set-contentsources-group-to-cs-domains
-
-
 
 parameters:
   - name: ENV_NAME


### PR DESCRIPTION
## Summary by Sourcery

Remove obsolete ContentSources migration task and its ClowdJobInvocation from the deployment configuration

Chores:
- Remove 'set-contentsources-group-to-cs-domains' job definition from clowdapp.yaml
- Remove corresponding ClowdJobInvocation for the ContentSources migration task