### PR TITLE
Skip publishing bindings when oapi schema missing

### DIFF
--- a/.tekton/pulp-deploy-and-test.yaml
+++ b/.tekton/pulp-deploy-and-test.yaml
@@ -934,6 +934,12 @@ spec:
           - name: PULP_DOMAIN
             type: string
             default: python-bindings
+          - name: TASK_RESULT_NOT_FOUND_NOTE
+            type: string
+            default: "OpenAPI schema not found! Maybe it was not pushed to Pulp yet. Skipping the next steps."
+        results:
+          - name: TEST_OUTPUT
+            description: The output of the step
         steps:
           - name: get-pulp-token
             image: "$(params.BONFIRE_IMAGE)"
@@ -985,9 +991,12 @@ spec:
                 value: $(params.PULP_DOMAIN)
               - name: PULP_BINDINGS_COMPONENTS
                 value: $(params.PULP_BINDINGS_COMPONENTS)
+              - name: TASK_RESULT_NOT_FOUND_NOTE
+                value: $(params.TASK_RESULT_NOT_FOUND_NOTE)
             script: |
               #!/usr/bin/env python3
-              import requests, os, sys
+              import json, requests, os, sys
+              from datetime import datetime
               with open("/workspace/commit_sha") as file:
                 commit_sha = file.read().strip()
                 print(commit_sha)
@@ -1009,6 +1018,17 @@ spec:
                     sys.exit(1)
                   results = response.json()['results']
                   print(results)
+
+                  # exit step if openapi-schema is not found
+                  if not results:
+                    print("OpenAPI schema not found! Skipping step.")
+                    note = os.getenv("TASK_RESULT_NOT_FOUND_NOTE","")
+                    timestamp = datetime.now().strftime("%Y-%m-%dT%H:%M:%S")
+                    task_results = {"result":"SKIPPED","timestamp":timestamp,"note":note,"successes":0,"failures":0,"warnings":1}
+                    with open('$(results.TEST_OUTPUT.path)', 'w') as f:
+                      f.write(json.dumps(task_results))
+                    sys.exit(0)
+
                   relative_path = results[0]['relative_path']
                   print(relative_path)
                   file.write(relative_path + "\n")
@@ -1020,7 +1040,18 @@ spec:
                 value: "https://cert.console.redhat.com/api/pulp-content/python-bindings/python-bindings/"
               - name: PULP_DOMAIN
                 value: $(params.PULP_DOMAIN)
+              - name: TASK_RESULT_NOT_FOUND_NOTE
+                value: $(params.TASK_RESULT_NOT_FOUND_NOTE)
             script: |
+              # skip step if openapi-schema is not found
+              if [ -f $(results.TEST_OUTPUT.path) ] ; then
+                grep "$TASK_RESULT_NOT_FOUND_NOTE" $(results.TEST_OUTPUT.path)
+                if [ $? -eq 0 ] ; then
+                  echo "OpenAPI schema not found! Skipping step."
+                  exit 0
+                fi
+              fi
+
               mkdir -p /workspace/api-json-files ; cd $_
               while read FILE ; do
                 curl -sLO -H "Authorization: Bearer $(cat /workspace/token)" https://cert.console.redhat.com/api/pulp-content/${PULP_DOMAIN}/python-bindings/${FILE}
@@ -1035,9 +1066,22 @@ spec:
             env:
               - name: SNAPSHOT
                 value: $(params.SNAPSHOT)
+              - name: TASK_RESULT_NOT_FOUND_NOTE
+                value: $(params.TASK_RESULT_NOT_FOUND_NOTE)
             script: |
               #!/usr/bin/env python3
-              import requests
+              import json, os, requests, sys
+
+              # skip step if openapi-schema is not found
+              test_output_file="$(results.TEST_OUTPUT.path)"
+              if os.path.exists(test_output_file):
+                with open(test_output_file,'r') as f:
+                  file_content=json.loads(f.read())
+                not_found_note = os.getenv("TASK_RESULT_NOT_FOUND_NOTE","")
+                if file_content['note'] == not_found_note:
+                  print("OpenAPI schema not found! Skipping step.")
+                  sys.exit(0)
+
               # get the latest pypi client version based on crc.pulpcore.client package
               pypi_url = f"https://pypi.org/pypi/crc.pulpcore.client/json"
               response = requests.get(pypi_url)
@@ -1055,7 +1099,18 @@ spec:
                 value: python
               - name: TEMPLATE_VERSION
                 value: $(params.TEMPLATE_VERSION)
+              - name: TASK_RESULT_NOT_FOUND_NOTE
+                value: $(params.TASK_RESULT_NOT_FOUND_NOTE)
             script: |
+              # skip step if openapi-schema is not found
+              if [ -f $(results.TEST_OUTPUT.path) ] ; then
+                grep "$TASK_RESULT_NOT_FOUND_NOTE" $(results.TEST_OUTPUT.path)
+                if [ $? -eq 0 ] ; then
+                  echo "OpenAPI schema not found! Skipping step."
+                  exit 0
+                fi
+              fi
+
               mkdir -p /workspace/templates ; cd $_
               for TEMPLATE in $BINDINGS_TEMPLATES ; do
                 curl -s -LO https://raw.githubusercontent.com/pulp/pulp-openapi-generator/refs/heads/main/templates/${TEMPLATE_LANG}/${TEMPLATE_VERSION}/${TEMPLATE}.mustache
@@ -1070,8 +1125,20 @@ spec:
             env:
               - name: PULP_BINDINGS_COMPONENTS
                 value: $(params.PULP_BINDINGS_COMPONENTS)
+              - name: TASK_RESULT_NOT_FOUND_NOTE
+                value: $(params.TASK_RESULT_NOT_FOUND_NOTE)
             script: |
               #!/bin/bash
+
+              # skip step if openapi-schema is not found
+              if [ -f $(results.TEST_OUTPUT.path) ] ; then
+                grep "$TASK_RESULT_NOT_FOUND_NOTE" $(results.TEST_OUTPUT.path)
+                if [ $? -eq 0 ] ; then
+                  echo "OpenAPI schema not found! Skipping step."
+                  exit 0
+                fi
+              fi
+
               set -ex
               today=$(date +%Y%m%d)
               latest_version_date=$(awk -F. '{print $1}' /workspace/latest-version-from-pypi)
@@ -1113,7 +1180,18 @@ spec:
                   secretKeyRef:
                     name: $(params.PYPI_API_TOKEN)
                     key: token
+              - name: TASK_RESULT_NOT_FOUND_NOTE
+                value: $(params.TASK_RESULT_NOT_FOUND_NOTE)
             script: |
+              # skip step if openapi-schema is not found
+              if [ -f $(results.TEST_OUTPUT.path) ] ; then
+                grep "$TASK_RESULT_NOT_FOUND_NOTE" $(results.TEST_OUTPUT.path)
+                if [ $? -eq 0 ] ; then
+                  echo "OpenAPI schema not found! Skipping step."
+                  exit 0
+                fi
+              fi
+
               set -e
               PKG_VERSION=$(cat /workspace/package_version)
               pip install build packaging twine wheel


### PR DESCRIPTION
ref: https://issues.redhat.com/browse/PULP-839

## Summary by Sourcery

Add logic to detect when the OpenAPI schema is missing and automatically skip subsequent Python bindings tasks in the Tekton pipeline

New Features:
- Add TASK_RESULT_NOT_FOUND_NOTE parameter and TEST_OUTPUT result to flag missing OpenAPI schemas
- Emit a SKIPPED test result with timestamp and note when no schema is found
- Inject pre-checks into download, client build, template generation, and publish steps to exit early if the schema is absent