### PR TITLE
add uploads timeout/cleanup

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -654,7 +654,7 @@ objects:
           - name: PULP_TASK_DIAGNOSTICS
             value: ${{PULP_TASK_DIAGNOSTICS}}
           - name: PULP_UPLOAD_PROTECTION_TIME
-            value: ${{PULP_UPLOAD_PROTECTION_TIME}}
+            value: ${PULP_UPLOAD_PROTECTION_TIME}
 
     - name: worker-auxiliary
       replicas: ${{PULP_WORKER_AUXILIARY_REPLICAS}}


### PR DESCRIPTION
By default the UPLOAD_PROTECTION_TIME is set to 0. 
Adding a 8h purging, so that leftover uploads can be cleaned up.

## Summary by Sourcery

Add upload timeout and cleanup configuration to the ClowdApp deployment

New Features:
- Introduce UPLOAD_PROTECTION_TIME environment variable to control how long uploads are retained
- Add UPLOAD_PROTECTION_TIME parameter (default 480 minutes) to enable automatic purge of leftover uploads after the specified period