### PR TITLE
Allow non-staff users to login into the admin interface.

### DIFF
--- a/pulp_service/pulp_service/app/admin.py
+++ b/pulp_service/pulp_service/app/admin.py
@@ -1,8 +1,9 @@
 from django.contrib.auth.admin import UserAdmin, GroupAdmin
-from django.contrib.auth.forms import UserChangeForm, UserCreationForm
+from django.contrib.auth.forms import AuthenticationForm, UserChangeForm, UserCreationForm
 from django.contrib.auth.models import User
 from django.contrib import admin
 from django.db.models import Q
+from django.core.exceptions import ValidationError
 
 from django import forms
 from django.core.validators import RegexValidator
@@ -221,9 +222,13 @@ class PulpGroupAdmin(GroupAdmin):
         """
         return request.user.is_authenticated
 
+class PulpAuthenticationForm(AuthenticationForm):
+    def confirm_login_allowed(self, user):
+        super().confirm_login_allowed(user)
 
 class PulpAdminSite(admin.AdminSite):
     site_header = "Pulp administration"
+    login_form = PulpAuthenticationForm
 
     def has_permission(self, request):
         """


### PR DESCRIPTION
## Summary by Sourcery

Allow non-staff users to log in to the Django admin interface by customizing the authentication form and adjusting permission checks

Enhancements:
- Relax admin.has_module_permission to allow any authenticated user instead of only staff
- Introduce PulpAuthenticationForm and configure it as AdminSite.login_form to bypass staff-only login restrictions