### PR TITLE
Hide the User admin view when it's a normal user.

### DIFF
--- a/pulp_service/pulp_service/app/admin.py
+++ b/pulp_service/pulp_service/app/admin.py
@@ -127,6 +127,8 @@ class PulpUserAdmin(UserAdmin):
             target_groups = set(obj.groups.values_list('pk', flat=True))
 
             return bool(user_groups.intersection(target_groups))
+        
+        return False
 
     def has_delete_permission(self, request, obj=None):
         """


### PR DESCRIPTION
## Summary by Sourcery

Restrict access to the Django User admin for non-staff users by hiding the module and filtering permissions and querysets based on is_staff and is_superuser flags

Enhancements:
- Limit User admin queryset: superusers see all users; staff see only themselves and group members; others see none
- Permit change permissions only for staff users sharing groups with the target user
- Show the User admin module exclusively to staff and superuser accounts instead of all authenticated users