### PR TITLE
Set the group field as non-required in the DomainOrg admin.

### DIFF
--- a/pulp_service/pulp_service/app/admin.py
+++ b/pulp_service/pulp_service/app/admin.py
@@ -278,8 +278,9 @@ class DomainOrgForm(forms.ModelForm):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        # Make user field optional since it can be null
+        # Make user and group field optional since it can be null
         self.fields['user'].required = False
+        self.fields['group'].required = False
 
 
 class DomainOrgAdmin(admin.ModelAdmin):
@@ -296,7 +297,7 @@ class DomainOrgAdmin(admin.ModelAdmin):
         if request.user.is_superuser:
             return qs
 
-        # For staff users, show DomainOrg entries where:
+        # For common users, show DomainOrg entries where:
         # 1. User is assigned directly, OR
         # 2. User belongs to the group assigned to the DomainOrg
         user_groups = request.user.groups.all()
@@ -345,10 +346,11 @@ class DomainOrgAdmin(admin.ModelAdmin):
         if obj is None:
             return True
 
-        # Check if user has access to this DomainOrg entry
-        user_groups = request.user.groups.all()
         if obj.user == request.user:
             return True
+
+        # Check if user has access to this DomainOrg entry
+        user_groups = request.user.groups.all()
 
         if user_groups.exists() and obj.group in user_groups:
             return True


### PR DESCRIPTION
## Summary by Sourcery

Allow the group field to be optional in the DomainOrg admin form and streamline related comments and permission checks.

Enhancements:
- Set the ‘group’ field as non-required alongside the ‘user’ field in the DomainOrgAdmin form
- Update filtering comment to refer to common users instead of staff users
- Move and consolidate the user_groups lookup in has_change_permission for clearer logic