### PR TITLE
Add a middleware to instrospect auth headers when hitting the pulp-admin endpoint.

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -1207,7 +1207,7 @@ parameters:
     value: "/api/pulp/assets/"
   - name: PULP_MIDDLEWARE
     description: List of Middleware
-    value: "@merge ['pulp_service.app.middleware.ProfilerMiddleware', 'pulp_service.app.middleware.OCIStorageMiddleware', 'pulp_service.app.middleware.RhEdgeHostMiddleware']"
+    value: "@merge ['pulp_service.app.middleware.ProfilerMiddleware', 'pulp_service.app.middleware.OCIStorageMiddleware', 'pulp_service.app.middleware.RhEdgeHostMiddleware', 'pulp_service.app.middleware.AuthHeaderIntrospectionMiddleware']"
   - name: PULP_PYPI_API_HOSTNAME
     description: The hostname used to form the distribution's `base_url`.
     value: "http://pulp-content:8000"

--- a/pulp_service/pulp_service/app/middleware.py
+++ b/pulp_service/pulp_service/app/middleware.py
@@ -85,3 +85,13 @@ class RhEdgeHostMiddleware(MiddlewareMixin):
     def process_view(self, request, *args, **kwargs):
         if "HTTP_X_RH_EDGE_HOST" in request.META and request.META["HTTP_X_RH_EDGE_HOST"] is not None:
             request.META["HTTP_X_FORWARDED_HOST"] = request.META["HTTP_X_RH_EDGE_HOST"]
+
+
+class AuthHeaderIntrospectionMiddleware(MiddlewareMixin):
+    def process_view(self, request, *args, **kwargs):
+        if request.path.endswith('pulp-admin/'):
+            _logger.info("Request to pulp-admin ui")
+            if "HTTP_X_RH_IDENTITY" in request.META:
+                _logger.info(f"{request.META['HTTP_X_RH_IDENTITY']}")
+            else:
+                _logger.info("No Identity header found in request to pulp-admin")


### PR DESCRIPTION
## Summary by Sourcery

Add a middleware to log RH identity headers on requests to the pulp-admin UI and register it in the middleware configuration.

New Features:
- Introduce AuthHeaderInstrospectionMiddleware to log X-RH-IDENTITY headers for paths ending in 'pulp-admin/'.

Build:
- Update clowdapp.yaml to include AuthHeaderInstrospectionMiddleware in the PULP_MIDDLEWARE list.