### PR TITLE
Add a new middleware to authenticate using rh-identity headers based on SAML data.

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -1207,7 +1207,7 @@ parameters:
     value: "/api/pulp/assets/"
   - name: PULP_MIDDLEWARE
     description: List of Middleware
-    value: "@merge ['pulp_service.app.middleware.ProfilerMiddleware', 'pulp_service.app.middleware.OCIStorageMiddleware', 'pulp_service.app.middleware.RhEdgeHostMiddleware', 'pulp_service.app.middleware.AuthHeaderIntrospectionMiddleware']"
+    value: "@merge ['pulp_service.app.middleware.ProfilerMiddleware', 'pulp_service.app.middleware.OCIStorageMiddleware', 'pulp_service.app.middleware.RhEdgeHostMiddleware', 'pulp_service.app.middleware.RHSamlAuthHeaderMiddleware']"
   - name: PULP_PYPI_API_HOSTNAME
     description: The hostname used to form the distribution's `base_url`.
     value: "http://pulp-content:8000"

--- a/pulp_service/pulp_service/app/authentication.py
+++ b/pulp_service/pulp_service/app/authentication.py
@@ -1,5 +1,3 @@
-import logging
-
 from pulpcore.app.authentication import JSONHeaderRemoteAuthentication
 
 

--- a/pulp_service/pulp_service/app/authentication.py
+++ b/pulp_service/pulp_service/app/authentication.py
@@ -1,6 +1,6 @@
-from pulpcore.app.authentication import JSONHeaderRemoteAuthentication
+import logging
 
-from django.conf import settings
+from pulpcore.app.authentication import JSONHeaderRemoteAuthentication
 
 
 class RHServiceAccountCertAuthentication(JSONHeaderRemoteAuthentication):
@@ -19,3 +19,9 @@ class RHEntitlementCertAuthentication(JSONHeaderRemoteAuthentication):
 
     def authenticate_header(self, request):
         return "Bearer"
+
+
+class RHSamlAuthentication(JSONHeaderRemoteAuthentication):
+
+    header = "HTTP_X_RH_IDENTITY"
+    jq_filter = ".identity.associate.email"


### PR DESCRIPTION
## Summary by Sourcery

Add SAML-based RH Identity header authentication for the pulp-admin UI using a new middleware and authentication backend

New Features:
- Introduce RHSamlAuthentication backend to extract and authenticate users via the HTTP_X_RH_IDENTITY header
- Add RHSamlAuthHeaderMiddleware to process RH Identity headers and automatically log in users for the admin UI

Enhancements:
- Update deployment configuration to replace the old AuthHeaderIntrospectionMiddleware with the new RHSamlAuthHeaderMiddleware