### PR TITLE
Change the jobname to force a migration job to run.

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -983,7 +983,7 @@ objects:
             - name: XDG_CACHE_HOME
               value: "/tmp"
 
-      - name: add-new-pulp-admin-users-2
+      - name: add-new-pulp-admin-users-3
         podSpec:
           image: ${IMAGE}:${IMAGE_TAG}
           command: [ 'pulpcore-manager' ]
@@ -1050,11 +1050,11 @@ objects:
 - apiVersion: cloud.redhat.com/v1alpha1
   kind: ClowdJobInvocation
   metadata:
-    name: add-new-pulp-admin-users-2
+    name: add-new-pulp-admin-users-3
   spec:
     appName: pulp
     jobs:
-      - add-new-pulp-admin-users-2
+      - add-new-pulp-admin-users-3
 
 parameters:
   - name: ENV_NAME


### PR DESCRIPTION
## Summary by Sourcery

Force the migration job to rerun by updating its name references and adjusting the environment variable order

Enhancements:
- Update ClowdJobInvocation metadata and job name from add-new-pulp-admin-users-1 to add-new-pulp-admin-users-3
- Reposition PULP_DB_ENCRYPTION_KEY environment variable within the pod spec env list