### PR TITLE
Prepopulate group creator in members list to prevent access loss

### DIFF
--- a/pulp_service/pulp_service/app/admin.py
+++ b/pulp_service/pulp_service/app/admin.py
@@ -95,9 +95,9 @@ class PulpGroupForm(forms.ModelForm):
     def clean_users(self):
         users = self.cleaned_data.get('users')
 
-        # For new groups, ensure the creating user is included
+        # For new groups, ensure the creating user is included (unless they're a superuser)
         if not self.instance.pk and hasattr(self, '_current_user'):
-            if self._current_user not in users:
+            if not self._current_user.is_superuser and self._current_user not in users:
                 raise ValidationError(
                     f'You must include yourself ({self._current_user.username}) in the group members. '
                     'This ensures you maintain access to the group after creation.'


### PR DESCRIPTION
When creating a new group in Django admin, users are now automatically
added to the group's member list and cannot remove themselves until
after creation. This prevents users from accidentally losing access
to groups they create.

Co-Authored-By: Claude <noreply@anthropic.com>

## Summary by Sourcery

Ensure group creators retain access by auto-including them in the members list when creating groups in the Django admin and enforcing this via form validation.

New Features:
- Automatically prepopulate the current user in the members field for new groups in the Django admin.
- Validate that the creating user cannot be removed from the members list during group creation.

Enhancements:
- Pass the admin request object into the group form to support user-based initialization.
- Wrap the form in get_form to inject request and customize the users queryset for non-superusers.