### PR TITLE
fix: use CONTENT_PATH_PREFIX for container registry redirects

### DIFF
--- a/images/assets/patches/0018-Re-root-the-registry-API-at-api-pulp-v2.patch
+++ b/images/assets/patches/0018-Re-root-the-registry-API-at-api-pulp-v2.patch
@@ -16,11 +16,11 @@ index dbe6418d..006e8afb 100644
 --- a/pulp_container/app/content.py
 +++ b/pulp_container/app/content.py
 @@ -6,7 +6,7 @@ from pulp_container.app.registry import Registry
- 
+
  registry = Registry()
- 
+
 -PREFIX = "/pulp/container/{pulp_domain}/" if settings.DOMAIN_ENABLED else "/pulp/container/"
-+PREFIX = "/api/pulp-container/{pulp_domain}/" if settings.DOMAIN_ENABLED else "/pulp/container/"
++PREFIX = f"{settings.CONTENT_PATH_PREFIX}container/{{pulp_domain}}/" if settings.DOMAIN_ENABLED else "/pulp/container/"
  
  app.add_routes(
      [
@@ -33,7 +33,7 @@ index 0c7a5898..fa4808cb 100644
          self.request = request
          self.path_prefix = (
 -            f"pulp/container/{request.pulp_domain.name}"
-+            f"api/pulp-container/{request.pulp_domain.name}"
++            f"{settings.CONTENT_PATH_PREFIX.lstrip('/')}container/{request.pulp_domain.name}"
              if settings.DOMAIN_ENABLED
              else "pulp/container"
          )


### PR DESCRIPTION
## Summary

- Update patch 0018 to use `CONTENT_PATH_PREFIX` setting instead of hardcoded `/api/pulp-container/` for container registry content app redirects
- Content app routes and redirect URLs now use `/api/pulp-content/container/<domain>/...` instead of `/api/pulp-container/<domain>/...`
- This aligns with the existing gateway route for the content app, eliminating the need for a dedicated `/api/pulp-container/` route in gateway or Turnpike

## Context

When pulling container images, `pulp_container` redirects manifest/blob requests to the content app. The hardcoded `/api/pulp-container/` path required a separate gateway route that only existed in Turnpike (not the regular 3scale gateway). By using `CONTENT_PATH_PREFIX` (`/api/pulp-content/`), the redirect goes through the existing content app route.

## Test plan

- [ ] Build and deploy to stage
- [ ] Verify `curl -n -L https://packages.stage.redhat.com/v2/py-decko/uv/manifests/latest` follows redirect correctly
- [ ] Verify blob pulls follow redirect correctly
- [ ] Verify existing `/api/pulp-content/*` content serving unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Align container registry redirect paths with the configurable content app prefix to remove reliance on a hardcoded /api/pulp-container route.

Bug Fixes:
- Fix container registry redirects by using the CONTENT_PATH_PREFIX setting instead of a hardcoded /api/pulp-container path.

Enhancements:
- Route container registry content through the existing /api/pulp-content-based content app endpoint, eliminating the need for a separate gateway route.