### PR TITLE
Add PyPIYankMonitor API with on-demand check and scheduled daily runs

### DIFF
--- a/pulp_service/pulp_service/app/constants.py
+++ b/pulp_service/pulp_service/app/constants.py
@@ -42,6 +42,7 @@ VULNERABILITY_TASK_THREAD_TIMEOUT = 60
 
 PYPI_JSON_URL = "https://pypi.org/pypi/{package}/json"
 PYPI_CHECK_CONCURRENCY = 50
+PYTHON_REPOSITORY_PULP_TYPE = "python.python"
 
 CONTENT_SOURCES_LABEL_NAME = "contentsources"
 RHEL_AI_DOMAIN_NAME = "rhel-ai"

--- a/pulp_service/pulp_service/app/migrations/0016_pypiyanksmonitor.py
+++ b/pulp_service/pulp_service/app/migrations/0016_pypiyanksmonitor.py
@@ -1,0 +1,42 @@
+import django.contrib.postgres.fields.hstore
+import django.db.models.deletion
+import uuid
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('core', '0144_delete_old_appstatus'),
+        ('service', '0015_agentscanreport'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='PyPIYankMonitor',
+            fields=[
+                ('pulp_id', models.UUIDField(default=uuid.uuid4, editable=False, primary_key=True, serialize=False)),
+                ('pulp_created', models.DateTimeField(auto_now_add=True)),
+                ('pulp_last_updated', models.DateTimeField(auto_now=True, null=True)),
+                ('name', models.TextField(db_index=True, unique=True)),
+                ('description', models.TextField(blank=True, null=True)),
+                ('pulp_labels', django.contrib.postgres.fields.hstore.HStoreField(default=dict)),
+                ('last_checked', models.DateTimeField(blank=True, null=True)),
+                ('repository', models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.CASCADE, related_name='service_pypiyankmonitor', to='core.repository')),
+                ('repository_version', models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.CASCADE, related_name='service_pypiyankmonitor', to='core.repositoryversion')),
+            ],
+            options={
+                'default_related_name': '%(app_label)s_%(model_name)s',
+            },
+        ),
+        migrations.AddField(
+            model_name='yankedpackagereport',
+            name='monitor',
+            field=models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.SET_NULL, related_name='reports', to='service.pypiyankmonitor'),
+        ),
+        migrations.AddField(
+            model_name='yankedpackagereport',
+            name='repository_name',
+            field=models.TextField(blank=True, null=True),
+        ),
+    ]

--- a/pulp_service/pulp_service/app/models.py
+++ b/pulp_service/pulp_service/app/models.py
@@ -15,7 +15,7 @@ from gettext import gettext as _
 from django.conf import settings
 from django.db import models
 
-from django.contrib.postgres.fields import ArrayField
+from django.contrib.postgres.fields import ArrayField, HStoreField
 
 from pulpcore.plugin.models import BaseModel, Content, Domain, Group, RepositoryVersion
 from pulpcore.plugin.models import AutoAddObjPermsMixin
@@ -183,6 +183,46 @@ class YankedPackageReport(BaseModel):
     """
 
     report = models.JSONField()
+    monitor = models.ForeignKey(
+        "PyPIYankMonitor",
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="reports",
+    )
+    repository_name = models.TextField(null=True, blank=True)
+
+    class Meta:
+        default_related_name = "%(app_label)s_%(model_name)s"
+
+
+class PyPIYankMonitor(BaseModel):
+    """
+    Registers a Python repository or repository version for daily PyPI yank monitoring.
+    Exactly one of repository or repository_version must be set.
+    """
+
+    name = models.TextField(db_index=True, unique=True)
+    description = models.TextField(null=True, blank=True)
+    pulp_labels = HStoreField(default=dict)
+    repository = models.ForeignKey(
+        "core.Repository", on_delete=models.CASCADE, null=True, blank=True
+    )
+    repository_version = models.ForeignKey(
+        "core.RepositoryVersion", on_delete=models.CASCADE, null=True, blank=True
+    )
+    last_checked = models.DateTimeField(null=True, blank=True)
+
+    def get_repo_version_and_name(self):
+        """Return (repository_version, repository_name) for this monitor.
+
+        If pinned to a version, return it directly. Otherwise return the latest
+        complete version of the repository.
+        """
+        if self.repository_version:
+            return self.repository_version, self.repository_version.repository.name
+        latest = self.repository.versions.complete().latest("number")
+        return latest, self.repository.name
 
     class Meta:
         default_related_name = "%(app_label)s_%(model_name)s"

--- a/pulp_service/pulp_service/app/serializers.py
+++ b/pulp_service/pulp_service/app/serializers.py
@@ -14,10 +14,12 @@ from pulpcore.plugin.serializers import (
 )
 from pulpcore.plugin.models import PulpTemporaryFile
 from pulpcore.plugin.serializers import IdentityField, RepositoryVersionRelatedField
+from pulpcore.app.models import Repository
 
 from pulp_service.app.models import (
     AgentScanReport,
     FeatureContentGuard,
+    PyPIYankMonitor,
     VulnerabilityReport,
     YankedPackageReport,
 )
@@ -25,6 +27,7 @@ from pulp_service.app.constants import (
     NPM_PACKAGE_LOCK_SCHEMA,
     OSV_RH_ECOSYSTEM_CPES_LABEL,
     OSV_RH_ECOSYSTEM_LABEL,
+    PYTHON_REPOSITORY_PULP_TYPE,
 )
 
 
@@ -64,11 +67,51 @@ class YankedPackageReportSerializer(ModelSerializer):
     A serializer for the YankedPackageReport Model.
     """
 
-    pulp_href = IdentityField(view_name="pypi_yank_report-detail")
-
     class Meta:
         model = YankedPackageReport
-        fields = ModelSerializer.Meta.fields + ("report",)
+        fields = ("pulp_created", "pulp_last_updated", "report", "repository_name")
+
+
+class PyPIYankMonitorSerializer(ModelSerializer):
+    """
+    A serializer for the PyPIYankMonitor Model.
+    """
+
+    pulp_href = IdentityField(view_name="pypi_yank_monitor-detail")
+    repository = DetailRelatedField(
+        view_name_pattern=r"repositories(-.*/.*)-detail",
+        queryset=Repository.objects.all(),
+        required=False,
+        allow_null=True,
+    )
+    repository_version = RepositoryVersionRelatedField(
+        required=False,
+        allow_null=True,
+    )
+
+    def validate(self, data):
+        repo = data.get("repository")
+        repo_version = data.get("repository_version")
+        if bool(repo) == bool(repo_version):
+            raise serializers.ValidationError(
+                _("Exactly one of 'repository' or 'repository_version' must be specified.")
+            )
+        if repo and repo.pulp_type != PYTHON_REPOSITORY_PULP_TYPE:
+            raise serializers.ValidationError(
+                _("Only Python repositories can be monitored for PyPI yanking.")
+            )
+        if repo_version and repo_version.repository.pulp_type != PYTHON_REPOSITORY_PULP_TYPE:
+            raise serializers.ValidationError(
+                _("Only Python repository versions can be monitored for PyPI yanking.")
+            )
+        return data
+
+    class Meta:
+        model = PyPIYankMonitor
+        fields = ModelSerializer.Meta.fields + (
+            "name", "description", "pulp_labels",
+            "repository", "repository_version", "last_checked",
+        )
 
 
 class ContentScanSerializer(serializers.Serializer, ValidateFieldsMixin):

--- a/pulp_service/pulp_service/app/signals.py
+++ b/pulp_service/pulp_service/app/signals.py
@@ -1,7 +1,7 @@
 import logging
 
 from django.conf import settings
-from django.db.models.signals import post_save
+from django.db.models.signals import post_migrate, post_save
 from django.dispatch import receiver
 from django.contrib.auth import get_user_model
 
@@ -11,6 +11,14 @@ from pulp_service.app.models import DomainOrg
 
 
 _logger = logging.getLogger(__name__)
+
+
+@receiver(post_migrate)
+def register_scheduled_tasks(sender, **kwargs):
+    if sender.name == "pulp_service.app":
+        from pulp_service.app.tasks.util import register_pypi_yank_monitor_schedule
+
+        register_pypi_yank_monitor_schedule()
 
 
 @receiver(post_save, sender=settings.AUTH_USER_MODEL)

--- a/pulp_service/pulp_service/app/tasks/pypi_yank_check.py
+++ b/pulp_service/pulp_service/app/tasks/pypi_yank_check.py
@@ -1,42 +1,90 @@
 import asyncio
+import logging
+
 import aiohttp
 
 from asgiref.sync import sync_to_async
-from pulpcore.plugin.models import CreatedResource
+from pulpcore.plugin.tasking import dispatch
 from pulp_python.app.models import PythonPackageContent
 from pulp_service.app.constants import PYPI_JSON_URL, PYPI_CHECK_CONCURRENCY
 from pulp_service.app.models import YankedPackageReport
 
 
-async def check_python_packages_for_yanked():
-    """
-    Query all PythonPackageContent in Pulp, check PyPI for yanked versions,
-    and store a YankedPackageReport.
-    """
-    packages = {}
+_logger = logging.getLogger(__name__)
+
+
+async def _gather_packages(content_qs):
+    """Return {name: {version, ...}} from a PythonPackageContent queryset."""
     qs = await sync_to_async(list)(
-        PythonPackageContent.objects.values_list("name", "version").distinct()
+        content_qs.values_list("name", "version").distinct()
     )
+    packages = {}
     for name, version in qs:
         if name and version:
             packages.setdefault(name, set()).add(version)
+    return packages
 
+
+async def _run_yank_check(packages):
+    """Check packages against PyPI and return {name==version: {yanked_reason}} for yanked ones."""
     yanked = {}
     semaphore = asyncio.Semaphore(PYPI_CHECK_CONCURRENCY)
-
     async with aiohttp.ClientSession() as session:
-        tasks = [
-            _check_package(session, semaphore, name, versions)
-            for name, versions in packages.items()
-        ]
-        results = await asyncio.gather(*tasks, return_exceptions=True)
-
+        results = await asyncio.gather(
+            *[
+                _check_package(session, semaphore, name, versions)
+                for name, versions in packages.items()
+            ],
+            return_exceptions=True,
+        )
     for result in results:
-        if isinstance(result, dict):
+        if isinstance(result, Exception):
+            _logger.error("PyPI yank check failed for a package: %s", result)
+        else:
             yanked.update(result)
+    return yanked
 
-    report = await sync_to_async(YankedPackageReport.objects.create)(report=yanked)
-    await CreatedResource.objects.acreate(content_object=report)
+
+
+def dispatch_pypi_yank_checks():
+    """Dispatch a per-monitor yank check task for every registered PyPIYankMonitor."""
+    from pulp_service.app.models import PyPIYankMonitor
+
+    monitors = PyPIYankMonitor.objects.select_related(
+        "repository", "repository_version__repository"
+    )
+    for monitor in monitors:
+        repo = monitor.repository or monitor.repository_version.repository
+        dispatch(
+            check_packages_for_monitor,
+            shared_resources=[repo],
+            kwargs={"monitor_pk": str(monitor.pk)},
+        )
+
+
+async def check_packages_for_monitor(monitor_pk):
+    """Run a PyPI yank check scoped to a single PyPIYankMonitor's repository/version."""
+    from django.utils import timezone
+    from pulp_service.app.models import PyPIYankMonitor
+
+    monitor = await sync_to_async(
+        PyPIYankMonitor.objects.select_related(
+            "repository", "repository_version__repository"
+        ).get
+    )(pk=monitor_pk)
+
+    repo_version, repo_name = await sync_to_async(monitor.get_repo_version_and_name)()
+
+    packages = await _gather_packages(
+        PythonPackageContent.objects.filter(pk__in=repo_version.content)
+    )
+    yanked = await _run_yank_check(packages)
+
+    await sync_to_async(YankedPackageReport.objects.create)(
+        report=yanked, monitor=monitor, repository_name=repo_name
+    )
+    monitor.last_checked = timezone.now()
+    await sync_to_async(monitor.save)(update_fields=["last_checked"])
 
 
 async def _check_package(session, semaphore, name, versions):

--- a/pulp_service/pulp_service/app/tasks/util.py
+++ b/pulp_service/pulp_service/app/tasks/util.py
@@ -44,6 +44,15 @@ def except_catch_and_raise(queue):
     return decorator
 
 
+def register_pypi_yank_monitor_schedule():
+    name = "Monitor PyPI packages for yanking"
+    task_name = "pulp_service.app.tasks.pypi_yank_check.dispatch_pypi_yank_checks"
+    TaskSchedule.objects.update_or_create(
+        name=name,
+        defaults={"task_name": task_name, "dispatch_interval": timedelta(days=1)},
+    )
+
+
 def no_op_task():
     with connections["default"].cursor() as cursor:
         cursor.execute("SELECT 1")

--- a/pulp_service/pulp_service/app/viewsets.py
+++ b/pulp_service/pulp_service/app/viewsets.py
@@ -10,6 +10,7 @@ from uuid import uuid4
 from django.conf import settings
 from django.db import transaction
 from django.db.models.query import QuerySet
+from django.http import Http404
 from django.shortcuts import redirect
 
 from drf_spectacular.utils import extend_schema, extend_schema_view
@@ -19,7 +20,8 @@ from rest_framework.exceptions import APIException
 from rest_framework.permissions import BasePermission, IsAdminUser
 from rest_framework.response import Response
 from rest_framework.views import APIView
-from rest_framework.mixins import DestroyModelMixin, ListModelMixin, RetrieveModelMixin
+from rest_framework.decorators import action
+from rest_framework.mixins import CreateModelMixin, DestroyModelMixin, ListModelMixin, RetrieveModelMixin
 
 from pulpcore.plugin.viewsets import OperationPostponedResponse
 from pulpcore.plugin.viewsets import ContentGuardViewSet, NamedModelViewSet, RolesMixin, TaskViewSet
@@ -27,6 +29,9 @@ from pulpcore.plugin.serializers import AsyncOperationResponseSerializer
 from pulpcore.plugin.tasking import dispatch
 from pulpcore.app.models import Domain, Group, Task
 from pulpcore.app.serializers import DomainSerializer
+from pulpcore.filters import BaseFilterSet, HyperlinkRelatedFilter
+from pulpcore.app.viewsets.base import NAME_FILTER_OPTIONS
+from pulpcore.app.viewsets.custom_filters import LabelFilter
 
 
 from pulp_service.app.authentication import (
@@ -36,12 +41,14 @@ from pulp_service.app.authentication import (
 
 from pulp_service.app.authorization import DomainBasedPermission
 from pulp_service.app.models import AgentScanReport, FeatureContentGuard
+from pulp_service.app.models import PyPIYankMonitor
 from pulp_service.app.models import VulnerabilityReport as VulnReport
-from pulp_service.app.models import YankedPackageReport as YankedReport
+from pulp_service.app.models import YankedPackageReport
 from pulp_service.app.serializers import (
     AgentScanReportSerializer,
     ContentScanSerializer,
     FeatureContentGuardSerializer,
+    PyPIYankMonitorSerializer,
     VulnerabilityReportSerializer,
     YankedPackageReportSerializer,
 )
@@ -229,25 +236,47 @@ class IsSuperuser(BasePermission):
         return request.user and request.user.is_superuser
 
 
-class YankedPackageReportViewSet(
-    NamedModelViewSet, ListModelMixin, RetrieveModelMixin, DestroyModelMixin
+
+class PyPIYankMonitorFilter(BaseFilterSet):
+    pulp_label_select = LabelFilter()
+    repository = HyperlinkRelatedFilter(allow_null=True)
+
+    class Meta:
+        model = PyPIYankMonitor
+        fields = {"name": NAME_FILTER_OPTIONS}
+
+
+class PyPIYankMonitorViewSet(
+    NamedModelViewSet, CreateModelMixin, ListModelMixin, RetrieveModelMixin, DestroyModelMixin
 ):
-    endpoint_name = "pypi_yank_report"
-    queryset = YankedReport.objects.all()
-    serializer_class = YankedPackageReportSerializer
+    endpoint_name = "pypi_yank_monitor"
+    queryset = PyPIYankMonitor.objects.all()
+    serializer_class = PyPIYankMonitorSerializer
+    filterset_class = PyPIYankMonitorFilter
     permission_classes = [IsSuperuser]
 
-    @extend_schema(
-        request=None,
-        description="Trigger a task to check Python packages stored in Pulp against PyPI for yanked versions",
-        summary="Check for yanked PyPI packages",
-        responses={202: AsyncOperationResponseSerializer},
-    )
-    def create(self, request):
-        from pulp_service.app.tasks.pypi_yank_check import check_python_packages_for_yanked
-
-        task = dispatch(check_python_packages_for_yanked, exclusive_resources=[])
+    @extend_schema(request=None, responses={202: AsyncOperationResponseSerializer})
+    @action(detail=True, methods=["post"], url_path="check")
+    def check(self, request, pk=None):
+        monitor = self.get_object()
+        repo = monitor.repository or monitor.repository_version.repository
+        task = dispatch(
+            "pulp_service.app.tasks.pypi_yank_check.check_packages_for_monitor",
+            shared_resources=[repo],
+            kwargs={"monitor_pk": str(monitor.pk)},
+        )
         return OperationPostponedResponse(task, request)
+
+    @extend_schema(responses=YankedPackageReportSerializer)
+    @action(detail=True, methods=["get"], url_path="report")
+    def report(self, request, pk=None):
+        monitor = self.get_object()
+        try:
+            latest_report = monitor.reports.latest("pulp_created")
+        except YankedPackageReport.DoesNotExist:
+            raise Http404
+        serializer = YankedPackageReportSerializer(latest_report, context={"request": request})
+        return Response(serializer.data)
 
 
 class TaskIngestionDispatcherView(APIView):

--- a/pulp_service/pulp_service/tests/functional/conftest.py
+++ b/pulp_service/pulp_service/tests/functional/conftest.py
@@ -25,10 +25,11 @@ def vuln_report_service_api(service_bindings):
     return service_bindings.VulnReportServiceApi
 
 
+
 @pytest.fixture(scope="session")
-def pypi_yank_report_api(service_bindings):
-    """PyPI Yank Report API fixture."""
-    return service_bindings.PypiYankReportApi
+def pypi_yank_monitor_api(service_bindings):
+    """PyPI Yank Monitor API fixture."""
+    return service_bindings.PypiYankMonitorApi
 
 
 

--- a/pulp_service/pulp_service/tests/functional/test_pypi_yank_check.py
+++ b/pulp_service/pulp_service/tests/functional/test_pypi_yank_check.py
@@ -1,65 +1,228 @@
-import hashlib
 import subprocess
+from uuid import uuid4
 
-from pulp_service.tests.functional.constants import NOT_YANKED_PACKAGES, YANKED_PACKAGES
+import pytest
 
-ALL_TEST_PACKAGES = YANKED_PACKAGES + NOT_YANKED_PACKAGES
+from pulpcore.client.pulp_service import ServicePyPIYankMonitor
+from pulpcore.client.pulp_service.exceptions import ApiException
 
 
 def _django_admin_shell(code):
     subprocess.run(["django-admin", "shell", "-c", code], check=True)
 
 
-def _create_packages():
-    lines = [
-        "import hashlib",
-        "from pulp_python.app.models import PythonPackageContent",
-    ]
-    for pkg in ALL_TEST_PACKAGES:
-        sha256 = hashlib.sha256(pkg["filename"].encode()).hexdigest()
-        lines.append(
-            f"PythonPackageContent.objects.create("
-            f"name={pkg['name']!r}, version={pkg['version']!r}, "
-            f"filename={pkg['filename']!r}, packagetype={pkg['packagetype']!r}, "
-            f"sha256={sha256!r})"
-        )
-    _django_admin_shell("\n".join(lines))
+def test_pypi_yank_monitor_crud(pypi_yank_monitor_api, python_repo_factory, add_to_cleanup):
+    repo = python_repo_factory()
 
-
-def _delete_packages():
-    names = [pkg["name"] for pkg in ALL_TEST_PACKAGES]
-    versions = [pkg["version"] for pkg in ALL_TEST_PACKAGES]
-    code = (
-        "from pulp_python.app.models import PythonPackageContent\n"
-        f"PythonPackageContent.objects.filter(name__in={names!r}, version__in={versions!r}).delete()"
+    # Create
+    monitor = pypi_yank_monitor_api.create(
+        ServicePyPIYankMonitor(name=str(uuid4()), repository=repo.pulp_href)
     )
-    _django_admin_shell(code)
+    add_to_cleanup(pypi_yank_monitor_api, monitor.pulp_href)
+    assert monitor.repository == repo.pulp_href
+    assert monitor.repository_version is None
+
+    # List
+    result = pypi_yank_monitor_api.list()
+    assert any(m.pulp_href == monitor.pulp_href for m in result.results)
+
+    # Retrieve
+    retrieved = pypi_yank_monitor_api.read(
+        service_py_p_i_yank_monitor_href=monitor.pulp_href
+    )
+    assert retrieved.repository == repo.pulp_href
+
+    # Delete
+    pypi_yank_monitor_api.delete(
+        service_py_p_i_yank_monitor_href=monitor.pulp_href
+    )
+    result = pypi_yank_monitor_api.list()
+    assert not any(m.pulp_href == monitor.pulp_href for m in result.results)
 
 
-def test_pypi_yank_check(pypi_yank_report_api, monitor_task, add_to_cleanup):
+def test_pypi_yank_monitor_create_with_repo_version(
+    pypi_yank_monitor_api, python_repo_factory, python_bindings, add_to_cleanup
+):
+    repo = python_repo_factory()
+    version_href = python_bindings.RepositoriesPythonApi.read(
+        python_python_repository_href=repo.pulp_href
+    ).latest_version_href
+
+    monitor = pypi_yank_monitor_api.create(
+        ServicePyPIYankMonitor(name=str(uuid4()), repository_version=version_href)
+    )
+    add_to_cleanup(pypi_yank_monitor_api, monitor.pulp_href)
+    assert monitor.repository_version == version_href
+    assert monitor.repository is None
+
+
+def test_pypi_yank_monitor_validation_neither(pypi_yank_monitor_api):
+    with pytest.raises(ApiException) as exc_info:
+        pypi_yank_monitor_api.create(ServicePyPIYankMonitor(name=str(uuid4())))
+    assert exc_info.value.status == 400
+
+
+def test_pypi_yank_monitor_validation_non_python_repo(
+    pypi_yank_monitor_api, file_bindings, gen_object_with_cleanup
+):
+    file_repo = gen_object_with_cleanup(
+        file_bindings.RepositoriesFileApi, {"name": str(uuid4())}
+    )
+    with pytest.raises(ApiException) as exc_info:
+        pypi_yank_monitor_api.create(
+            ServicePyPIYankMonitor(name=str(uuid4()), repository=file_repo.pulp_href)
+        )
+    assert exc_info.value.status == 400
+
+
+def test_pypi_yank_monitor_report_not_found(
+    pypi_yank_monitor_api, python_repo_factory, add_to_cleanup
+):
+    repo = python_repo_factory()
+    monitor = pypi_yank_monitor_api.create(
+        ServicePyPIYankMonitor(name=str(uuid4()), repository=repo.pulp_href)
+    )
+    add_to_cleanup(pypi_yank_monitor_api, monitor.pulp_href)
+
+    with pytest.raises(ApiException) as exc_info:
+        pypi_yank_monitor_api.report(
+            service_py_p_i_yank_monitor_href=monitor.pulp_href
+        )
+    assert exc_info.value.status == 404
+
+
+_CREATE_YANKED_PKG_CODE = "\n".join([
+    "import hashlib",
+    "from pulp_python.app.models import PythonPackageContent",
+    "sha = hashlib.sha256(b'attrs-21.1.0-py2.py3-none-any.whl').hexdigest()",
+    "pkg, _ = PythonPackageContent.objects.get_or_create(",
+    "    sha256=sha,",
+    "    defaults=dict(name='attrs', version='21.1.0',",
+    "        filename='attrs-21.1.0-py2.py3-none-any.whl', packagetype='bdist_wheel'))",
+    "print(f'/pulp/api/v3/content/python/packages/{pkg.pk}/')",
+])
+
+_DELETE_YANKED_PKG_CODE = (
+    "import hashlib\n"
+    "from pulp_python.app.models import PythonPackageContent\n"
+    "sha = hashlib.sha256(b'attrs-21.1.0-py2.py3-none-any.whl').hexdigest()\n"
+    "PythonPackageContent.objects.filter(sha256=sha).delete()"
+)
+
+
+def test_pypi_yank_monitor_scoped_check(
+    pypi_yank_monitor_api, python_repo_factory, python_bindings, monitor_task, add_to_cleanup
+):
     """
-    Verify that check_python_packages_for_yanked detects packages stored in Pulp
-    that have been yanked from PyPI, and does not include packages that have not
-    been yanked.
+    Verify that check_packages_for_monitor runs a yank check scoped to a
+    specific repository and stores the result with the correct repository_name.
 
-    PythonPackageContent records are created via django-admin shell because
-    yanked packages cannot be uploaded through the Pulp API.
+    Package content is created via django-admin shell because yanked packages
+    cannot be uploaded through the Pulp API. The repository version is created
+    via the REST API modify endpoint.
     """
-    _create_packages()
+    from pulpcore.client.pulp_python import RepositoryAddRemoveContent
+
+    repo = python_repo_factory()
+
+    result = subprocess.run(
+        ["django-admin", "shell", "-c", _CREATE_YANKED_PKG_CODE],
+        check=True, capture_output=True, text=True,
+    )
+    pkg_href = result.stdout.strip()
     try:
-        response = pypi_yank_report_api.create()
-        task = monitor_task(response.task)
-        report_href = task.created_resources[0]
-        add_to_cleanup(pypi_yank_report_api, report_href)
+        # Add the package to the repo via the REST API (creates a new repo version)
+        modify_response = python_bindings.RepositoriesPythonApi.modify(
+            python_python_repository_href=repo.pulp_href,
+            repository_add_remove_content=RepositoryAddRemoveContent(
+                add_content_units=[pkg_href]
+            ),
+        )
+        monitor_task(modify_response.task)
 
-        report = pypi_yank_report_api.read(service_yanked_package_report_href=report_href)
+        monitor = pypi_yank_monitor_api.create(
+            ServicePyPIYankMonitor(name=str(uuid4()), repository=repo.pulp_href)
+        )
+        add_to_cleanup(pypi_yank_monitor_api, monitor.pulp_href)
 
-        for pkg in YANKED_PACKAGES:
-            key = f"{pkg['name']}=={pkg['version']}"
-            assert key in report.report, f"Expected {key} to be in the yanked package report"
+        check_response = pypi_yank_monitor_api.check(
+            service_py_p_i_yank_monitor_href=monitor.pulp_href
+        )
+        monitor_task(check_response.task)
 
-        for pkg in NOT_YANKED_PACKAGES:
-            key = f"{pkg['name']}=={pkg['version']}"
-            assert key not in report.report, f"Expected {key} to not be in the yanked package report"
+        report = pypi_yank_monitor_api.report(
+            service_py_p_i_yank_monitor_href=monitor.pulp_href
+        )
+        assert report.repository_name == repo.name
+        assert "attrs==21.1.0" in report.report
+        assert "attrs==23.1.0" not in report.report
+
+        updated_monitor = pypi_yank_monitor_api.read(
+            service_py_p_i_yank_monitor_href=monitor.pulp_href
+        )
+        assert updated_monitor.last_checked is not None
     finally:
-        _delete_packages()
+        # Delete the repo via REST API first so RepositoryContent associations are removed,
+        # then delete the package content (RepositoryContent has a PROTECTED FK to content).
+        delete_response = python_bindings.RepositoriesPythonApi.delete(
+            python_python_repository_href=repo.pulp_href
+        )
+        monitor_task(delete_response.task)
+        _django_admin_shell(_DELETE_YANKED_PKG_CODE)
+
+
+def test_pypi_yank_monitor_scoped_check_repo_version(
+    pypi_yank_monitor_api, python_repo_factory, python_bindings, monitor_task, add_to_cleanup
+):
+    """
+    Verify that check_packages_for_monitor works when the monitor is pinned to a
+    specific repository version rather than the repository itself.
+    """
+    from pulpcore.client.pulp_python import RepositoryAddRemoveContent
+
+    repo = python_repo_factory()
+
+    result = subprocess.run(
+        ["django-admin", "shell", "-c", _CREATE_YANKED_PKG_CODE],
+        check=True, capture_output=True, text=True,
+    )
+    pkg_href = result.stdout.strip()
+    try:
+        modify_response = python_bindings.RepositoriesPythonApi.modify(
+            python_python_repository_href=repo.pulp_href,
+            repository_add_remove_content=RepositoryAddRemoveContent(
+                add_content_units=[pkg_href]
+            ),
+        )
+        monitor_task(modify_response.task)
+
+        version_href = python_bindings.RepositoriesPythonApi.read(
+            python_python_repository_href=repo.pulp_href
+        ).latest_version_href
+
+        monitor = pypi_yank_monitor_api.create(
+            ServicePyPIYankMonitor(name=str(uuid4()), repository_version=version_href)
+        )
+        add_to_cleanup(pypi_yank_monitor_api, monitor.pulp_href)
+
+        check_response = pypi_yank_monitor_api.check(
+            service_py_p_i_yank_monitor_href=monitor.pulp_href
+        )
+        monitor_task(check_response.task)
+
+        report = pypi_yank_monitor_api.report(
+            service_py_p_i_yank_monitor_href=monitor.pulp_href
+        )
+        assert report.repository_name == repo.name
+        assert "attrs==21.1.0" in report.report
+
+        updated_monitor = pypi_yank_monitor_api.read(
+            service_py_p_i_yank_monitor_href=monitor.pulp_href
+        )
+        assert updated_monitor.last_checked is not None
+    finally:
+        delete_response = python_bindings.RepositoriesPythonApi.delete(
+            python_python_repository_href=repo.pulp_href
+        )
+        monitor_task(delete_response.task)
+        _django_admin_shell(_DELETE_YANKED_PKG_CODE)


### PR DESCRIPTION
Replaces the global yank check API with a per-monitor model that scopes yank checks to a specific repository or repository version. Key changes:

- PyPIYankMonitor model: tracks repository/version under watch and last_checked timestamp updated after each successful check
- YankedPackageReport: linked to monitor with repository_name for display
- POST /pypi_yank_monitor/{pk}/check/ triggers an on-demand check (async)
- GET /pypi_yank_monitor/{pk}/report/ returns the latest report for a monitor
- Daily TaskSchedule registered via post_migrate signal
- Removed the global check-all-content endpoint and task

## Summary by Sourcery

Introduce per-repository PyPI yank monitoring with on-demand checks and scheduled daily execution, replacing the previous global yank check mechanism.

New Features:
- Add PyPIYankMonitor model and API to track yank monitoring for a specific Python repository or repository version, including last_checked metadata.
- Expose monitor-specific endpoints to trigger an asynchronous yank check and fetch the latest yanked package report with repository context.

Enhancements:
- Scope yank checks to content in the monitored repository/version, attach reports to monitors with repository_name, and log per-package check errors without failing the overall run.
- Refine YankedPackageReport serialization to return creation timestamps and repository name instead of a generic href-based resource.
- Register a daily TaskSchedule via post-migrate to dispatch yank checks for all configured monitors and wire it into the task utilities.

Tests:
- Replace the previous global yank check functional test with new tests covering monitor CRUD, validation, scoped yank checks, report retrieval, and error conditions for the new monitor API.

Chores:
- Add migration to create the PyPIYankMonitor model and link existing YankedPackageReport records to monitors with an optional repository_name field.