### PR TITLE
fix: add getall and getone to HeadersWithModifiedXForwardedFor

### DIFF
--- a/pulp_service/pulp_service/app/content.py
+++ b/pulp_service/pulp_service/app/content.py
@@ -51,6 +51,16 @@ class HeadersWithModifiedXForwardedFor:
     def __len__(self):
         return len(self._original)
 
+    def getall(self, key, default=None):
+        if key.lower() == "x-forwarded-for":
+            return [self._modified_xff]
+        return self._original.getall(key, default)
+
+    def getone(self, key, default=None):
+        if key.lower() == "x-forwarded-for":
+            return self._modified_xff
+        return self._original.getone(key, default)
+
     def keys(self):
         return self._original.keys()
 

--- a/pulp_service/pulp_service/app/content.py
+++ b/pulp_service/pulp_service/app/content.py
@@ -56,10 +56,10 @@ class HeadersWithModifiedXForwardedFor:
             return [self._modified_xff]
         return self._original.getall(key, default)
 
-    def getone(self, key, default=None):
+    def getone(self, key):
         if key.lower() == "x-forwarded-for":
             return self._modified_xff
-        return self._original.getone(key, default)
+        return self._original.getone(key)
 
     def keys(self):
         return self._original.keys()


### PR DESCRIPTION
## Summary

- Add `getall()` and `getone()` methods to `HeadersWithModifiedXForwardedFor` wrapper class
- These methods are part of aiohttp's `CIMultiDictProxy` interface that the wrapper needs to proxy

## Context

The `HeadersWithModifiedXForwardedFor` class wraps aiohttp request headers to prepend `True-Client-IP` to `X-Forwarded-For`. However, it was missing `getall()` and `getone()` methods.

`pulp_container`'s content cache code calls `request.headers.getall("accept", [])` to build the cache key. When the wrapper is active (any request with a `True-Client-IP` header, i.e. all Akamai traffic), this raises:

```
AttributeError: 'HeadersWithModifiedXForwardedFor' object has no attribute 'getall'
```

This breaks container image pulls via the content app, returning 500 Internal Server Error.

GlitchTip: https://glitchtip.devshift.net/insights/issues/4363276?project=84

## Test plan

- [ ] Deploy to stage
- [ ] Verify `podman pull packages.stage.redhat.com/py-decko/uv:latest` succeeds
- [ ] Verify container manifest and blob redirects return content (not 500)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Ensure the HeadersWithModifiedXForwardedFor wrapper implements getall() and getone() so callers using the standard CIMultiDictProxy API no longer fail with AttributeError when accessing headers like Accept or X-Forwarded-For.