### PR TITLE
feat: add PyPI yank monitor config script and docs

### DIFF
--- a/docs/pypi-yank-monitor.md
+++ b/docs/pypi-yank-monitor.md
@@ -1,0 +1,160 @@
+# PyPI Yank Monitor
+
+The PyPI Yank Monitor checks Python packages in your Pulp repositories against public PyPI to detect yanked versions. When a package version is yanked on PyPI (for example, due to a security vulnerability or supply chain attack), the monitor identifies matching packages in your local repositories and generates a report.
+
+Monitors run automatically on a daily schedule. You can also trigger a check on demand.
+
+## Prerequisites
+
+Before proceeding, ensure that you have:
+
+1. **Superuser access** to the Pulp instance. The yank monitor API requires superuser permissions.
+2. **A Python repository** in your Pulp domain with content to monitor.
+3. **API credentials** configured. See the [API access guide](https://gitlab.cee.redhat.com/hosted-pulp/pulp-docs/-/blob/main/api-access.md) for authentication options.
+
+## Getting started
+
+### Define environment variables
+
+Set the following variables to simplify the commands in this guide:
+
+```bash
+BASE_URL=https://packages.redhat.com
+DOMAIN=public-rhai
+API_BASE=${BASE_URL}/api/pulp/${DOMAIN}/api/v3
+AUTH="-u '11009103|myuser:eyJhbGciOi...'"
+```
+
+Replace `DOMAIN` with your Pulp domain name and the credentials with your own Terms-Based Registry credentials.
+
+### Find the repository to monitor
+
+List the Python repositories in your domain:
+
+```bash
+curl ${AUTH} ${API_BASE}/repositories/python/python/
+```
+
+Note the `pulp_href` value of the repository that you want to monitor. For example:
+
+```
+/api/pulp/public-rhai/api/v3/repositories/python/python/01234567-89ab-cdef-0123-456789abcdef/
+```
+
+## Creating a yank monitor
+
+Create a monitor by specifying a name and the repository `pulp_href`:
+
+```bash
+curl ${AUTH} -X POST ${API_BASE}/pypi_yank_monitor/ \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "name": "yank-monitor-my-repo",
+    "repository": "/api/pulp/public-rhai/api/v3/repositories/python/python/01234567-89ab-cdef-0123-456789abcdef/"
+  }'
+```
+
+The response includes the monitor `pulp_href`:
+
+```json
+{
+  "pulp_href": "/api/pulp/public-rhai/api/v3/pypi_yank_monitor/abcdef01-2345-6789-abcd-ef0123456789/",
+  "name": "yank-monitor-my-repo",
+  "repository": "/api/pulp/public-rhai/api/v3/repositories/python/python/01234567-89ab-cdef-0123-456789abcdef/",
+  "repository_version": null,
+  "last_checked": null
+}
+```
+
+You can also pin the monitor to a specific repository version instead of the latest by using `repository_version` instead of `repository`. Exactly one of the two fields must be specified.
+
+## Triggering a yank check
+
+Monitors run automatically once per day. To trigger an on-demand check, send a POST request to the monitor `check` endpoint:
+
+```bash
+curl ${AUTH} -X POST \
+  ${API_BASE}/pypi_yank_monitor/abcdef01-2345-6789-abcd-ef0123456789/check/
+```
+
+The response returns a `202 Accepted` with a task reference:
+
+```json
+{
+  "task": "/api/pulp/public-rhai/api/v3/tasks/fedcba98-7654-3210-fedc-ba9876543210/"
+}
+```
+
+You can check the task status:
+
+```bash
+curl ${AUTH} ${API_BASE}/tasks/fedcba98-7654-3210-fedc-ba9876543210/
+```
+
+## Viewing yank reports
+
+After a check completes, retrieve the latest report for a monitor:
+
+```bash
+curl ${AUTH} \
+  ${API_BASE}/pypi_yank_monitor/abcdef01-2345-6789-abcd-ef0123456789/report/
+```
+
+The response includes the report with any yanked packages found:
+
+```json
+{
+  "pulp_created": "2026-04-13T10:30:00.000000Z",
+  "pulp_last_updated": "2026-04-13T10:30:00.000000Z",
+  "report": {
+    "attrs==21.1.0": {
+      "yanked_reason": "This version has been yanked due to a security issue."
+    }
+  },
+  "repository_name": "my-repo"
+}
+```
+
+The `report` field is a JSON object where each key is a package in `name==version` format. If no yanked packages are found, the `report` field is an empty object (`{}`).
+
+If no check has been run yet, the endpoint returns a `404 Not Found`.
+
+## Listing and managing monitors
+
+### List all monitors
+
+```bash
+curl ${AUTH} ${API_BASE}/pypi_yank_monitor/
+```
+
+### Filter monitors by name
+
+```bash
+curl ${AUTH} "${API_BASE}/pypi_yank_monitor/?name=yank-monitor-my-repo"
+```
+
+### Filter monitors by repository
+
+```bash
+curl ${AUTH} "${API_BASE}/pypi_yank_monitor/?repository=/api/pulp/public-rhai/api/v3/repositories/python/python/01234567-89ab-cdef-0123-456789abcdef/"
+```
+
+### Delete a monitor
+
+```bash
+curl ${AUTH} -X DELETE \
+  ${API_BASE}/pypi_yank_monitor/abcdef01-2345-6789-abcd-ef0123456789/
+```
+
+## API reference
+
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `/api/v3/pypi_yank_monitor/` | `GET` | List all monitors (supports filtering by `name`, `repository`, `pulp_label_select`) |
+| `/api/v3/pypi_yank_monitor/` | `POST` | Create a new monitor |
+| `/api/v3/pypi_yank_monitor/{id}/` | `GET` | Retrieve a specific monitor |
+| `/api/v3/pypi_yank_monitor/{id}/` | `DELETE` | Delete a monitor |
+| `/api/v3/pypi_yank_monitor/{id}/check/` | `POST` | Trigger an on-demand yank check (returns 202 with task) |
+| `/api/v3/pypi_yank_monitor/{id}/report/` | `GET` | Retrieve the latest yank report (returns 404 if no report exists) |
+
+All endpoints require **superuser** permissions.

--- a/docs/pypi-yank-monitor.md
+++ b/docs/pypi-yank-monitor.md
@@ -4,6 +4,14 @@ The PyPI Yank Monitor checks Python packages in your Pulp repositories against p
 
 Monitors run automatically on a daily schedule. You can also trigger a check on demand.
 
+## How monitoring works
+
+A daily scheduled task dispatches a yank check for every registered monitor. The task queries the PyPI JSON API for each package in the monitored repository and compares the yank status of each version. Results are stored as a report linked to the monitor.
+
+Yank monitors are **not scoped to a Pulp domain**. Although you access the API through a domain-specific path (for example, `/api/pulp/public-rhai/api/v3/`), monitors are stored globally. The daily scheduled task runs from the `default` domain and processes all monitors regardless of which domain path was used to create them.
+
+> **Note**: The `pulp_href` returned for a monitor always uses the `default` domain path (for example, `/api/pulp/default/api/v3/pypi_yank_monitor/...`), even when you create the monitor through a different domain path. Use the returned `pulp_href` for subsequent operations on that monitor.
+
 ## Prerequisites
 
 Before proceeding, ensure that you have:
@@ -58,7 +66,7 @@ The response includes the monitor `pulp_href`:
 
 ```json
 {
-  "pulp_href": "/api/pulp/public-rhai/api/v3/pypi_yank_monitor/abcdef01-2345-6789-abcd-ef0123456789/",
+  "pulp_href": "/api/pulp/default/api/v3/pypi_yank_monitor/abcdef01-2345-6789-abcd-ef0123456789/",
   "name": "yank-monitor-my-repo",
   "repository": "/api/pulp/public-rhai/api/v3/repositories/python/python/01234567-89ab-cdef-0123-456789abcdef/",
   "repository_version": null,
@@ -148,13 +156,15 @@ curl ${AUTH} -X DELETE \
 
 ## API reference
 
+All endpoints use the base path `/api/pulp/{domain}/api/v3/`.
+
 | Endpoint | Method | Description |
 |----------|--------|-------------|
-| `/api/v3/pypi_yank_monitor/` | `GET` | List all monitors (supports filtering by `name`, `repository`, `pulp_label_select`) |
-| `/api/v3/pypi_yank_monitor/` | `POST` | Create a new monitor |
-| `/api/v3/pypi_yank_monitor/{id}/` | `GET` | Retrieve a specific monitor |
-| `/api/v3/pypi_yank_monitor/{id}/` | `DELETE` | Delete a monitor |
-| `/api/v3/pypi_yank_monitor/{id}/check/` | `POST` | Trigger an on-demand yank check (returns 202 with task) |
-| `/api/v3/pypi_yank_monitor/{id}/report/` | `GET` | Retrieve the latest yank report (returns 404 if no report exists) |
+| `pypi_yank_monitor/` | `GET` | List all monitors (supports filtering by `name`, `repository`, `pulp_label_select`) |
+| `pypi_yank_monitor/` | `POST` | Create a new monitor |
+| `pypi_yank_monitor/{id}/` | `GET` | Retrieve a specific monitor |
+| `pypi_yank_monitor/{id}/` | `DELETE` | Delete a monitor |
+| `pypi_yank_monitor/{id}/check/` | `POST` | Trigger an on-demand yank check (returns 202 with task) |
+| `pypi_yank_monitor/{id}/report/` | `GET` | Retrieve the latest yank report (returns 404 if no report exists) |
 
 All endpoints require **superuser** permissions.

--- a/docs/pypi-yank-monitor.md
+++ b/docs/pypi-yank-monitor.md
@@ -16,7 +16,7 @@ Yank monitors are **not scoped to a Pulp domain**. Although you access the API t
 
 Before proceeding, ensure that you have:
 
-1. **Superuser access** to the Pulp instance. The yank monitor API requires superuser permissions.
+1. **Domain access** — Your organization must be a member of the domain where the monitored repositories reside. Access is granted through DomainOrg membership.
 2. **A Python repository** in your Pulp domain with content to monitor.
 3. **API credentials** configured. See the [API access guide](https://gitlab.cee.redhat.com/hosted-pulp/pulp-docs/-/blob/main/api-access.md) for authentication options.
 
@@ -167,4 +167,4 @@ All endpoints use the base path `/api/pulp/{domain}/api/v3/`.
 | `pypi_yank_monitor/{id}/check/` | `POST` | Trigger an on-demand yank check (returns 202 with task) |
 | `pypi_yank_monitor/{id}/report/` | `GET` | Retrieve the latest yank report (returns 404 if no report exists) |
 
-All endpoints require **superuser** permissions.
+All endpoints require **DomainOrg membership** for the target domain.

--- a/management_tools/configure-yank-monitors.py
+++ b/management_tools/configure-yank-monitors.py
@@ -1,0 +1,294 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "requests",
+# ]
+# ///
+"""
+Configure and verify PyPI yank monitors for Python repositories in a Pulp domain.
+
+Creates a PyPIYankMonitor for each Python repository that doesn't already have one.
+Use --verify to check which repositories have monitors configured.
+
+Authentication uses credentials from ~/.netrc.
+
+Usage:
+    uv run management_tools/configure-yank-monitors.py --env prod --domain public-rhai --dry-run
+    uv run management_tools/configure-yank-monitors.py --env prod --domain public-rhai
+    uv run management_tools/configure-yank-monitors.py --env prod --domain public-rhai --verify
+    uv run management_tools/configure-yank-monitors.py --env prod --domain public-rhai --repository my-repo
+    uv run management_tools/configure-yank-monitors.py --env prod --domain public-rhai --repository repo1 --repository repo2
+"""
+
+import argparse
+import netrc
+import sys
+from urllib.parse import urlparse
+
+import requests
+
+ENVIRONMENTS = {
+    "stage": "https://packages.stage.redhat.com",
+    "prod": "https://packages.redhat.com",
+}
+
+
+def _raise_for_status(response: requests.Response) -> None:
+    """Raise with the response body included for diagnostics."""
+    try:
+        response.raise_for_status()
+    except requests.HTTPError as err:
+        body = response.text[:500]
+        raise requests.HTTPError(
+            f"{err}\nResponse body: {body}",
+            response=response,
+        ) from err
+
+
+def _safe_next_url(next_url: str | None, expected_host: str) -> str | None:
+    """Return next_url only if it points to the expected host."""
+    if next_url is None:
+        return None
+    parsed = urlparse(next_url)
+    if parsed.hostname != expected_host:
+        raise ValueError(
+            f"Pagination URL host mismatch: expected {expected_host}, "
+            f"got {parsed.hostname}"
+        )
+    return next_url
+
+
+def get_session(base_url: str) -> requests.Session:
+    """Create a requests session using .netrc credentials."""
+    hostname = urlparse(base_url).hostname
+
+    try:
+        nrc = netrc.netrc()
+        auth_tuple = nrc.authenticators(hostname)
+    except (FileNotFoundError, netrc.NetrcParseError) as err:
+        print(f"Error reading .netrc: {err}", file=sys.stderr)
+        sys.exit(1)
+
+    if auth_tuple is None:
+        print(f"No .netrc entry found for {hostname}", file=sys.stderr)
+        sys.exit(1)
+
+    login, _, password = auth_tuple
+
+    session = requests.Session()
+    session.auth = (login, password)
+
+    response = session.get(f"{base_url}/api/pulp/api/v3/status/")
+    _raise_for_status(response)
+    return session
+
+
+def list_python_repositories(
+    session: requests.Session, api_base: str, expected_host: str
+) -> list[dict]:
+    """List all Python repositories in the domain, handling pagination."""
+    repositories = []
+    url = f"{api_base}repositories/python/python/"
+
+    while url:
+        response = session.get(url)
+        _raise_for_status(response)
+        data = response.json()
+        repositories.extend(data.get("results", []))
+        url = _safe_next_url(data.get("next"), expected_host)
+
+    return repositories
+
+
+def list_existing_monitors(
+    session: requests.Session, api_base: str, expected_host: str
+) -> dict[str, dict]:
+    """List existing yank monitors, returning a dict keyed by repository pulp_href."""
+    monitors = {}
+    url = f"{api_base}pypi_yank_monitor/"
+
+    while url:
+        response = session.get(url)
+        _raise_for_status(response)
+        data = response.json()
+        for monitor in data.get("results", []):
+            repo_href = monitor.get("repository")
+            if repo_href:
+                monitors[repo_href] = monitor
+        url = _safe_next_url(data.get("next"), expected_host)
+
+    return monitors
+
+
+def create_monitor(
+    session: requests.Session,
+    api_base: str,
+    name: str,
+    repository_href: str,
+) -> dict:
+    """Create a PyPIYankMonitor for a repository."""
+    url = f"{api_base}pypi_yank_monitor/"
+    payload = {
+        "name": name,
+        "repository": repository_href,
+    }
+    response = session.post(url, json=payload)
+    _raise_for_status(response)
+    return response.json()
+
+
+def verify_monitors(
+    repositories: list[dict], existing_monitors: dict[str, dict]
+) -> bool:
+    """Check which repositories have yank monitors configured. Returns True if all covered."""
+    monitored = []
+    unmonitored = []
+
+    for repo in repositories:
+        repo_name = repo["name"]
+        repo_href = repo["pulp_href"]
+        monitor = existing_monitors.get(repo_href)
+
+        if monitor:
+            last_checked = monitor.get("last_checked") or "never"
+            monitored.append((repo_name, monitor["name"], last_checked))
+        else:
+            unmonitored.append(repo_name)
+
+    if monitored:
+        print(f"\nMonitored ({len(monitored)}):")
+        for repo_name, monitor_name, last_checked in monitored:
+            print(f"  OK  {repo_name} — monitor '{monitor_name}', last checked: {last_checked}")
+
+    if unmonitored:
+        print(f"\nNot monitored ({len(unmonitored)}):")
+        for repo_name in unmonitored:
+            print(f"  MISSING  {repo_name}")
+
+    all_covered = len(unmonitored) == 0
+    print(f"\nCoverage: {len(monitored)}/{len(repositories)} repositories monitored")
+    return all_covered
+
+
+def configure_monitors(
+    session: requests.Session,
+    api_base: str,
+    repositories: list[dict],
+    existing_monitors: dict[str, dict],
+    dry_run: bool,
+) -> None:
+    """Create monitors for repositories that don't have one."""
+    created_count = 0
+    skipped_count = 0
+    failed_count = 0
+
+    for repo in repositories:
+        repo_name = repo["name"]
+        repo_href = repo["pulp_href"]
+        monitor_name = f"yank-monitor-{repo_name}"
+
+        if repo_href in existing_monitors:
+            existing = existing_monitors[repo_href]
+            print(f"  SKIP: {repo_name} — monitor '{existing['name']}' already exists")
+            skipped_count += 1
+            continue
+
+        if dry_run:
+            print(f"  DRY RUN: would create monitor '{monitor_name}' for {repo_name}")
+            continue
+
+        print(f"  CREATING: monitor '{monitor_name}' for {repo_name}...", end=" ")
+        try:
+            monitor = create_monitor(session, api_base, monitor_name, repo_href)
+            print(f"OK ({monitor['pulp_href']})")
+            created_count += 1
+        except requests.HTTPError as err:
+            print(f"FAILED\n    {err}", file=sys.stderr)
+            failed_count += 1
+
+    print(f"\nDone. Created: {created_count}, Skipped: {skipped_count}, Failed: {failed_count}")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Configure and verify PyPI yank monitors for Python repositories."
+    )
+    parser.add_argument(
+        "--env",
+        choices=ENVIRONMENTS.keys(),
+        help="Environment (stage or prod)",
+    )
+    parser.add_argument(
+        "--base-url",
+        help="Pulp base URL (alternative to --env)",
+    )
+    parser.add_argument(
+        "--domain",
+        default="public-rhai",
+        help="Pulp domain name (default: public-rhai)",
+    )
+    parser.add_argument(
+        "--verify",
+        action="store_true",
+        help="Check which repositories have yank monitors configured (read-only)",
+    )
+    parser.add_argument(
+        "--repository",
+        action="append",
+        dest="repositories",
+        metavar="NAME",
+        help="Target specific repository name(s). Can be repeated. If omitted, targets all.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="List repositories and planned monitors without creating anything",
+    )
+    args = parser.parse_args()
+
+    if args.base_url:
+        base_url = args.base_url
+    elif args.env:
+        base_url = ENVIRONMENTS[args.env]
+    else:
+        parser.error("Either --env or --base-url is required")
+
+    api_base = f"{base_url}/api/pulp/{args.domain}/api/v3/"
+    expected_host = urlparse(base_url).hostname
+
+    print(f"Connecting to {base_url} (domain: {args.domain})")
+    session = get_session(base_url)
+
+    print("Listing Python repositories...")
+    all_repositories = list_python_repositories(session, api_base, expected_host)
+    if not all_repositories:
+        print("No Python repositories found in this domain.")
+        sys.exit(0)
+
+    if args.repositories:
+        available_names = {repo["name"] for repo in all_repositories}
+        unknown = set(args.repositories) - available_names
+        if unknown:
+            print(f"Repository(ies) not found in domain: {', '.join(sorted(unknown))}", file=sys.stderr)
+            print(f"Available: {', '.join(sorted(available_names))}", file=sys.stderr)
+            sys.exit(1)
+        repositories = [repo for repo in all_repositories if repo["name"] in set(args.repositories)]
+    else:
+        repositories = all_repositories
+
+    print(f"Targeting {len(repositories)} of {len(all_repositories)} Python repository(ies):")
+    for repo in repositories:
+        print(f"  - {repo['name']}")
+
+    print("\nFetching existing yank monitors...")
+    existing_monitors = list_existing_monitors(session, api_base, expected_host)
+
+    if args.verify:
+        all_covered = verify_monitors(repositories, existing_monitors)
+        sys.exit(0 if all_covered else 1)
+
+    configure_monitors(session, api_base, repositories, existing_monitors, args.dry_run)
+
+
+if __name__ == "__main__":
+    main()

--- a/management_tools/configure-yank-monitors.py
+++ b/management_tools/configure-yank-monitors.py
@@ -46,11 +46,14 @@ def _raise_for_status(response: requests.Response) -> None:
 
 
 def _safe_next_url(next_url: str | None, expected_host: str) -> str | None:
-    """Return next_url only if it points to the expected host."""
+    """Return next_url only if it points to the expected host.
+
+    Relative URLs (no hostname) are treated as same-host and returned as-is.
+    """
     if next_url is None:
         return None
     parsed = urlparse(next_url)
-    if parsed.hostname != expected_host:
+    if parsed.hostname is not None and parsed.hostname != expected_host:
         raise ValueError(
             f"Pagination URL host mismatch: expected {expected_host}, "
             f"got {parsed.hostname}"
@@ -181,6 +184,7 @@ def configure_monitors(
     created_count = 0
     skipped_count = 0
     failed_count = 0
+    would_create_count = 0
 
     for repo in repositories:
         repo_name = repo["name"]
@@ -195,6 +199,7 @@ def configure_monitors(
 
         if dry_run:
             print(f"  DRY RUN: would create monitor '{monitor_name}' for {repo_name}")
+            would_create_count += 1
             continue
 
         print(f"  CREATING: monitor '{monitor_name}' for {repo_name}...", end=" ")
@@ -206,7 +211,10 @@ def configure_monitors(
             print(f"FAILED\n    {err}", file=sys.stderr)
             failed_count += 1
 
-    print(f"\nDone. Created: {created_count}, Skipped: {skipped_count}, Failed: {failed_count}")
+    if dry_run:
+        print(f"\nDry run complete. Would create: {would_create_count}, Skipped: {skipped_count}")
+    else:
+        print(f"\nDone. Created: {created_count}, Skipped: {skipped_count}, Failed: {failed_count}")
 
 
 def main():

--- a/pulp_service/pulp_service/app/viewsets.py
+++ b/pulp_service/pulp_service/app/viewsets.py
@@ -253,7 +253,7 @@ class PyPIYankMonitorViewSet(
     queryset = PyPIYankMonitor.objects.all()
     serializer_class = PyPIYankMonitorSerializer
     filterset_class = PyPIYankMonitorFilter
-    permission_classes = [IsSuperuser]
+    permission_classes = [DomainBasedPermission]
 
     @extend_schema(request=None, responses={202: AsyncOperationResponseSerializer})
     @action(detail=True, methods=["post"], url_path="check")


### PR DESCRIPTION
## Summary

- Add `management_tools/configure-yank-monitors.py` script to bulk-create and verify PyPI yank monitors for Python repositories in a domain
- Add `docs/pypi-yank-monitor.md` with feature documentation covering the yank monitor API (CRUD, triggering checks, viewing reports)

## Details

The script supports:
- `--verify` to check which repos have monitors configured
- `--repository` to target specific repos
- `--dry-run` to preview changes
- `--env` (stage/prod) for environment selection
- `.netrc` authentication

Ref: PULP-1592, PULP-1593

## Test plan

- [x] Run `configure-yank-monitors.py --env prod --domain public-rhai --verify` to verify existing state
- [x] Run `configure-yank-monitors.py --env prod --domain public-rhai --dry-run` to preview monitor creation
- [ ] Verify API examples in docs against a live instance

## Review with Claude Code

To review this PR with Claude Code, try:

```
Review PR pulp/pulp-service#1031. Check the script for correctness,
error handling, and security. Verify that the docs accurately reflect
the API behavior — especially the domain scoping notes.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add a management script and documentation for configuring and operating PyPI yank monitors, and relax monitor API permissions to domain-based access.

New Features:
- Introduce a configure-yank-monitors management script to bulk-create and verify PyPI yank monitors for Python repositories in a domain.
- Document the PyPI yank monitor API, including setup, triggering checks, viewing reports, and managing monitors.

Enhancements:
- Change the PyPIYankMonitor API viewset to use domain-based permissions instead of requiring superuser access.