### PR TITLE
Modify build-agent-splunk workflow release step

### DIFF
--- a/.github/workflows/build-agent-splunk.yml
+++ b/.github/workflows/build-agent-splunk.yml
@@ -10,22 +10,23 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-go@v6
         with:
           go-version: '1.25'
       - name: Build
         working-directory: tools/agents/agent-splunk
         run: CGO_ENABLED=0 go build -o agent-splunk .
       - name: Upload binary artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: agent-splunk
           path: tools/agents/agent-splunk/agent-splunk
       - name: Build and push image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: tools/agents/agent-splunk
+          file: tools/agents/agent-splunk/Containerfile
           push: true
           tags: ghcr.io/pulp/agent-splunk:latest
 
@@ -36,7 +37,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Determine version
         id: version
         run: |
@@ -46,13 +47,19 @@ jobs:
           fi
           echo "tag=$VERSION" >> "$GITHUB_OUTPUT"
       - name: Download binary artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: agent-splunk
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
-        with:
-          tag_name: ${{ steps.version.outputs.tag }}
-          name: agent-splunk ${{ steps.version.outputs.tag }}
-          generate_release_notes: true
-          files: agent-splunk
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${{ steps.version.outputs.tag }}"
+          if gh release view "$TAG" > /dev/null 2>&1; then
+            gh release upload "$TAG" agent-splunk --clobber
+          else
+            gh release create "$TAG" \
+              --title "agent-splunk $TAG" \
+              --generate-notes \
+              agent-splunk
+          fi


### PR DESCRIPTION
Assisted By: claude-opus-4.6

## Summary by Sourcery

CI:
- Switch the build-agent-splunk release step from softprops/action-gh-release to a shell step invoking the GitHub CLI with GITHUB_TOKEN for authentication.