### PR TITLE
Bump pulp-python to 3.28.2

### DIFF
--- a/pulp_service/requirements.txt
+++ b/pulp_service/requirements.txt
@@ -1,7 +1,7 @@
 pulpcore==3.107.1
 pulp-rpm==3.35.2
 pulp-gem==0.7.5
-pulp-python==3.28.0
+pulp-python==3.28.2
 pulp-npm==0.7.0
 pulp-container==2.27.2
 pulp-maven==0.12.0


### PR DESCRIPTION
## Summary

- Bump pulp-python from 3.28.0 to 3.28.2

3.28.2 fixes `repair_metadata` OOM on large repositories (1000+ packages) by reducing peak memory consumption. Workers were hitting 7.7GB (96.8% of 8GB limit), missing their heartbeat, and getting marked as "Worker has gone missing."

Upstream PR: https://github.com/pulp/pulp_python/pull/1189
Upstream issue: https://github.com/pulp/pulp_python/issues/1188

## Test plan

- [ ] CI passes
- [ ] Deploy to stage
- [ ] Run `repair-python-metadata.py --env stage --domain <large-domain>` and verify no OOM

JIRA: PULP-1602

🤖 Generated with [Claude Code](https://claude.com/claude-code)