### PR TITLE
Remove container build/push from agent-splunk pipeline

### DIFF
--- a/.github/workflows/build-agent-splunk.yml
+++ b/.github/workflows/build-agent-splunk.yml
@@ -22,13 +22,6 @@ jobs:
         with:
           name: agent-splunk
           path: tools/agents/agent-splunk/agent-splunk
-      - name: Build and push image
-        uses: docker/build-push-action@v6
-        with:
-          context: tools/agents/agent-splunk
-          file: tools/agents/agent-splunk/Containerfile
-          push: true
-          tags: ghcr.io/pulp/agent-splunk:latest
 
   release:
     needs: build

--- a/tools/agents/agent-splunk/README.md
+++ b/tools/agents/agent-splunk/README.md
@@ -41,4 +41,3 @@ go build -o agent-splunk .
 podman build -f Containerfile -t agent-splunk .
 podman run --env-file .env agent-splunk
 ```
-


### PR DESCRIPTION
## Summary by Sourcery

Remove container image build and push from the agent-splunk GitHub Actions workflow.

Build:
- Stop building and pushing the agent-splunk container image in the build-agent-splunk GitHub Actions workflow.

Documentation:
- Clean up agent-splunk README by removing a trailing blank line.