### PR TITLE
Update build-agent-splunk pipeline release step

### DIFF
--- a/.github/workflows/build-agent-splunk.yml
+++ b/.github/workflows/build-agent-splunk.yml
@@ -53,6 +53,5 @@ jobs:
           else
             gh release create "$TAG" \
               --title "agent-splunk $TAG" \
-              --generate-notes \
               agent-splunk
           fi

--- a/tools/agents/agent-splunk/README.md
+++ b/tools/agents/agent-splunk/README.md
@@ -41,3 +41,4 @@ go build -o agent-splunk .
 podman build -f Containerfile -t agent-splunk .
 podman run --env-file .env agent-splunk
 ```
+


### PR DESCRIPTION
## Summary by Sourcery

Update the build-agent-splunk GitHub Actions workflow release step and make a minor README adjustment.

Build:
- Stop auto-generating GitHub release notes in the build-agent-splunk workflow release step.

Documentation:
- Tidy the agent-splunk README formatting with a trailing newline.