### PR TITLE
Replaced os.ReadFile with go:embed jira-workflows.md

### DIFF
--- a/tools/agents/agent-splunk/Containerfile
+++ b/tools/agents/agent-splunk/Containerfile
@@ -15,7 +15,6 @@ FROM registry.access.redhat.com/ubi9-minimal:latest
 WORKDIR /app
 
 COPY --from=builder /opt/app-root/src/agent-splunk .
-COPY --from=builder /opt/app-root/src/skills/jira-workflows.md ./skills/
 
 USER 1001
 

--- a/tools/agents/agent-splunk/README.md
+++ b/tools/agents/agent-splunk/README.md
@@ -41,4 +41,3 @@ go build -o agent-splunk .
 podman build -f Containerfile -t agent-splunk .
 podman run --env-file .env agent-splunk
 ```
-

--- a/tools/agents/agent-splunk/main.go
+++ b/tools/agents/agent-splunk/main.go
@@ -90,11 +90,8 @@ func run() error {
 		fmt.Fprintf(os.Stderr, "[splunk] registered splunk_search tool (%s)\n", splunkURL)
 	}
 
-	// Load skill file
-	skillMsg, err := skills.LoadSkill()
-	if err != nil {
-		return fmt.Errorf("LoadSkill: %w", err)
-	}
+	// Load embedded skill
+	skillMsg := skills.LoadSkill()
 	fmt.Fprintf(os.Stderr, "[skills] loaded jira-workflow.md\n")
 
 	var model models.Model

--- a/tools/agents/agent-splunk/skills/load.go
+++ b/tools/agents/agent-splunk/skills/load.go
@@ -1,21 +1,16 @@
 package skills
 
 import (
-	"fmt"
-	"os"
+	_ "embed"
 
 	"github.com/tmc/langchaingo/llms"
 )
 
-const JIRA_STRUCTURE_SKILL_FILE = "./skills/jira-workflows.md"
+//go:embed jira-workflows.md
+var jiraWorkflowsSkill string
 
-// LoadSkill reads the jira-workflows.md file and returns its content as an llms.MessageContent
+// LoadSkill returns the embedded jira-workflows.md content as an llms.MessageContent
 // that can be prepended to the LLM conversation history.
-func LoadSkill() (llms.MessageContent, error) {
-	content, err := os.ReadFile(JIRA_STRUCTURE_SKILL_FILE)
-	if err != nil {
-		return llms.MessageContent{}, fmt.Errorf("reading skill file: %w", err)
-	}
-
-	return llms.TextParts(llms.ChatMessageTypeSystem, string(content)), nil
+func LoadSkill() llms.MessageContent {
+	return llms.TextParts(llms.ChatMessageTypeSystem, jiraWorkflowsSkill)
 }


### PR DESCRIPTION
Embed the file content into the binary at compile time to avoid having to load it at runtime.

Assisted By: claude-opus-4.6

## Summary by Sourcery

Embed the Jira workflows skill content into the Splunk agent binary instead of reading it from a file at runtime.

Enhancements:
- Replace runtime file loading of jira-workflows.md with a go:embed-based embedded skill message for the Splunk agent.

Build:
- Remove the Containerfile step that copies jira-workflows.md into the image since the skill content is now embedded at build time.