### PR TITLE
Add Splunk log analyzer agent and workflow

### DIFF
--- a/.alcove/tasks/splunk-analyzer.yml
+++ b/.alcove/tasks/splunk-analyzer.yml
@@ -18,8 +18,3 @@ credentials:
   SPLUNK_TOKEN: splunk
   JIRA_TOKEN: jira
   VERTEX_SA_JSON: google-vertex
-
-trigger:
-  schedule:
-    cron: "0 * * * *"
-    enabled: true

--- a/.alcove/tasks/splunk-analyzer.yml
+++ b/.alcove/tasks/splunk-analyzer.yml
@@ -1,0 +1,25 @@
+name: Splunk Log Analyzer
+description: |
+  Analyzes Splunk logs for 5xx errors and drafts Jira issues.
+  Runs as a pre-compiled agent binary from GitHub Releases.
+
+executable:
+  url: https://github.com/pulp/pulp-service/releases/download/agent-splunk-20260414-e4c209e/agent-splunk
+  args: ["--model", "claude-opus-4-6"]
+  env:
+    SPLUNK_INSECURE_SKIP_VERIFY: "true"
+
+timeout: 1800
+
+profiles:
+  - splunk-analyzer
+
+credentials:
+  SPLUNK_TOKEN: splunk
+  JIRA_TOKEN: jira
+  VERTEX_SA_JSON: google-vertex
+
+trigger:
+  schedule:
+    cron: "0 * * * *"
+    enabled: true

--- a/.alcove/workflows/splunk-analysis-pipeline.yml
+++ b/.alcove/workflows/splunk-analysis-pipeline.yml
@@ -1,0 +1,10 @@
+name: Splunk Analysis Pipeline
+
+workflow:
+  - id: analyze-logs
+    agent: Splunk Log Analyzer
+    trigger:
+      schedule:
+        cron: "0 * * * *"
+        enabled: true
+    outputs: [issues_found, issues_created, error_summary]


### PR DESCRIPTION
## Summary

- Add Alcove agent definition (`.alcove/tasks/splunk-analyzer.yml`) that runs the pre-compiled `agent-splunk` binary from [GitHub Releases](https://github.com/pulp/pulp-service/releases/tag/agent-splunk-20260414-e4c209e)
- Add DAG workflow (`.alcove/workflows/splunk-analysis-pipeline.yml`) that triggers the agent on an hourly cron schedule

## How it works

The agent definition uses Alcove's `executable:` field instead of a `prompt:`. At runtime, Alcove's Skiff container downloads the binary from the release URL, injects credentials (Splunk, Jira, Vertex AI) via environment variables, and executes it. The binary analyzes Splunk logs for 5xx errors and drafts Jira issues for findings.

The workflow wraps the agent in a single-step DAG pipeline with `outputs` declared so downstream steps can be added later (e.g., notification, escalation).

## Files

- `.alcove/tasks/splunk-analyzer.yml` — agent definition with executable URL, credentials, hourly cron trigger
- `.alcove/workflows/splunk-analysis-pipeline.yml` — DAG workflow wrapping the agent

## Test plan

- [ ] Configure pulp/pulp-service as an agent repo on an Alcove installation
- [ ] Verify the agent definition and workflow sync correctly
- [ ] Run the agent manually and verify it downloads and executes the binary

## Summary by Sourcery

Add an Alcove task and workflow to run a precompiled Splunk log analyzer agent on an hourly schedule.

New Features:
- Introduce a Splunk Log Analyzer agent task that executes a precompiled binary with configured credentials and timeout.
- Add a Splunk Analysis Pipeline workflow that runs the Splunk Log Analyzer agent and exposes its key outputs for downstream steps.