### PR TITLE
Fix: move hourly schedule to task definition

### DIFF
--- a/.alcove/tasks/splunk-analyzer.yml
+++ b/.alcove/tasks/splunk-analyzer.yml
@@ -18,3 +18,7 @@ credentials:
   SPLUNK_TOKEN: splunk
   JIRA_TOKEN: jira
   VERTEX_SA_JSON: google-vertex
+
+schedule:
+  cron: "0 * * * *"
+  enabled: true

--- a/.alcove/workflows/splunk-analysis-pipeline.yml
+++ b/.alcove/workflows/splunk-analysis-pipeline.yml
@@ -3,8 +3,4 @@ name: Splunk Analysis Pipeline
 workflow:
   - id: analyze-logs
     agent: Splunk Log Analyzer
-    trigger:
-      schedule:
-        cron: "0 * * * *"
-        enabled: true
     outputs: [issues_found, issues_created, error_summary]


### PR DESCRIPTION
## Summary

- Move the cron schedule from the workflow step trigger to the task definition's top-level `schedule:` field

## Root Cause

Workflow step triggers use `EventTrigger` which only supports GitHub events, not cron schedules. The `schedule:` inside a workflow step trigger was silently ignored. The task definition has a separate top-level `schedule` field (`TaskDefSchedule`) that properly creates cron-based schedule entries.

## Test plan

- [ ] Sync the repo on an Alcove installation and verify the schedule is created
- [ ] Verify the agent definition shows `has_schedule: true`

## Summary by Sourcery

Bug Fixes:
- Ensure the Splunk analyzer cron schedule is applied by moving it from the workflow step trigger to the task definition's top-level schedule field.