### PR TITLE
Remove non-existent splunk-analyzer security profile

### DIFF
--- a/.alcove/tasks/splunk-analyzer.yml
+++ b/.alcove/tasks/splunk-analyzer.yml
@@ -11,9 +11,6 @@ executable:
 
 timeout: 1800
 
-profiles:
-  - splunk-analyzer
-
 credentials:
   SPLUNK_TOKEN: splunk
   JIRA_TOKEN: jira


### PR DESCRIPTION
Removes the profiles reference that causes a sync error on every cycle.

## Summary by Sourcery

Bug Fixes:
- Fix recurring sync errors by removing a reference to a non-existent splunk-analyzer security profile from the task configuration.