### PR TITLE
Update workflow definitions for workflow graph v2

### DIFF
--- a/.alcove/workflows/splunk-analysis-pipeline.yml
+++ b/.alcove/workflows/splunk-analysis-pipeline.yml
@@ -2,5 +2,6 @@ name: Splunk Analysis Pipeline
 
 workflow:
   - id: analyze-logs
+    type: agent
     agent: Splunk Log Analyzer
     outputs: [issues_found, issues_created, error_summary]


### PR DESCRIPTION
## Summary
- Add explicit `type: agent` annotation to the Splunk Analysis Pipeline workflow step for compatibility with Alcove workflow graph v2
- Task definition (`splunk-analyzer.yml`) left unchanged — it uses a pre-compiled binary via the `executable` field and its schedule/credentials/timeout config remains as-is

## Test plan
- [ ] Verify the workflow YAML parses correctly with Alcove's workflow graph v2 schema
- [ ] Confirm the Splunk Log Analyzer agent still runs on its hourly schedule

Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Ensure the Splunk Analysis Pipeline workflow step is correctly recognized as an agent under workflow graph v2.