### PR TITLE
Modify agent splunk for alcove support

### DIFF
--- a/tools/agents/agent-splunk/README.md
+++ b/tools/agents/agent-splunk/README.md
@@ -7,7 +7,7 @@ An AI agent that queries Splunk for 5xx errors, analyzes them using an LLM (Clau
 - Go 1.25+
 - Authentication configured for your chosen provider (see below)
 - Access to a Splunk instance
-- A running [MCP Atlassian](Containerfile.mcp-atlassian) server
+- MCP servers: either a running [MCP Atlassian](Containerfile.mcp-atlassian) server (`JIRA_MCP_URL`) or an `ALCOVE_MCP_CONFIG` with stdio-based MCP servers
 
 ## Environment Variables
 
@@ -27,7 +27,8 @@ If both `ANTHROPIC_API_KEY` and `ANTHROPIC_VERTEX_PROJECT_ID` are set, the direc
 | `CLOUD_ML_REGION` | Vertex AI region (default: `us-east5`) |
 | `SPLUNK_URL` | Splunk instance URL |
 | `SPLUNK_TOKEN` | Splunk auth token |
-| `JIRA_MCP_URL` | URL of the Jira MCP server |
+| `ALCOVE_MCP_CONFIG` | JSON config for stdio MCP servers (used by Alcove, takes precedence over `JIRA_MCP_URL`) |
+| `JIRA_MCP_URL` | URL of the Jira MCP server (standalone mode) |
 
 ## Usage
 

--- a/tools/agents/agent-splunk/README.md
+++ b/tools/agents/agent-splunk/README.md
@@ -5,14 +5,24 @@ An AI agent that queries Splunk for 5xx errors, analyzes them using an LLM (Clau
 ## Prerequisites
 
 - Go 1.25+
-- Google Cloud credentials configured (for Vertex AI access)
+- Authentication configured for your chosen provider (see below)
 - Access to a Splunk instance
 - A running [MCP Atlassian](Containerfile.mcp-atlassian) server
 
 ## Environment Variables
 
+The agent supports two authentication methods for Claude models:
+
+**Option 1: Direct Anthropic API** — set `ANTHROPIC_API_KEY` (and optionally `ANTHROPIC_BASE_URL`).
+
+**Option 2: Vertex AI** — set `ANTHROPIC_VERTEX_PROJECT_ID` and configure Google Cloud credentials.
+
+If both `ANTHROPIC_API_KEY` and `ANTHROPIC_VERTEX_PROJECT_ID` are set, the direct API is used. Gemini models always require Vertex AI.
+
 | Variable | Description |
 |---|---|
+| `ANTHROPIC_API_KEY` | Anthropic API key for direct API access |
+| `ANTHROPIC_BASE_URL` | Custom base URL for the Anthropic API (optional) |
 | `ANTHROPIC_VERTEX_PROJECT_ID` | Google Cloud project ID for Vertex AI |
 | `CLOUD_ML_REGION` | Vertex AI region (default: `us-east5`) |
 | `SPLUNK_URL` | Splunk instance URL |

--- a/tools/agents/agent-splunk/main.go
+++ b/tools/agents/agent-splunk/main.go
@@ -29,10 +29,9 @@ func run() error {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
+	apiKey := os.Getenv("ANTHROPIC_API_KEY")
+	baseURL := os.Getenv("ANTHROPIC_BASE_URL")
 	projectID := os.Getenv("ANTHROPIC_VERTEX_PROJECT_ID")
-	if projectID == "" {
-		return fmt.Errorf("ANTHROPIC_VERTEX_PROJECT_ID environment variable is required")
-	}
 
 	region := os.Getenv("CLOUD_ML_REGION")
 	if region == "" {
@@ -49,6 +48,18 @@ func run() error {
 	}
 	if _, exists := supportedModels[*inputModel]; !exists {
 		return fmt.Errorf("unsupported model: %s. Supported models: claude-opus-4-6, gemini-2.5-pro", *inputModel)
+	}
+
+	// Validate required auth env vars early, before any MCP/tool setup.
+	switch *inputModel {
+	case "claude-opus-4-6":
+		if apiKey == "" && projectID == "" {
+			return fmt.Errorf("either ANTHROPIC_API_KEY or ANTHROPIC_VERTEX_PROJECT_ID environment variable is required")
+		}
+	case "gemini-2.5-pro":
+		if projectID == "" {
+			return fmt.Errorf("ANTHROPIC_VERTEX_PROJECT_ID environment variable is required for Gemini models")
+		}
 	}
 
 	question := *inputQuestion
@@ -97,10 +108,18 @@ func run() error {
 	var model models.Model
 	switch *inputModel {
 	case "claude-opus-4-6":
-		model = models.Claude{
-			Model:     *inputModel,
-			ProjectID: projectID,
-			Region:    region,
+		if apiKey != "" {
+			model = models.Claude{
+				Model:   *inputModel,
+				APIKey:  apiKey,
+				BaseURL: baseURL,
+			}
+		} else {
+			model = models.Claude{
+				Model:     *inputModel,
+				ProjectID: projectID,
+				Region:    region,
+			}
 		}
 	case "gemini-2.5-pro":
 		model = models.Gemini{

--- a/tools/agents/agent-splunk/mcp-client/client.go
+++ b/tools/agents/agent-splunk/mcp-client/client.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"os/exec"
 	"strings"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -48,33 +49,101 @@ func (m *MCPManager) Close() {
 	}
 }
 
-// ConnectMCP connects to all configured MCP servers over HTTP.
+// mcpServerSpec describes an MCP server to be launched as a stdio child process.
+// This matches the format used in the ALCOVE_MCP_CONFIG environment variable.
+type mcpServerSpec struct {
+	Command string            `json:"command"`
+	Args    []string          `json:"args,omitempty"`
+	Env     map[string]string `json:"env,omitempty"`
+}
+
+// ConnectMCP connects to all configured MCP servers.
 //
-// Jira:    JIRA_MCP_URL → Streamable HTTP transport
+// It supports two modes:
 //
-// Environment variables for Jira (must be configured on the MCP server side):
+//  1. Alcove mode (ALCOVE_MCP_CONFIG): spawns MCP servers as stdio child
+//     processes using the command/args/env defined in the JSON config.
 //
-//	JIRA_URL, JIRA_USERNAME, JIRA_TOKEN
+//  2. Standalone mode (JIRA_MCP_URL): connects to a running MCP server
+//     over Streamable HTTP.
+//
+// Alcove mode takes precedence when ALCOVE_MCP_CONFIG is set.
 func ConnectMCP(ctx context.Context) (*MCPManager, error) {
 	mgr := &MCPManager{
 		toolMap:     make(map[string]*mcp.ClientSession),
 		nativeTools: make(map[string]NativeToolHandler),
 	}
 
-	// --- Jira MCP (HTTP) ---
-	if url := os.Getenv("JIRA_MCP_URL"); url != "" {
-		session, err := connectHTTP(ctx, url)
-		if err != nil {
-			return nil, fmt.Errorf("jira MCP: %w", err)
+	// --- Alcove mode: stdio child processes ---
+	if mcpConfig := os.Getenv("ALCOVE_MCP_CONFIG"); mcpConfig != "" {
+		var servers map[string]mcpServerSpec
+		if err := json.Unmarshal([]byte(mcpConfig), &servers); err != nil {
+			return nil, fmt.Errorf("parse ALCOVE_MCP_CONFIG: %w", err)
 		}
-		mgr.sessions = append(mgr.sessions, session)
-		fmt.Fprintf(os.Stderr, "[mcp] connected to Jira (http: %s)\n", url)
+		var errs []string
+		for name, spec := range servers {
+			if spec.Command == "" {
+				continue
+			}
+			session, err := connectStdio(ctx, spec)
+			if err != nil {
+				errs = append(errs, fmt.Sprintf("%s: %v", name, err))
+				fmt.Fprintf(os.Stderr, "[mcp] failed to connect to %s: %v\n", name, err)
+				continue
+			}
+			mgr.sessions = append(mgr.sessions, session)
+			fmt.Fprintf(os.Stderr, "[mcp] connected to %s (stdio: %s)\n", name, spec.Command)
+		}
+		if len(mgr.sessions) == 0 && len(errs) > 0 {
+			return nil, fmt.Errorf("all MCP servers failed: %s", strings.Join(errs, "; "))
+		}
+	} else {
+		// --- Standalone mode: HTTP ---
+		if url := os.Getenv("JIRA_MCP_URL"); url != "" {
+			session, err := connectHTTP(ctx, url)
+			if err != nil {
+				return nil, fmt.Errorf("jira MCP: %w", err)
+			}
+			mgr.sessions = append(mgr.sessions, session)
+			fmt.Fprintf(os.Stderr, "[mcp] connected to Jira (http: %s)\n", url)
+		}
 	}
 
 	if len(mgr.sessions) == 0 {
 		return nil, nil // no MCP servers configured
 	}
 	return mgr, nil
+}
+
+func connectStdio(ctx context.Context, spec mcpServerSpec) (*mcp.ClientSession, error) {
+	// Validate the command before executing. ALCOVE_MCP_CONFIG is set by the
+	// platform, but we still guard against path traversal and injection.
+	if strings.Contains(spec.Command, "..") {
+		return nil, fmt.Errorf("command path must not contain '..': %s", spec.Command)
+	}
+	resolvedCmd, err := exec.LookPath(spec.Command)
+	if err != nil {
+		return nil, fmt.Errorf("command not found: %s", spec.Command)
+	}
+
+	cmd := exec.CommandContext(ctx, resolvedCmd, spec.Args...)
+	cmd.Env = os.Environ()
+	for k, v := range spec.Env {
+		cmd.Env = append(cmd.Env, k+"="+v)
+	}
+	cmd.Stderr = os.Stderr
+
+	client := mcp.NewClient(&mcp.Implementation{
+		Name:    "agent-splunk",
+		Version: "v1.0.0",
+	}, nil)
+
+	transport := &mcp.CommandTransport{Command: cmd}
+	session, err := client.Connect(ctx, transport, nil)
+	if err != nil {
+		return nil, err
+	}
+	return session, nil
 }
 
 func connectHTTP(ctx context.Context, endpoint string) (*mcp.ClientSession, error) {

--- a/tools/agents/agent-splunk/models/anthropic.go
+++ b/tools/agents/agent-splunk/models/anthropic.go
@@ -13,20 +13,33 @@ type Claude struct {
 	Model     string
 	ProjectID string
 	Region    string
+	APIKey    string
+	BaseURL   string
 }
 
 func (claude Claude) ModelRun(ctx context.Context, cfg RunConfig) (string, error) {
+	var opts []anthropic.Option
+	opts = append(opts, anthropic.WithModel(claude.Model))
 
-	// Claude via Vertex AI.
-	llm, err := anthropic.New(
-		anthropic.WithModel(claude.Model),
-		anthropic.WithToken("vertex-ai"),
-		anthropic.WithHTTPClient(&anthropicClient.VertexClient{
-			ProjectID: claude.ProjectID,
-			Region:    claude.Region,
-			Model:     claude.Model,
-		}),
-	)
+	if claude.APIKey != "" {
+		// Direct Anthropic API authentication.
+		opts = append(opts, anthropic.WithToken(claude.APIKey))
+		if claude.BaseURL != "" {
+			opts = append(opts, anthropic.WithBaseURL(claude.BaseURL))
+		}
+	} else {
+		// Claude via Vertex AI.
+		opts = append(opts,
+			anthropic.WithToken("vertex-ai"),
+			anthropic.WithHTTPClient(&anthropicClient.VertexClient{
+				ProjectID: claude.ProjectID,
+				Region:    claude.Region,
+				Model:     claude.Model,
+			}),
+		)
+	}
+
+	llm, err := anthropic.New(opts...)
 	if err != nil {
 		return "", fmt.Errorf("init anthropic client: %w", err)
 	}


### PR DESCRIPTION
## Summary by Sourcery

Add Alcove-compatible stdio MCP server support and expand LLM authentication options for the Splunk agent.

New Features:
- Support launching MCP servers as stdio child processes based on the ALCOVE_MCP_CONFIG environment variable.
- Allow using Claude models via direct Anthropic API credentials in addition to Vertex AI.
- Support configuring a custom Anthropic API base URL via environment variable.

Enhancements:
- Retain and fallback to existing HTTP-based Jira MCP connectivity when Alcove configuration is not provided.
- Improve validation of required environment variables by checking model-specific auth requirements at startup.
- Harden MCP stdio command execution with basic path validation and explicit PATH resolution.

Documentation:
- Update README to document dual Anthropic auth modes, Alcove MCP configuration, and revised environment variable requirements.