### PR TITLE
docs: add malware scanning feature documentation

### DIFF
--- a/docs/malware-scanning.md
+++ b/docs/malware-scanning.md
@@ -1,0 +1,158 @@
+# Malware Scanning for Python Packages
+
+Pulp can automatically scan Python packages for malware when new content is uploaded to a repository. When a new repository version is created, Pulp dispatches a background task that uses an LLM agent to analyze each newly added package and generate a security report.
+
+Scanning is **non-blocking** — the upload completes immediately and the scan runs as a background task. Reports are available for human review through the API. This approach avoids false positives that could disrupt build pipelines.
+
+## How scanning works
+
+When a Python repository has scanning enabled, the following process occurs on each upload:
+
+1. A new repository version is created with the uploaded content.
+2. For each newly added package, Pulp dispatches a background scan task.
+3. The scan task extracts the package archive and invokes the `agent-scan` binary.
+4. The `agent-scan` binary uses an LLM (Claude or Gemini via Vertex AI) to analyze the package files for malware and vulnerabilities.
+5. The analysis results are stored as an `AgentScanReport` linked to the content and the repository version.
+
+> **Note**: Scan reports are **domain-scoped**. Reports are accessible only through the domain where the scanned repository resides.
+
+## Prerequisites
+
+Before proceeding, ensure that you have:
+
+1. **Domain access** — Your organization must be a member of the domain where the repository resides. Access is granted through DomainOrg membership.
+2. **A Python repository** in your Pulp domain.
+3. **API credentials** configured. See the [API access guide](https://gitlab.cee.redhat.com/hosted-pulp/pulp-docs/-/blob/main/api-access.md) for authentication options.
+
+You can interact with the malware scanning feature using either the **Pulp CLI** or the **REST API**. Both options are documented below.
+
+## Enabling scanning on a repository
+
+Malware scanning is controlled by setting the `agent_scan` label to `true` on a Python repository.
+
+### Option 1: Pulp CLI
+
+The Pulp CLI `label` commands operate on individual labels without affecting other labels on the repository.
+
+Enable scanning:
+
+```bash
+pulp python repository label set --repository my-python-repo --key agent_scan --value true
+```
+
+Verify that the label is set:
+
+```bash
+pulp python repository label show --repository my-python-repo --key agent_scan
+```
+
+Disable scanning by removing the label:
+
+```bash
+pulp python repository label unset --repository my-python-repo --key agent_scan
+```
+
+### Option 2: REST API
+
+Set the following environment variables to simplify the curl commands in this guide:
+
+```bash
+BASE_URL=https://packages.redhat.com
+DOMAIN=public-rhai
+API_BASE=${BASE_URL}/api/pulp/${DOMAIN}/api/v3
+AUTH="-u '11009103|myuser:eyJhbGciOi...'"
+REPO_UUID=01234567-89ab-cdef-0123-456789abcdef
+```
+
+Replace `DOMAIN` with your Pulp domain name, `REPO_UUID` with the repository UUID, and the credentials with your own Terms-Based Registry credentials.
+
+Enable scanning:
+
+```bash
+curl ${AUTH} -X PATCH ${API_BASE}/repositories/python/python/${REPO_UUID}/ \
+  -H 'Content-Type: application/json' \
+  -d '{"pulp_labels": {"agent_scan": "true"}}'
+```
+
+Disable scanning:
+
+```bash
+curl ${AUTH} -X PATCH ${API_BASE}/repositories/python/python/${REPO_UUID}/ \
+  -H 'Content-Type: application/json' \
+  -d '{"pulp_labels": {"agent_scan": "false"}}'
+```
+
+> **Note**: The REST API `PATCH` with `pulp_labels` replaces all labels on the repository. To preserve existing labels, include them in the JSON dictionary. The Pulp CLI `label set` and `label unset` commands do not have this limitation.
+
+After scanning is enabled, all subsequent uploads to the repository trigger automatic scanning.
+
+## Viewing scan reports
+
+### List all reports
+
+List the scan reports in your domain:
+
+```bash
+curl ${AUTH} ${API_BASE}/agent_scan_report/
+```
+
+The response includes a list of reports with content and repository version references:
+
+```json
+{
+  "count": 1,
+  "results": [
+    {
+      "pulp_href": "/api/pulp/public-rhai/api/v3/agent_scan_report/abcdef01-2345-6789-abcd-ef0123456789/",
+      "pulp_created": "2026-04-13T10:30:00.000000Z",
+      "pulp_last_updated": "2026-04-13T10:30:00.000000Z",
+      "reports": "<LLM-generated analysis text>",
+      "content": "/api/pulp/public-rhai/api/v3/content/python/packages/fedcba98-7654-3210-fedc-ba9876543210/",
+      "repo_versions": [
+        "/api/pulp/public-rhai/api/v3/repositories/python/python/01234567-89ab-cdef-0123-456789abcdef/versions/3/"
+      ]
+    }
+  ]
+}
+```
+
+The `reports` field contains the LLM-generated analysis as free-form text. The format of this text depends on the LLM model and scanning configuration. The `content` field links to the scanned package, and `repo_versions` lists the repository versions where the content appears.
+
+The list endpoint does not support filtering. To find reports for a specific package, retrieve the list and match by the `content` href.
+
+### Retrieve a specific report
+
+```bash
+curl ${AUTH} ${API_BASE}/agent_scan_report/abcdef01-2345-6789-abcd-ef0123456789/
+```
+
+### Delete a report
+
+```bash
+curl ${AUTH} -X DELETE \
+  ${API_BASE}/agent_scan_report/abcdef01-2345-6789-abcd-ef0123456789/
+```
+
+## What happens when malware is detected
+
+When the scan identifies suspicious content, the report contains the findings from the LLM analysis. **No automatic action is taken** — the report is stored for human review.
+
+DomainOrg members can review the reports through the API and take one of the following actions:
+
+- Remove the affected content from the repository.
+- Add the package to the repository blocklist (if configured).
+- Investigate the findings further.
+
+This design prioritizes avoiding false positives that could disrupt automated build pipelines.
+
+## API reference
+
+All endpoints use the base path `/api/pulp/{domain}/api/v3/`.
+
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `agent_scan_report/` | `GET` | List all scan reports (no filtering supported) |
+| `agent_scan_report/{id}/` | `GET` | Retrieve a specific scan report |
+| `agent_scan_report/{id}/` | `DELETE` | Delete a scan report |
+
+Reports are domain-scoped and require DomainOrg membership for the target domain.

--- a/docs/malware-scanning.md
+++ b/docs/malware-scanning.md
@@ -40,7 +40,7 @@ Enable scanning:
 pulp python repository label set --repository my-python-repo --key agent_scan --value true
 ```
 
-Verify that the label is set:
+The `label set` command produces no output on success. To verify that the label is set:
 
 ```bash
 pulp python repository label show --repository my-python-repo --key agent_scan
@@ -51,6 +51,8 @@ Disable scanning by removing the label:
 ```bash
 pulp python repository label unset --repository my-python-repo --key agent_scan
 ```
+
+The `label unset` command produces no output on success. After removing the label, `label show` returns an error: `Could not find label with key 'agent_scan'`. This is expected behavior.
 
 ### Option 2: REST API
 
@@ -64,7 +66,7 @@ AUTH="-u '11009103|myuser:eyJhbGciOi...'"
 REPO_UUID=01234567-89ab-cdef-0123-456789abcdef
 ```
 
-Replace `DOMAIN` with your Pulp domain name, `REPO_UUID` with the repository UUID, and the credentials with your own Terms-Based Registry credentials.
+Replace `DOMAIN` with your Pulp domain name, `REPO_UUID` with the repository UUID, and the credentials with your own Terms-Based Registry credentials. If you have `.netrc` configured, you can use `--netrc` instead of the `${AUTH}` variable.
 
 Enable scanning:
 
@@ -72,6 +74,12 @@ Enable scanning:
 curl ${AUTH} -X PATCH ${API_BASE}/repositories/python/python/${REPO_UUID}/ \
   -H 'Content-Type: application/json' \
   -d '{"pulp_labels": {"agent_scan": "true"}}'
+```
+
+The PATCH request returns a task href, not the updated repository. To verify that the task completed, check the task status:
+
+```bash
+curl ${AUTH} ${API_BASE}/tasks/<task-uuid>/
 ```
 
 Disable scanning:
@@ -83,6 +91,8 @@ curl ${AUTH} -X PATCH ${API_BASE}/repositories/python/python/${REPO_UUID}/ \
 ```
 
 > **Note**: The REST API `PATCH` with `pulp_labels` replaces all labels on the repository. To preserve existing labels, include them in the JSON dictionary. The Pulp CLI `label set` and `label unset` commands do not have this limitation.
+
+> **Note**: The CLI `label unset` command removes the label key entirely, while the REST API approach above sets the value to `"false"`. Both effectively disable scanning because the code only triggers scanning when the label value is exactly `"true"`. However, the resulting state differs: `label show` returns an error after `label unset`, while the REST API approach leaves the key present with a `"false"` value.
 
 After scanning is enabled, all subsequent uploads to the repository trigger automatic scanning.
 

--- a/docs/malware-scanning.md
+++ b/docs/malware-scanning.md
@@ -1,17 +1,17 @@
 # Malware Scanning for Python Packages
 
-Pulp can automatically scan Python packages for malware when new content is uploaded to a repository. When a new repository version is created, Pulp dispatches a background task that uses an LLM agent to analyze each newly added package and generate a security report.
+Pulp can automatically scan Python packages for malware when a new repository version is created. Pulp dispatches a background task that uses an LLM agent to analyze each newly added package and generate a security report.
 
-Scanning is **non-blocking** — the upload completes immediately and the scan runs as a background task. Reports are available for human review through the API. This approach avoids false positives that could disrupt build pipelines.
+Scanning is **non-blocking** — the operation that creates the repository version completes immediately and the scan runs as a background task. Reports are available for human review through the API. This approach avoids false positives that could disrupt build pipelines.
 
 ## How scanning works
 
-When a Python repository has scanning enabled, the following process occurs on each upload:
+When a Python repository has scanning enabled, the following process occurs each time a new repository version is created (for example, after an upload or a sync):
 
-1. A new repository version is created with the uploaded content.
+1. A new repository version is created with the added content.
 2. For each newly added package, Pulp dispatches a background scan task.
-3. The scan task extracts the package archive and invokes the `agent-scan` binary.
-4. The `agent-scan` binary uses an LLM (Claude or Gemini via Vertex AI) to analyze the package files for malware and vulnerabilities.
+3. The scan task passes the package artifact (`.whl` or `.tar.gz`) to the `agent-scan` binary.
+4. The `agent-scan` binary extracts the archive and uses an LLM (Claude or Gemini via Vertex AI) to analyze the package files for malware and vulnerabilities.
 5. The analysis results are stored as an `AgentScanReport` linked to the content and the repository version.
 
 > **Note**: Scan reports are **domain-scoped**. Reports are accessible only through the domain where the scanned repository resides.
@@ -94,7 +94,7 @@ curl ${AUTH} -X PATCH ${API_BASE}/repositories/python/python/${REPO_UUID}/ \
 
 > **Note**: The CLI `label unset` command removes the label key entirely, while the REST API approach above sets the value to `"false"`. Both effectively disable scanning because the code only triggers scanning when the label value is exactly `"true"`. However, the resulting state differs: `label show` returns an error after `label unset`, while the REST API approach leaves the key present with a `"false"` value.
 
-After scanning is enabled, all subsequent uploads to the repository trigger automatic scanning.
+After scanning is enabled, all subsequent repository version creations (for example, uploads or syncs) trigger automatic scanning.
 
 ## Viewing scan reports
 


### PR DESCRIPTION
## Summary

- Add `docs/malware-scanning.md` documenting the agent-scan malware scanning feature
- Covers enabling/disabling via Pulp CLI (`label set`/`label unset`) and REST API
- Documents scan report API, what happens on detection, and key behaviors

Ref: PULP-1594

## Test plan

- [ ] Verify Pulp CLI `label set` command works for enabling scanning
- [ ] Verify malware scanning API examples against a live instance

## Review with Claude Code

To review this PR with Claude Code, try:

```
Review PR pulp/pulp-service#<number>. Check that the docs accurately
reflect the malware scanning API behavior, the CLI examples are
correct, and the domain scoping notes are accurate.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Documentation:
- Add a malware scanning guide describing non-blocking LLM-based scans for Python repositories, including enabling/disabling via Pulp CLI and REST API, viewing and managing scan reports, and domain-scoping and detection behavior.