### PR TITLE
Patch pulpcore cleanup_old_versions method from Repository

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -188,6 +188,9 @@ RUN patch -p1 -d /usr/local/lib/pulp/lib/python${PYTHON_VERSION}/site-packages <
 COPY images/assets/patches/0053-python-agent-scan-task.patch /tmp/
 RUN patch -p1 -d /usr/local/lib/pulp/lib/python${PYTHON_VERSION}/site-packages < /tmp/0053-python-agent-scan-task.patch
 
+COPY images/assets/patches/0054-defer-contentid-cleanup-old-versions.patch /tmp/
+RUN patch -p1 -d /usr/local/lib/pulp/lib/python${PYTHON_VERSION}/site-packages < /tmp/0054-defer-contentid-cleanup-old-versions.patch
+
 RUN mkdir /licenses
 COPY LICENSE /licenses/LICENSE
 

--- a/images/assets/patches/0054-defer-contentid-cleanup-old-versions.patch
+++ b/images/assets/patches/0054-defer-contentid-cleanup-old-versions.patch
@@ -1,0 +1,15 @@
+diff --git a/pulpcore/app/models/repository.py b/pulpcore/app/models/repository.py
+index a2350072e..2e9e4fcf0 100644
+--- a/pulpcore/app/models/repository.py
++++ b/pulpcore/app/models/repository.py
+@@ -416,7 +416,9 @@ class Repository(MasterModel):
+         if self.retain_repo_versions:
+             # Consider only completed versions that aren't protected for cleanup
+             versions = self.versions.complete().exclude(pk__in=self.protected_versions())
+-            for version in versions.order_by("-number")[self.retain_repo_versions :]:
++            for version in versions.defer("content_ids").order_by("-number")[
++                self.retain_repo_versions :
++            ]:
+                 _logger.info(
+                     "Deleting repository version {} due to version retention limit.".format(version)
+                 )


### PR DESCRIPTION
The .defer("content_ids") will exclude the potentially massive UUID array from the SELECT query. The delete() method and its _squash logic don't access content_ids, so this is safe.

Assisted By: claude-opus-4.6

## Summary by Sourcery

Build:
- Update Dockerfile to apply an additional pulpcore patch during image build for improved cleanup_old_versions performance.