### PR TITLE
Add debug-env agent definition

### DIFF
--- a/.alcove/tasks/debug-env.yml
+++ b/.alcove/tasks/debug-env.yml
@@ -1,0 +1,9 @@
+name: Debug Environment Inspector
+description: Prints all Skiff environment variables with dummy token detection and secret masking. Manually trigger to diagnose credential or networking issues.
+executable:
+  url: file:///usr/local/bin/debug-env
+timeout: 60
+credentials:
+  SPLUNK_TOKEN: splunk
+  JIRA_TOKEN: jira
+  VERTEX_SA_JSON: google-vertex


### PR DESCRIPTION
Manually triggered agent that prints all Skiff environment variables with dummy token detection. Includes credentials block matching the Splunk agent for diagnosing credential propagation issues.

## Summary by Sourcery

Add a manually triggered debug agent task to inspect Skiff environment variables and diagnose credential or networking issues.

New Features:
- Introduce a Debug Environment Inspector task configuration that runs a local debug-env executable to print environment variables with masking and dummy token detection.

Enhancements:
- Align the debug agent's credentials configuration with the existing Splunk agent to help troubleshoot credential propagation problems.