### PR TITLE
Modify cleanup_old_versions again by materializing protected PKs

### DIFF
--- a/images/assets/patches/0054-defer-contentid-cleanup-old-versions.patch
+++ b/images/assets/patches/0054-defer-contentid-cleanup-old-versions.patch
@@ -1,12 +1,20 @@
 diff --git a/pulpcore/app/models/repository.py b/pulpcore/app/models/repository.py
-index a2350072e..2e9e4fcf0 100644
+index a2350072e..5435d19f1 100644
 --- a/pulpcore/app/models/repository.py
 +++ b/pulpcore/app/models/repository.py
-@@ -416,7 +416,9 @@ class Repository(MasterModel):
+@@ -414,9 +414,15 @@ class Repository(MasterModel):
+                 _("Attempt to cleanup old versions, while a new version is in flight.")
+             )
          if self.retain_repo_versions:
-             # Consider only completed versions that aren't protected for cleanup
-             versions = self.versions.complete().exclude(pk__in=self.protected_versions())
+-            # Consider only completed versions that aren't protected for cleanup
+-            versions = self.versions.complete().exclude(pk__in=self.protected_versions())
 -            for version in versions.order_by("-number")[self.retain_repo_versions :]:
++            # Consider only completed versions that aren't protected for cleanup.
++            # Evaluate protected PKs eagerly to avoid embedding the complex
++            # protected_versions() queryset as a NOT IN subquery, which causes
++            # PostgreSQL to pick expensive join plans.
++            protected_pks = set(self.protected_versions().values_list("pk", flat=True))
++            versions = self.versions.complete().exclude(pk__in=protected_pks)
 +            for version in versions.defer("content_ids").order_by("-number")[
 +                self.retain_repo_versions :
 +            ]:


### PR DESCRIPTION
The cleanup_old_versions method is probably generating a slow SQL query(~6 minutes) due to two issues:

1. The protected_versions() queryset was embedded as a NOT IN subquery with LEFT OUTER JOIN on core_publication and nested subqueries on core_distribution, causing PostgreSQL to pick an expensive join plan. Fixed by eagerly evaluating the protected PKs into a small set of literal UUIDs before passing to exclude().

2. The content_ids ArrayField (which can contain hundreds of thousands of UUIDs per version) was being fetched for every version, despite not being used by version.delete(). Fixed by using .defer("content_ids").

## Summary by Sourcery

Bug Fixes:
- Avoid slow SQL plans in cleanup_old_versions by materializing protected primary keys before exclusion and deferring large content_ids fields.