### PR TITLE
Patch protected_versions query by avoiding JOINs

### DIFF
--- a/images/assets/patches/0054-defer-contentid-cleanup-old-versions.patch
+++ b/images/assets/patches/0054-defer-contentid-cleanup-old-versions.patch
@@ -1,20 +1,66 @@
 diff --git a/pulpcore/app/models/repository.py b/pulpcore/app/models/repository.py
-index a2350072e..5435d19f1 100644
+index a2350072e..c07ba74ec 100644
 --- a/pulpcore/app/models/repository.py
 +++ b/pulpcore/app/models/repository.py
-@@ -414,9 +414,15 @@ class Repository(MasterModel):
-                 _("Attempt to cleanup old versions, while a new version is in flight.")
+@@ -323,20 +323,31 @@ class Repository(MasterModel):
+         """
+         from .publication import Distribution, Publication
+ 
++        protected_pks = set()
++
+         # find all repo versions set on a distribution
+-        qs = self.versions.filter(pk__in=Distribution.objects.values_list("repository_version_id"))
++        protected_pks.update(
++            Distribution.objects.filter(
++                repository_version__repository=self,
++            ).values_list("repository_version_id", flat=True)
++        )
+ 
+         # find all repo versions with publications set on a distribution
+-        qs |= self.versions.filter(
+-            publication__pk__in=Distribution.objects.values_list("publication_id")
++        dist_pub_ids = Distribution.objects.values_list("publication_id", flat=True)
++        protected_pks.update(
++            Publication.objects.filter(
++                pk__in=dist_pub_ids,
++                repository_version__repository=self,
++            ).values_list("repository_version_id", flat=True)
+         )
+ 
+         # Protect repo versions of distributed checkpoint publications.
+         if Distribution.objects.filter(repository=self.pk, checkpoint=True).exists():
+-            qs |= self.versions.filter(
+-                publication__pk__in=Publication.objects.filter(checkpoint=True).values_list(
+-                    "pulp_id"
+-                )
++            protected_pks.update(
++                Publication.objects.filter(
++                    checkpoint=True,
++                    repository_version__repository=self,
++                ).values_list("repository_version_id", flat=True)
              )
+ 
+         if distro := Distribution.objects.filter(repository=self.pk, checkpoint=False).first():
+@@ -352,9 +363,12 @@ class Repository(MasterModel):
+                 version = self.latest_version()
+ 
+             if version:
+-                qs |= self.versions.filter(pk=version.pk)
++                protected_pks.add(version.pk)
++
++        # Discard None values from distributions with no repository_version set
++        protected_pks.discard(None)
+ 
+-        return qs.distinct()
++        return self.versions.filter(pk__in=protected_pks)
+ 
+     def pull_through_add_content(self, content_artifact):
+         """
+@@ -416,7 +430,9 @@ class Repository(MasterModel):
          if self.retain_repo_versions:
--            # Consider only completed versions that aren't protected for cleanup
--            versions = self.versions.complete().exclude(pk__in=self.protected_versions())
+             # Consider only completed versions that aren't protected for cleanup
+             versions = self.versions.complete().exclude(pk__in=self.protected_versions())
 -            for version in versions.order_by("-number")[self.retain_repo_versions :]:
-+            # Consider only completed versions that aren't protected for cleanup.
-+            # Evaluate protected PKs eagerly to avoid embedding the complex
-+            # protected_versions() queryset as a NOT IN subquery, which causes
-+            # PostgreSQL to pick expensive join plans.
-+            protected_pks = set(self.protected_versions().values_list("pk", flat=True))
-+            versions = self.versions.complete().exclude(pk__in=protected_pks)
 +            for version in versions.defer("content_ids").order_by("-number")[
 +                self.retain_repo_versions :
 +            ]:


### PR DESCRIPTION
The protected_versions() method was building a single queryset using |= (OR) operations that caused Django to generate a LEFT OUTER JOIN on core_publication across all repository versions (10,000+ rows), resulting in ~6 minute queries.

Rewritten to collect protected version PKs from separate simple queries against Distribution and Publication tables, then return a simple filter(pk__in=...).

Also defer the content_ids ArrayField in cleanup_old_versions since it can contain hundreds of thousands of UUIDs per version and is not needed by version.delete().

Assisted By: claude-opus-4.6

## Summary by Sourcery

Optimize protected repository version selection and cleanup performance by simplifying queries and deferring heavy fields.

Bug Fixes:
- Avoid expensive JOIN-based queryset construction in protected_versions that caused multi-minute queries on large datasets.

Enhancements:
- Rework protected_versions to gather protected version IDs via simpler Distribution and Publication queries and filter by primary key.
- Defer loading of large content_ids arrays in cleanup_old_versions since they are unnecessary for deletion and can be very large.