### PR TITLE
fix: remove unpinned gunicorn from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -70,7 +70,6 @@ RUN pip install --upgrade pip setuptools wheel && \
     pip install  \
          rhsm \
          setproctitle \
-         gunicorn \
          python-nginx \
          django-storages\[boto3,azure]\>=1.12.2 \
          requests\[use_chardet_on_py3] \


### PR DESCRIPTION
## Summary

- Removes explicit `pip install gunicorn` from Dockerfile
- Lets pulpcore's dependency constraint (`gunicorn>=22.0,<25.1.0`) manage the version
- Fixes continuous "Control server error: Permission denied: '/.gunicorn'" errors on all API and content pods

## Problem

The unpinned `gunicorn` in the Dockerfile was pulling gunicorn 25.3.0, overriding pulpcore's upper bound. Gunicorn 25.1.0+ introduced a control socket feature that tries to create a Unix socket at `/.gunicorn`. Under `restricted-v2` SCC, `/` is read-only, generating ~23,000-97,000 error logs per day across stage and prod since Apr 10.

## Root Cause

- Commit `6b97d4d` (pulpcore v3.107.1 bump, Apr 10) triggered a Docker rebuild
- `pip install gunicorn` (no version pin) pulled 25.3.0, overriding pulpcore's `<25.1.0` constraint
- All 50 prod API pods + 6 stage API pods affected, evenly distributed

## Fix

Remove `gunicorn` from the Dockerfile's pip install. Pulpcore already declares `gunicorn>=22.0,<25.1.0` as a dependency, so gunicorn is still installed — just at a version that doesn't have the control socket feature.

## Test plan

- [ ] Build container image and verify gunicorn version is < 25.1.0
- [ ] Deploy to stage and confirm "Permission denied: '/.gunicorn'" errors stop
- [ ] Verify `--max-requests` worker recycling still works (check for "Worker exiting" / "Booting worker" logs)
- [ ] Deploy to prod and monitor CloudWatch + GlitchTip issue #4367061

Closes: PULP-1626

🤖 Generated with [Claude Code](https://claude.com/claude-code)