### PR TITLE
fix: pin gunicorn<25.1.0 to prevent control socket errors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -70,6 +70,7 @@ RUN pip install --upgrade pip setuptools wheel && \
     pip install  \
          rhsm \
          setproctitle \
+         "gunicorn>=22.0,<25.1.0" \
          python-nginx \
          django-storages\[boto3,azure]\>=1.12.2 \
          requests\[use_chardet_on_py3] \


### PR DESCRIPTION
## Summary

- Pins `gunicorn>=22.0,<25.1.0` in the Dockerfile to match pulpcore's dependency constraint
- Fixes the "Control server error: Permission denied: '/.gunicorn'" errors that persist after #1053

## Why #1053 wasn't enough

PR #1053 removed the unpinned `gunicorn` from the Dockerfile, expecting pulpcore's constraint (`gunicorn>=22.0,<25.1.0`) to manage the version. However, Docker layer caching preserved the previously installed gunicorn 25.3.0. When `pip install /tmp/pulp_service` ran (which installs pulpcore), pip saw gunicorn was already installed and didn't downgrade it.

Confirmed via CloudWatch logs: stage pods running image `pulp:a451275` (which includes #1053) still report `Starting gunicorn 25.3.0`.

## Fix

Explicitly pin `gunicorn>=22.0,<25.1.0` in the pip install step. This forces pip to install/downgrade to a version without the control socket feature, regardless of Docker layer cache state.

## Test plan

- [ ] Verify built image has gunicorn < 25.1.0 (`Starting gunicorn 2x.x.x` in logs)
- [ ] Deploy to stage and confirm "Permission denied: '/.gunicorn'" errors stop
- [ ] Deploy to prod and monitor CloudWatch + GlitchTip issue #4367061

Closes: PULP-1626

🤖 Generated with [Claude Code](https://claude.com/claude-code)