### PR TITLE
Add security profile for upgrade-deps agent

### DIFF
--- a/.alcove/security-profiles/pulp-service-contributor.yml
+++ b/.alcove/security-profiles/pulp-service-contributor.yml
@@ -1,0 +1,19 @@
+name: pulp-service-contributor
+display_name: Pulp Service Contributor
+description: Clone pulp/pulp-service, push branches, and create PRs
+tools:
+  github:
+    rules:
+      - repos: ["pulp/pulp-service"]
+        operations:
+          - clone
+          - read_prs
+          - read_issues
+          - read_contents
+          - read_commits
+          - read_branches
+          - read_git
+          - push_branch
+          - create_pr
+          - create_pr_draft
+          - create_comment

--- a/.alcove/tasks/upgrade-deps.yml
+++ b/.alcove/tasks/upgrade-deps.yml
@@ -27,3 +27,6 @@ repos:
   - url: https://github.com/pulp/pulp-service
     ref: main
     name: pulp-service
+
+profiles:
+  - pulp-service-contributor


### PR DESCRIPTION
## Summary

- Adds `.alcove/security-profiles/pulp-service-contributor.yml` — a security profile granting Gate SCM proxy access to `pulp/pulp-service` (clone, read, push branches, create PRs and comments)
- Updates `.alcove/tasks/upgrade-deps.yml` to reference the `pulp-service-contributor` profile via the `profiles:` field
- Without a security profile, the upgrade-deps agent cannot interact with GitHub through Gate to push branches or create PRs

## Test plan
- [ ] Resync the agent repo and verify the security profile appears in the team's profile list
- [ ] Trigger the upgrade-deps agent and confirm it can push a branch and create a PR on `pulp/pulp-service`

## Summary by Sourcery

Define a security profile for the upgrade-deps automation and wire it into the existing task so the agent can interact with the pulp-service repository via GitHub.

New Features:
- Introduce a pulp-service-contributor security profile granting scoped GitHub access to the pulp/pulp-service repository for automation.

Enhancements:
- Configure the upgrade-deps task to use the new pulp-service-contributor security profile.