### PR TITLE
Remove PR operations from security profile

### DIFF
--- a/.alcove/security-profiles/pulp-service-contributor.yml
+++ b/.alcove/security-profiles/pulp-service-contributor.yml
@@ -1,6 +1,6 @@
 name: pulp-service-contributor
 display_name: Pulp Service Contributor
-description: Clone pulp/pulp-service, push branches, and create PRs
+description: Clone pulp/pulp-service and push branches
 tools:
   github:
     rules:
@@ -14,6 +14,3 @@ tools:
           - read_branches
           - read_git
           - push_branch
-          - create_pr
-          - create_pr_draft
-          - create_comment


### PR DESCRIPTION
## Summary

- Removes `create_pr`, `create_pr_draft`, and `create_comment` from the `pulp-service-contributor` security profile
- Bridge steps handle PR creation/merging with their own credentials, so the agent only needs push access

## Test plan
- [ ] Resync and verify the profile no longer includes PR operations

## Summary by Sourcery

Enhancements:
- Remove pull request creation and commenting permissions from the pulp-service-contributor security profile and adjust its description accordingly.