### PR TITLE
Update upgrade pipeline: bridge creates PR, agent only pushes

### DIFF
--- a/.alcove/agents/upgrade-deps/AGENT.md
+++ b/.alcove/agents/upgrade-deps/AGENT.md
@@ -128,11 +128,11 @@ If tests fail:
    RUN patch -p1 -d /usr/local/lib/pulp/lib/python${PYTHON_VERSION}/site-packages < /tmp/{name}.patch
    ```
 
-## Phase 8: Create PR
+## Phase 8: Commit and Push
 
-1. Create a new branch from upstream/main:
+1. Create a new branch using the name from the Workflow Context (the `branch` input):
    ```
-   git checkout -b upgrade/{package}-{version}
+   git checkout -b $BRANCH
    ```
 
 2. Stage all changed files:
@@ -150,24 +150,17 @@ If tests fail:
    - Which patches were removed (upstreamed)
    - Which patches were regenerated
    - Any code fixes made
-   - Note that full Tekton CI should be verified
 
-4. Push and create PR:
+4. Push the branch:
    ```
-   git push -u origin {branch_name}
-   gh pr create --repo pulp/pulp-service --base main \
-     --title "Upgrade {package} to {version}" \
-     --body "{detailed description}"
+   git push -u origin $BRANCH
    ```
 
-5. If there are unresolved test failures or patch issues, create the PR as a draft:
-   ```
-   gh pr create --draft ...
-   ```
+Do NOT create a PR — the pipeline's bridge action handles PR creation automatically after this step completes.
 
 ## Error Handling
 
-- If ALL patches fail: create a draft PR listing every failure with analysis.
-- If migrations fail persistently: create a draft PR noting the migration issue.
-- If tests fail after 3 fix attempts: create the PR as draft noting failures and requesting human review.
-- Always create a PR (even as draft) so work is not lost.
+- If ALL patches fail: commit what you have with a detailed message explaining the failures.
+- If migrations fail persistently: commit with a note about the migration issue.
+- If tests fail after 3 fix attempts: commit noting failures and requesting human review.
+- Always commit and push so work is not lost. The pipeline will create a draft PR.

--- a/.alcove/tasks/reviewer.yml
+++ b/.alcove/tasks/reviewer.yml
@@ -1,0 +1,30 @@
+name: PR Reviewer
+description: |
+  Reviews pull requests for correctness and adherence to project conventions.
+  Used by the upgrade pipeline after CI passes.
+
+prompt: |
+  You are a code reviewer for the pulp-service project (pulp/pulp-service).
+
+  Review the PR in your context for correctness, bugs, and adherence to
+  project conventions. Focus on dependency version changes, patch file
+  modifications, and Dockerfile updates.
+
+  Post your review via the GitHub API. If requesting changes, be specific
+  about what needs to change and why.
+
+  Output: {"approved": true/false, "comments": "summary of review"}
+
+repos:
+  - url: https://github.com/pulp/pulp-service
+    ref: main
+    name: pulp-service
+
+timeout: 1800
+
+outputs:
+  - approved
+  - comments
+
+profiles:
+  - pulp-service-contributor

--- a/.alcove/tasks/upgrade-deps.yml
+++ b/.alcove/tasks/upgrade-deps.yml
@@ -14,6 +14,9 @@ prompt: |
   for your full instructions. Follow all 8 phases in order. If PACKAGES env var
   is set, use those target versions; otherwise auto-detect latest from PyPI.
 
+  Push your work to the branch specified in the Workflow Context.
+  Do NOT create a PR — the pipeline handles that automatically.
+
 timeout: 7200
 
 schedule:

--- a/.alcove/workflows/upgrade-deps-pipeline.yml
+++ b/.alcove/workflows/upgrade-deps-pipeline.yml
@@ -5,7 +5,7 @@ workflow:
     type: agent
     agent: Upgrade Pulp Dependencies
     inputs:
-      branch: "upgrade/deps-{{trigger.issue_number}}"
+      branch: "upgrade/deps-auto"
     outputs: [packages_upgraded, patches_modified, patches_removed, tests_passed]
 
   - id: create-pr
@@ -22,8 +22,26 @@ workflow:
   - id: await-ci
     type: bridge
     action: await-ci
-    depends: "create-pr.Succeeded"
+    depends: "create-pr.Succeeded || ci-fix.Succeeded"
     max_iterations: 4
     inputs:
       repo: pulp/pulp-service
       pr: "{{steps.create-pr.outputs.pr_number}}"
+
+  - id: ci-fix
+    type: agent
+    agent: Upgrade Pulp Dependencies
+    depends: "await-ci.Failed"
+    max_iterations: 3
+    inputs:
+      branch: "{{steps.upgrade-dependencies.inputs.branch}}"
+      ci_logs: "{{steps.await-ci.outputs.failure_logs}}"
+    outputs: [summary]
+
+  - id: code-review
+    type: agent
+    agent: PR Reviewer
+    depends: "await-ci.Succeeded"
+    inputs:
+      pr: "{{steps.create-pr.outputs.pr_number}}"
+    outputs: [approved, comments]

--- a/.alcove/workflows/upgrade-deps-pipeline.yml
+++ b/.alcove/workflows/upgrade-deps-pipeline.yml
@@ -4,4 +4,26 @@ workflow:
   - id: upgrade-dependencies
     type: agent
     agent: Upgrade Pulp Dependencies
-    outputs: [packages_upgraded, patches_modified, patches_removed, tests_passed, pr_url]
+    inputs:
+      branch: "upgrade/deps-{{trigger.issue_number}}"
+    outputs: [packages_upgraded, patches_modified, patches_removed, tests_passed]
+
+  - id: create-pr
+    type: bridge
+    action: create-pr
+    depends: "upgrade-dependencies.Succeeded"
+    inputs:
+      repo: pulp/pulp-service
+      branch: "{{steps.upgrade-dependencies.inputs.branch}}"
+      title: "Upgrade pulp dependencies"
+      base: main
+      draft: true
+
+  - id: await-ci
+    type: bridge
+    action: await-ci
+    depends: "create-pr.Succeeded"
+    max_iterations: 4
+    inputs:
+      repo: pulp/pulp-service
+      pr: "{{steps.create-pr.outputs.pr_number}}"


### PR DESCRIPTION
## Summary
- Add `create-pr` (draft) and `await-ci` bridge steps to the upgrade-deps workflow pipeline
- Update AGENT.md Phase 8: agent commits and pushes to branch only, no PR creation
- Update agent prompt to reference workflow context branch
- Pipeline orchestrates PR creation and CI monitoring; agent focuses on upgrade work

## Changes
- `.alcove/workflows/upgrade-deps-pipeline.yml` — 3-step pipeline: upgrade-dependencies → create-pr (draft) → await-ci
- `.alcove/tasks/upgrade-deps.yml` — prompt updated to mention branch from context
- `.alcove/agents/upgrade-deps/AGENT.md` — Phase 8 rewritten: commit+push only, no gh pr create

## Summary by Sourcery

Orchestrate dependency upgrade PR creation and CI monitoring via the workflow pipeline while limiting the agent to committing and pushing changes to a designated branch.

New Features:
- Add bridge steps to the upgrade-deps workflow to create a draft PR and wait for CI on the resulting pull request.

Enhancements:
- Update the upgrade-deps workflow to provide a deterministic branch name to the agent and remove PR URL output.
- Revise the upgrade-deps agent instructions so Phase 8 only commits and pushes to the workflow-specified branch and delegates PR creation to the pipeline.
- Clarify the upgrade-deps task prompt to instruct the agent to push to the workflow context branch and not create PRs manually.