### PR TITLE
Add pulp-service-reviewer security profile

### DIFF
--- a/.alcove/security-profiles/pulp-service-reviewer.yml
+++ b/.alcove/security-profiles/pulp-service-reviewer.yml
@@ -1,0 +1,16 @@
+name: pulp-service-reviewer
+display_name: Pulp Service Reviewer
+description: Read-only access to pulp/pulp-service with permission to post review comments
+tools:
+  github:
+    rules:
+      - repos: ["pulp/pulp-service"]
+        operations:
+          - clone
+          - read_prs
+          - read_issues
+          - read_contents
+          - read_commits
+          - read_branches
+          - read_git
+          - create_comment

--- a/.alcove/tasks/reviewer.yml
+++ b/.alcove/tasks/reviewer.yml
@@ -27,4 +27,4 @@ outputs:
   - comments
 
 profiles:
-  - pulp-service-contributor
+  - pulp-service-reviewer


### PR DESCRIPTION
Separate read-only + comment profile for the PR Reviewer agent.

## Summary by Sourcery

Introduce a dedicated read-only security profile for the PR reviewer task and assign it to the reviewer workflow.

New Features:
- Add a pulp-service-reviewer security profile granting read-only access to the pulp-service repository with permission to post review comments.

Enhancements:
- Update the reviewer task configuration to use the new pulp-service-reviewer profile instead of the contributor profile.