### PR TITLE
fix: prevent gunicorn worker recycling from corrupting histogram aggregation

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -61,7 +61,7 @@ objects:
         
           metrics/aggregation:
             receivers: [otlp]
-            processors: 
+            processors:
             - memory_limiter
             - filter/filter_pulp_api_request_duration
             - attributes/remove_worker_name
@@ -373,6 +373,8 @@ objects:
             value: ${{OTEL_PYTHON_EXCLUDED_URLS}}
           - name: PULP_OTEL_PULP_API_HISTOGRAM_BUCKETS
             value: ${PULP_OTEL_PULP_API_HISTOGRAM_BUCKETS}
+          - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+            value: "delta"
           - name: PULP_REDIS_PORT
             value: "6379"
           - name: SENTRY_DSN
@@ -543,6 +545,8 @@ objects:
             value: ${OTEL_METRIC_EXPORT_TIMEOUT}
           - name: OTEL_TRACES_EXPORTER
             value: "none"
+          - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+            value: "delta"
           - name: PULP_REDIS_PORT
             value: "6379"
           - name: SENTRY_DSN
@@ -658,6 +662,8 @@ objects:
             value: ${{OTEL_EXPORTER_OTLP_ENDPOINT}}
           - name: OTEL_TRACES_EXPORTER
             value: "none"
+          - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+            value: "delta"
           - name: PULP_OTEL_METRICS_DISPATCH_INTERVAL_MINUTES
             value: ${PULP_OTEL_METRICS_DISPATCH_INTERVAL_MINUTES}
           - name: PULP_REDIS_PORT


### PR DESCRIPTION
## Problem

Gunicorn worker recycling (`--max-requests`) resets in-memory counters to 0. The OTel pipeline strips `worker.name` and sums all workers into a single cumulative counter via `groupbyattrs`. When a worker recycles, the aggregate can decrease.

This causes a "hidden counter reset": if the recycled worker's final `le=+Inf` bucket value coincidentally equals the new worker's starting value (e.g. both are `1` because the new worker immediately handled a slow request before the first scrape), Prometheus does not detect the reset for `le=+Inf`. But `le=1000` resets visibly (new worker starts at 0, no fast requests yet). This inflates `rate(le=1000)` relative to `rate(le=+Inf)`, producing SLI latency ratios greater than 1.

## Fix

Set `OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE=delta` on pulp-api, pulp-content, and pulp-worker. With delta temporality, the SDK exports only the change since the last interval rather than a running total. When a worker recycles, its first export is a small non-negative delta — not a drop from a large cumulative value. The `groupbyattrs` aggregation then sums non-negative per-worker deltas, and the Prometheus exporter accumulates them into a monotonically increasing cumulative counter.

This approach requires no new OTel collector processors and preserves the existing cardinality reduction from `attributes/remove_worker_name` + `groupbyattrs/api_aggregation`.

## Verification

Tested in an ephemeral environment. The OTel collector starts cleanly and `pulp_api_request_duration_milliseconds_bucket` is exported without a `worker_name` label, confirming the aggregation pipeline is functioning correctly.

## Test plan

- [ ] Deploy to stage
- [ ] Confirm the SLI query returns ≤ 1 with a 1h window:
  ```promql
  sum(rate(pulp_api_request_duration_milliseconds_bucket{le="1000",exported_job="pulp-api",http_method=~"PUT|POST|PATCH",http_target!~".*/upload/.*"}[1h]))
  /
  sum(rate(pulp_api_request_duration_milliseconds_bucket{le="+Inf",exported_job="pulp-api",http_method=~"PUT|POST|PATCH",http_target!~".*/upload/.*"}[1h]))
  ```
- [ ] Confirm no per-series ratios return `+Inf`:
  ```promql
  rate(pulp_api_request_duration_milliseconds_bucket{le="1000",...}[1h])
  / ignoring(le)
  rate(pulp_api_request_duration_milliseconds_bucket{le="+Inf",...}[1h])
  ```
- [ ] Confirm raw counter sums remain monotonically increasing

🤖 Generated with [Claude Code](https://claude.com/claude-code)