### PR TITLE
Refactor dev container to run without root

### DIFF
--- a/dev-container/Dockerfile
+++ b/dev-container/Dockerfile
@@ -109,21 +109,23 @@ RUN openssl rand -base64 32 > /etc/pulp/certs/database_fields.symmetric.key && \
 
 # PostgreSQL: initialize as pulp user (not postgres) for rootless operation.
 # PostgreSQL only requires that the process user owns PGDATA.
+# The RPM creates /var/lib/pgsql owned by postgres — reassign everything to pulp.
 RUN mkdir -p /var/run/postgresql /var/lib/pgsql/16/data && \
-    chown -R pulp:pulp /var/run/postgresql /var/lib/pgsql/16
+    chown -R 700:700 /var/run/postgresql /var/lib/pgsql && \
+    chmod -R 700 /var/lib/pgsql/16/data
 
-USER pulp:pulp
+USER 700
 RUN /usr/pgsql-16/bin/initdb -D /var/lib/pgsql/16/data && \
     echo "local all all trust" > /var/lib/pgsql/16/data/pg_hba.conf && \
     echo "host all all 127.0.0.1/32 trust" >> /var/lib/pgsql/16/data/pg_hba.conf && \
     echo "host all all ::1/128 trust" >> /var/lib/pgsql/16/data/pg_hba.conf
-USER root:root
+USER root
 
 # Ensure all runtime directories are writable by pulp for rootless operation
-RUN chown -R pulp:pulp /var/run/postgresql /var/lib/pgsql /var/log/pulp \
-                       /var/lib/pulp /usr/local/lib/pulp /etc/pulp && \
+RUN chown -R 700:700 /var/run/postgresql /var/lib/pgsql /var/log/pulp \
+                     /var/lib/pulp /usr/local/lib/pulp /etc/pulp && \
     mkdir -p /var/run/supervisord && \
-    chown pulp:pulp /var/run/supervisord && \
+    chown 700:700 /var/run/supervisord && \
     chmod 777 /workspace
 
 COPY dev-container/settings.py /etc/pulp/settings.py

--- a/dev-container/Dockerfile
+++ b/dev-container/Dockerfile
@@ -107,19 +107,33 @@ RUN openssl rand -base64 32 > /etc/pulp/certs/database_fields.symmetric.key && \
     chown pulp:pulp /etc/pulp/certs/database_fields.symmetric.key && \
     chmod 600 /etc/pulp/certs/database_fields.symmetric.key
 
+# PostgreSQL: initialize as pulp user (not postgres) for rootless operation.
+# PostgreSQL only requires that the process user owns PGDATA.
 RUN mkdir -p /var/run/postgresql /var/lib/pgsql/16/data && \
-    chown -R postgres:postgres /var/run/postgresql /var/lib/pgsql/16
+    chown -R pulp:pulp /var/run/postgresql /var/lib/pgsql/16
 
-RUN runuser -l postgres -c "/usr/pgsql-16/bin/initdb -D /var/lib/pgsql/16/data" && \
+USER pulp:pulp
+RUN /usr/pgsql-16/bin/initdb -D /var/lib/pgsql/16/data && \
     echo "local all all trust" > /var/lib/pgsql/16/data/pg_hba.conf && \
     echo "host all all 127.0.0.1/32 trust" >> /var/lib/pgsql/16/data/pg_hba.conf && \
     echo "host all all ::1/128 trust" >> /var/lib/pgsql/16/data/pg_hba.conf
+USER root:root
+
+# Ensure all runtime directories are writable by pulp for rootless operation
+RUN chown -R pulp:pulp /var/run/postgresql /var/lib/pgsql /var/log/pulp \
+                       /var/lib/pulp /usr/local/lib/pulp /etc/pulp && \
+    mkdir -p /var/run/supervisord && \
+    chown pulp:pulp /var/run/supervisord && \
+    chmod 777 /workspace
 
 COPY dev-container/settings.py /etc/pulp/settings.py
 COPY dev-container/supervisord.conf /etc/supervisord.conf
 COPY dev-container/entrypoint.sh /entrypoint.sh
 COPY dev-container/scripts/ /usr/local/bin/
 RUN chmod +x /entrypoint.sh /usr/local/bin/pulp-*
+
+# Run as pulp user — no root required at runtime
+USER 700
 
 VOLUME ["/workspace"]
 EXPOSE 24817 24816

--- a/dev-container/entrypoint.sh
+++ b/dev-container/entrypoint.sh
@@ -4,22 +4,22 @@ set -e
 PG_BIN=/usr/pgsql-16/bin
 PG_DATA=/var/lib/pgsql/16/data
 
-echo "=== Pulp Dev Container Starting ==="
+echo "=== Pulp Dev Container Starting (rootless) ==="
 
-# Start PostgreSQL
+# Start PostgreSQL (runs as current user — no runuser needed)
 echo "Starting PostgreSQL..."
-runuser -l postgres -c "$PG_BIN/pg_ctl -D $PG_DATA start -l /var/lib/pgsql/pg.log -w"
+$PG_BIN/pg_ctl -D $PG_DATA start -l /var/lib/pgsql/pg.log -w
 
 # Wait for PostgreSQL
 until $PG_BIN/pg_isready -h localhost -q; do
     sleep 1
 done
 
-# Create pulp database and user (idempotent)
-runuser -l postgres -c "$PG_BIN/psql -tc \"SELECT 1 FROM pg_user WHERE usename = 'pulp'\" | grep -q 1 || $PG_BIN/psql -c \"CREATE USER pulp WITH SUPERUSER PASSWORD 'pulp'\""
-runuser -l postgres -c "$PG_BIN/psql -tc \"SELECT 1 FROM pg_database WHERE datname = 'pulp'\" | grep -q 1 || $PG_BIN/psql -c \"CREATE DATABASE pulp OWNER pulp\""
+# Create pulp database (idempotent — current user is the DB superuser)
+$PG_BIN/psql -d postgres -tc "SELECT 1 FROM pg_database WHERE datname = 'pulp'" | grep -q 1 || \
+    $PG_BIN/psql -d postgres -c "CREATE DATABASE pulp"
 
-# Start Redis
+# Start Redis (runs as current user)
 echo "Starting Redis..."
 redis-server --bind 127.0.0.1 --daemonize yes --protected-mode yes
 
@@ -29,16 +29,16 @@ if [ -d "/workspace/pulp-service/pulp_service" ]; then
     pip install -e /workspace/pulp-service/pulp_service --quiet 2>&1 || true
 fi
 
-# Run database migrations
+# Run database migrations (already running as pulp)
 echo "Running database migrations..."
-runuser -u pulp -- bash -c 'PATH=/usr/local/lib/pulp/bin:$PATH pulpcore-manager migrate --noinput'
+pulpcore-manager migrate --noinput
 
 # Set admin password
 echo "Setting admin password..."
-runuser -u pulp -- bash -c "PATH=/usr/local/lib/pulp/bin:\$PATH pulpcore-manager reset-admin-password --password '${PULP_DEFAULT_ADMIN_PASSWORD:-password}'" 2>/dev/null || true
+pulpcore-manager reset-admin-password --password "${PULP_DEFAULT_ADMIN_PASSWORD:-password}" 2>/dev/null || true
 
 # Stop PostgreSQL and Redis — supervisord will manage them
-runuser -l postgres -c "$PG_BIN/pg_ctl -D $PG_DATA stop -m fast -w"
+$PG_BIN/pg_ctl -D $PG_DATA stop -m fast -w
 redis-cli shutdown 2>/dev/null || true
 
 echo "=== Initialization complete. Starting services via supervisord ==="

--- a/dev-container/supervisord.conf
+++ b/dev-container/supervisord.conf
@@ -1,21 +1,19 @@
 [supervisord]
 nodaemon=true
-user=root
 logfile=/var/log/pulp/supervisord.log
-pidfile=/var/run/supervisord.pid
+pidfile=/var/run/supervisord/supervisord.pid
 
 [unix_http_server]
-file=/var/run/supervisor.sock
+file=/var/run/supervisord/supervisor.sock
 
 [rpcinterface:supervisor]
 supervisor.rpcinterface_factory=supervisor.rpcinterface:make_main_rpcinterface
 
 [supervisorctl]
-serverurl=unix:///var/run/supervisor.sock
+serverurl=unix:///var/run/supervisord/supervisor.sock
 
 [program:postgresql]
 command=/usr/pgsql-16/bin/postgres -D /var/lib/pgsql/16/data
-user=postgres
 autostart=true
 autorestart=true
 priority=100
@@ -32,7 +30,6 @@ stderr_logfile=/var/log/pulp/redis-stderr.log
 
 [program:pulp-api]
 command=/usr/bin/pulp-api
-user=pulp
 autostart=true
 autorestart=true
 priority=300
@@ -42,7 +39,6 @@ stderr_logfile=/var/log/pulp/pulp-api-stderr.log
 
 [program:pulp-content]
 command=/usr/bin/pulp-content
-user=pulp
 autostart=true
 autorestart=true
 priority=300
@@ -52,7 +48,6 @@ stderr_logfile=/var/log/pulp/pulp-content-stderr.log
 
 [program:pulp-worker]
 command=/usr/bin/pulp-worker
-user=pulp
 autostart=true
 autorestart=true
 priority=300


### PR DESCRIPTION
## Summary

Refactors the dev container (`ghcr.io/pulp/hosted-pulp-dev-env`) to run entirely as a non-root user, making it compatible with OpenShift's `restricted-v2` SCC and Kubernetes `runAsNonRoot: true` security contexts.

### Changes

**Dockerfile:**
- PostgreSQL initialized as `pulp` user (not `postgres`) — PostgreSQL only requires PGDATA ownership, not a specific OS user
- All runtime directories (`/var/run/postgresql`, `/var/lib/pgsql`, `/var/log/pulp`, `/usr/local/lib/pulp`, `/etc/pulp`) owned by `pulp` at build time
- Supervisord PID/socket moved to `/var/run/supervisord/` (owned by `pulp`)
- Final `USER 700` directive — container runs as non-root by default
- `/workspace` set to `chmod 777` for arbitrary UID compatibility

**entrypoint.sh:**
- Removed all `runuser` calls — PostgreSQL, migrations, and admin password all run directly as the current user
- Database creation uses `psql -d postgres` (current user is the DB superuser since they own PGDATA)

**supervisord.conf:**
- Removed `user=root` from `[supervisord]` section
- Removed `user=postgres` from `[program:postgresql]` — runs as current user
- Removed `user=pulp` from Pulp service programs — already running as pulp
- PID/socket paths moved to `/var/run/supervisord/`

### Why

Alcove dispatches dev containers as Kubernetes sidecars. On OpenShift (ROSA), the `restricted-v2` SCC enforces `runAsNonRoot: true` and assigns arbitrary UIDs from the namespace range. The previous dev container required root for `runuser` calls, causing it to crash with "runuser: may not be used by non-root users".

### Testing

Once the CI builds the image from this branch, verify with:
```bash
# Run as non-root (UID 700)
podman run --rm --user 700 ghcr.io/pulp/hosted-pulp-dev-env:rootless-dev-container

# Run with arbitrary UID (simulates OpenShift)
podman run --rm --user 1000830000 ghcr.io/pulp/hosted-pulp-dev-env:rootless-dev-container

# Verify the API responds
curl http://localhost:24817/pulp/api/v3/status/
```

## Summary by Sourcery

Refactor the dev container to run entirely as a non-root user while remaining compatible with PostgreSQL, Redis, and supervisord orchestration.

Enhancements:
- Run PostgreSQL, Redis, and Pulp services as the current non-root user instead of switching users at runtime.
- Initialize PostgreSQL data directories as the pulp user and ensure all runtime paths are owned or writable by pulp for rootless operation.
- Adjust supervisord configuration to remove explicit user directives and relocate PID/socket files into a pulp-writable runtime directory.
- Configure the container image to default to a non-root user ID and make the workspace directory compatible with arbitrary UIDs.