### PR TITLE
when we create tbr accounts, there's no org

### DIFF
--- a/pulp_service/pulp_service/app/authentication.py
+++ b/pulp_service/pulp_service/app/authentication.py
@@ -25,8 +25,10 @@ class RHServiceAccountCertAuthentication(JSONHeaderRemoteAuthentication):
 class RHTermsBasedRegistryAuthentication(JSONHeaderRemoteAuthentication):
 
     header = "HTTP_X_RH_IDENTITY"
-    # Combines org_id with username - returns null if either is missing
-    jq_filter = '.identity | if .org_id and .user.username then "\(.org_id)|\(.user.username)" else null end'
+    # Combines org_id with username - falls back to "|username" if org_id is missing
+    jq_filter = (
+        '.identity | if .user.username then "\(.org_id // "")|\(.user.username)" else null end'
+    )
 
     def authenticate_header(self, request):
         return "Bearer"


### PR DESCRIPTION
We need to allow authentication from TBR when there's no org_id
As the accounts created by us through their partners API don't get an org_id

## Summary by Sourcery

Bug Fixes:
- Handle RH identity payloads without org_id by constructing an authentication key that falls back to username-only.