### PR TITLE
Tbr automatic accounts

### DIFF
--- a/pulp_service/pulp_service/app/authentication.py
+++ b/pulp_service/pulp_service/app/authentication.py
@@ -25,8 +25,10 @@ class RHServiceAccountCertAuthentication(JSONHeaderRemoteAuthentication):
 class RHTermsBasedRegistryAuthentication(JSONHeaderRemoteAuthentication):
 
     header = "HTTP_X_RH_IDENTITY"
-    # Combines org_id with username - returns null if either is missing
-    jq_filter = '.identity | if .org_id and .user.username then "\(.org_id)|\(.user.username)" else null end'
+    # Combines org_id with username - falls back to "|username" if org_id is missing
+    jq_filter = (
+        '.identity | if .user.username then "\(.org_id // "")|\(.user.username)" else null end'
+    )
 
     def authenticate_header(self, request):
         return "Bearer"

--- a/pulp_service/pulp_service/app/authentication.py
+++ b/pulp_service/pulp_service/app/authentication.py
@@ -50,8 +50,8 @@ class TurnpikeTermsBasedRegistryAuthentication(JSONHeaderRemoteAuthentication):
 
     header = "HTTP_X_RH_IDENTITY"
     jq_filter = (
-        'if .identity.auth_type == "registry-auth" and .identity.registry.org_id and .identity.registry.username '
-        'then "\(.identity.registry.org_id)|\(.identity.registry.username)" '
+        'if .identity.auth_type == "registry-auth" and .identity.registry.username '
+        'then "\(.identity.registry.org_id // "")|\(.identity.registry.username)" '
         'else null end'
     )
 

--- a/pulp_service/pulp_service/tests/functional/test_authentication.py
+++ b/pulp_service/pulp_service/tests/functional/test_authentication.py
@@ -95,7 +95,7 @@ def test_authentication_with_only_username(
     gen_object_with_cleanup,
     cleanup_auth_headers,
 ):
-    """Test that requests with only username (no org_id) in x-rh-identity header return 401."""
+    """Test that requests with only username (no org_id) in x-rh-identity header still authenticate."""
     only_username = {"identity": {"user": {"username": "anotheruser"}}}
 
     with anonymous_user:
@@ -104,16 +104,18 @@ def test_authentication_with_only_username(
 
         pulpcore_bindings.DomainsApi.api_client.default_headers["x-rh-identity"] = auth_header
 
-        with pytest.raises(pulpcore_bindings.ApiException) as exp:
-            gen_object_with_cleanup(
-                pulpcore_bindings.DomainsApi,
-                {
-                    "name": str(uuid4()),
-                    "storage_class": "pulpcore.app.models.storage.FileSystem",
-                    "storage_settings": {"MEDIA_ROOT": "/var/lib/pulp/media/"},
-                },
-            )
-        assert exp.value.status == 401
+        domain_name = str(uuid4())
+        domain = gen_object_with_cleanup(
+            pulpcore_bindings.DomainsApi,
+            {
+                "name": domain_name,
+                "storage_class": "pulpcore.app.models.storage.FileSystem",
+                "storage_settings": {"MEDIA_ROOT": "/var/lib/pulp/media/"},
+            },
+        )
+
+        assert domain is not None
+        assert domain.name == domain_name
 
 
 def test_get_requests_without_auth_to_simple_api(


### PR DESCRIPTION
Updating alsot he turnpike authentication

## Summary by Sourcery

Allow registry authentication to succeed when x-rh-identity contains only a username without an org_id and update tests to cover the new behavior.

Enhancements:
- Relax identity parsing in registry authentication to accept identities without org_id by deriving credentials from username alone.

Tests:
- Update functional authentication test to expect successful domain creation when x-rh-identity includes only a username.