### PR TITLE
Enable direct outbound networking for Splunk agent

### DIFF
--- a/.alcove/agents/splunk-analyzer.yml
+++ b/.alcove/agents/splunk-analyzer.yml
@@ -11,6 +11,8 @@ executable:
 
 timeout: 1800
 
+direct_outbound: true
+
 credentials:
   SPLUNK_TOKEN: splunk
   JIRA_TOKEN: jira


### PR DESCRIPTION
The agent reaches Splunk and Jira APIs directly — needs `direct_outbound: true`.

## Summary by Sourcery

Enhancements:
- Allow the Splunk analyzer agent to make direct outbound connections to Splunk and Jira APIs.