### PR TITLE
Fix Splunk agent env vars and credential mapping

### DIFF
--- a/.alcove/agents/splunk-analyzer.yml
+++ b/.alcove/agents/splunk-analyzer.yml
@@ -8,6 +8,11 @@ executable:
   args: ["--model", "claude-opus-4-6"]
   env:
     SPLUNK_INSECURE_SKIP_VERIFY: "true"
+    SPLUNK_URL: "https://splunk-api.corp.redhat.com:8089/"
+    JIRA_URL: "https://redhat.atlassian.net/"
+    JIRA_USERNAME: "dkliban+pulp-sre-agent@redhat.com"
+    ANTHROPIC_VERTEX_PROJECT_ID: "itpc-gcp-core-pe-eng-claude"
+    CLOUD_ML_REGION: "us-east5"
 
 timeout: 1800
 
@@ -15,7 +20,7 @@ direct_outbound: true
 
 credentials:
   SPLUNK_TOKEN: splunk
-  JIRA_TOKEN: jira
+  JIRA_API_TOKEN: jira
   VERTEX_SA_JSON: google-vertex
 
 schedule:

--- a/.alcove/agents/splunk-analyzer.yml
+++ b/.alcove/agents/splunk-analyzer.yml
@@ -11,6 +11,8 @@ executable:
 
 timeout: 1800
 
+direct_outbound: true
+
 credentials:
   SPLUNK_TOKEN: splunk
   JIRA_TOKEN: jira


### PR DESCRIPTION
Add missing env vars and fix JIRA_TOKEN → JIRA_API_TOKEN credential key.

## Summary by Sourcery

Update Splunk analyzer agent configuration to include required environment variables and correct credential key names.

New Features:
- Configure additional environment variables for Splunk, JIRA, and Anthropic Vertex in the Splunk analyzer agent.

Bug Fixes:
- Fix the JIRA credential mapping by using the JIRA_API_TOKEN key instead of JIRA_TOKEN.

Enhancements:
- Enable direct outbound access for the Splunk analyzer agent.