### PR TITLE
Update Splunk agent to latest binary

### DIFF
--- a/.alcove/agents/splunk-analyzer.yml
+++ b/.alcove/agents/splunk-analyzer.yml
@@ -4,7 +4,7 @@ description: |
   Runs as a pre-compiled agent binary from GitHub Releases.
 
 executable:
-  url: https://github.com/pulp/pulp-service/releases/download/agent-splunk-20260414-e4c209e/agent-splunk
+  url: https://github.com/pulp/pulp-service/releases/download/agent-splunk-20260416-697d4e1/agent-splunk
   args: ["--model", "claude-opus-4-6"]
   env:
     SPLUNK_INSECURE_SKIP_VERIFY: "true"


### PR DESCRIPTION
Updates from agent-splunk-20260414-e4c209e to agent-splunk-20260416-697d4e1.

## Summary by Sourcery

Build:
- Bump Splunk analyzer agent binary URL to the newest agent-splunk release artifact.