### PR TITLE
Update workflow actions to unified bridge names

### DIFF
--- a/.alcove/workflows/sdlc-pipeline.yml
+++ b/.alcove/workflows/sdlc-pipeline.yml
@@ -26,7 +26,7 @@ workflow:
 
   - id: create-pr
     type: bridge
-    action: create-pr
+    action: create-merge-request
     depends: "implement.Succeeded"
     inputs:
       repo: pulp/pulp-service
@@ -38,7 +38,7 @@ workflow:
 
   - id: await-ci
     type: bridge
-    action: await-ci
+    action: await-checks
     depends: "create-pr.Succeeded || ci-fix.Succeeded"
     max_iterations: 4
     inputs:
@@ -86,7 +86,7 @@ workflow:
 
   - id: merge
     type: bridge
-    action: merge-pr
+    action: merge
     depends: "code-review.Succeeded"
     inputs:
       repo: pulp/pulp-service

--- a/.alcove/workflows/upgrade-deps-pipeline.yml
+++ b/.alcove/workflows/upgrade-deps-pipeline.yml
@@ -10,7 +10,7 @@ workflow:
 
   - id: create-pr
     type: bridge
-    action: create-pr
+    action: create-merge-request
     depends: "upgrade-dependencies.Succeeded"
     inputs:
       repo: pulp/pulp-service
@@ -21,7 +21,7 @@ workflow:
 
   - id: await-ci
     type: bridge
-    action: await-ci
+    action: await-checks
     depends: "create-pr.Succeeded || ci-fix.Succeeded"
     max_iterations: 4
     inputs:


### PR DESCRIPTION
## Summary
- Replaces deprecated bridge action aliases with unified names in workflow YAML files
- `create-pr` -> `create-merge-request`, `await-ci` -> `await-checks`, `merge-pr` -> `merge`
- Affects `sdlc-pipeline.yml` and `upgrade-deps-pipeline.yml`

## Test plan
- [ ] Verify workflows still trigger and execute correctly (old names are backward compatible aliases)
- [ ] Confirm only `action:` field values changed, no step IDs or depends expressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Update Alcove SDLC and dependency upgrade workflows to use the new unified bridge action names in place of deprecated aliases.

Enhancements:
- Align bridge action references in SDLC and upgrade-deps pipelines with the new create-merge-request, await-checks, and merge action names.

Build:
- Refresh workflow YAMLs to replace deprecated bridge action aliases with their unified counterparts.