### PR TITLE
Fix: don't pre-create PGDATA directory, let initdb create it at runtime

### DIFF
--- a/dev-container/Dockerfile
+++ b/dev-container/Dockerfile
@@ -107,19 +107,12 @@ RUN openssl rand -base64 32 > /etc/pulp/certs/database_fields.symmetric.key && \
     chown pulp:pulp /etc/pulp/certs/database_fields.symmetric.key && \
     chmod 600 /etc/pulp/certs/database_fields.symmetric.key
 
-# PostgreSQL: initialize as pulp user for rootless operation.
-# On OpenShift, containers run with arbitrary UIDs but always GID 0.
-# Make all directories group-writable (GID 0) for OpenShift compatibility.
-RUN mkdir -p /var/run/postgresql /var/lib/pgsql/16/data && \
+# PostgreSQL directories — initdb runs at startup (not build time) because
+# OpenShift assigns arbitrary UIDs and PostgreSQL requires PGDATA owned by
+# the process UID. GID 0 group-writable for OpenShift compatibility.
+RUN mkdir -p /var/run/postgresql /var/lib/pgsql/16 && \
     chown -R 700:0 /var/run/postgresql /var/lib/pgsql && \
     chmod -R g+rwX /var/run/postgresql /var/lib/pgsql
-
-USER 700
-RUN /usr/pgsql-16/bin/initdb -D /var/lib/pgsql/16/data && \
-    echo "local all all trust" > /var/lib/pgsql/16/data/pg_hba.conf && \
-    echo "host all all 127.0.0.1/32 trust" >> /var/lib/pgsql/16/data/pg_hba.conf && \
-    echo "host all all ::1/128 trust" >> /var/lib/pgsql/16/data/pg_hba.conf
-USER root
 
 # Ensure all runtime directories are writable by any UID in GID 0 (OpenShift convention)
 RUN chown -R 700:0 /var/run/postgresql /var/lib/pgsql /var/log/pulp \

--- a/dev-container/entrypoint.sh
+++ b/dev-container/entrypoint.sh
@@ -5,8 +5,21 @@ PG_BIN=/usr/pgsql-16/bin
 PG_DATA=/var/lib/pgsql/16/data
 
 echo "=== Pulp Dev Container Starting (rootless) ==="
+echo "Running as UID $(id -u), GID $(id -g)"
 
-# Start PostgreSQL (runs as current user — no runuser needed)
+# Initialize PostgreSQL if PGDATA is empty (first run).
+# This must happen at runtime, not build time, because OpenShift assigns
+# arbitrary UIDs and PostgreSQL requires PGDATA owned by the process UID.
+if [ ! -f "$PG_DATA/PG_VERSION" ]; then
+    echo "Initializing PostgreSQL (first run)..."
+    $PG_BIN/initdb -D $PG_DATA --auth=trust --no-locale
+    echo "local all all trust" > $PG_DATA/pg_hba.conf
+    echo "host all all 127.0.0.1/32 trust" >> $PG_DATA/pg_hba.conf
+    echo "host all all ::1/128 trust" >> $PG_DATA/pg_hba.conf
+    echo "PostgreSQL initialized."
+fi
+
+# Start PostgreSQL
 echo "Starting PostgreSQL..."
 $PG_BIN/pg_ctl -D $PG_DATA start -l /var/lib/pgsql/pg.log -w
 
@@ -15,11 +28,11 @@ until $PG_BIN/pg_isready -h localhost -q; do
     sleep 1
 done
 
-# Create pulp database (idempotent — current user is the DB superuser)
+# Create pulp database (idempotent)
 $PG_BIN/psql -d postgres -tc "SELECT 1 FROM pg_database WHERE datname = 'pulp'" | grep -q 1 || \
     $PG_BIN/psql -d postgres -c "CREATE DATABASE pulp"
 
-# Start Redis (runs as current user)
+# Start Redis
 echo "Starting Redis..."
 redis-server --bind 127.0.0.1 --daemonize yes --protected-mode yes
 
@@ -29,7 +42,7 @@ if [ -d "/workspace/pulp-service/pulp_service" ]; then
     pip install -e /workspace/pulp-service/pulp_service --quiet 2>&1 || true
 fi
 
-# Run database migrations (already running as pulp)
+# Run database migrations
 echo "Running database migrations..."
 pulpcore-manager migrate --noinput
 


### PR DESCRIPTION
initdb requires chmod 0700 on the data directory, which fails when the dir was pre-created at build time. Fix: only create the parent dir at build time, let initdb create data/ at runtime with correct ownership.

## Summary by Sourcery

Initialize PostgreSQL data directory at container startup instead of during image build to ensure correct ownership and permissions in OpenShift rootless environments.

Enhancements:
- Log container runtime UID/GID at startup for easier debugging.

Build:
- Stop running initdb at image build time and only create the PostgreSQL parent data directory with OpenShift-compatible permissions.