### PR TITLE
Fix: create pulp PostgreSQL role at startup

### DIFF
--- a/dev-container/Dockerfile
+++ b/dev-container/Dockerfile
@@ -107,11 +107,12 @@ RUN openssl rand -base64 32 > /etc/pulp/certs/database_fields.symmetric.key && \
     chown pulp:pulp /etc/pulp/certs/database_fields.symmetric.key && \
     chmod 600 /etc/pulp/certs/database_fields.symmetric.key
 
-ARG CACHE_BUST=2026-04-22
-# PostgreSQL directories — initdb runs at startup (not build time) because
-# OpenShift assigns arbitrary UIDs and PostgreSQL requires PGDATA owned by
-# the process UID. GID 0 group-writable for OpenShift compatibility.
-RUN mkdir -p /var/run/postgresql /var/lib/pgsql/16 && \
+# PostgreSQL: remove the data directory created by the RPM, so initdb can
+# create it at runtime with the correct UID ownership. On OpenShift, the
+# runtime UID is arbitrary (e.g., 1000830000) and initdb requires creating
+# PGDATA itself with 0700 permissions.
+RUN mkdir -p /var/run/postgresql && \
+    rm -rf /var/lib/pgsql/16/data && \
     chown -R 700:0 /var/run/postgresql /var/lib/pgsql && \
     chmod -R g+rwX /var/run/postgresql /var/lib/pgsql
 

--- a/dev-container/entrypoint.sh
+++ b/dev-container/entrypoint.sh
@@ -28,9 +28,11 @@ until $PG_BIN/pg_isready -h localhost -q; do
     sleep 1
 done
 
-# Create pulp database (idempotent)
+# Create pulp role and database (idempotent)
+$PG_BIN/psql -d postgres -tc "SELECT 1 FROM pg_roles WHERE rolname = 'pulp'" | grep -q 1 || \
+    $PG_BIN/psql -d postgres -c "CREATE ROLE pulp WITH LOGIN SUPERUSER"
 $PG_BIN/psql -d postgres -tc "SELECT 1 FROM pg_database WHERE datname = 'pulp'" | grep -q 1 || \
-    $PG_BIN/psql -d postgres -c "CREATE DATABASE pulp"
+    $PG_BIN/psql -d postgres -c "CREATE DATABASE pulp OWNER pulp"
 
 # Start Redis
 echo "Starting Redis..."


### PR DESCRIPTION
When running as an arbitrary UID (OpenShift), initdb creates the superuser as the numeric UID, not 'pulp'. The Django settings expect USER=pulp. Fix: create the pulp role in the entrypoint.

## Summary by Sourcery

Ensure the dev container initializes PostgreSQL correctly under arbitrary UIDs by adjusting data directory handling and explicitly creating the pulp role and database at startup.

Bug Fixes:
- Create the pulp PostgreSQL role at container startup so Django can authenticate using the expected 'pulp' user even when initdb uses a numeric UID.
- Remove the precreated PostgreSQL data directory so initdb can recreate it at runtime with correct ownership and permissions under OpenShift.