### PR TITLE
Fix Redis for rootless dev container

### DIFF
--- a/dev-container/entrypoint.sh
+++ b/dev-container/entrypoint.sh
@@ -34,9 +34,9 @@ $PG_BIN/psql -d postgres -tc "SELECT 1 FROM pg_roles WHERE rolname = 'pulp'" | g
 $PG_BIN/psql -d postgres -tc "SELECT 1 FROM pg_database WHERE datname = 'pulp'" | grep -q 1 || \
     $PG_BIN/psql -d postgres -c "CREATE DATABASE pulp OWNER pulp"
 
-# Start Redis
+# Start Redis (--save "" disables persistence, --dir /tmp for writable working dir)
 echo "Starting Redis..."
-redis-server --bind 127.0.0.1 --daemonize yes --protected-mode yes
+redis-server --bind 127.0.0.1 --daemonize yes --protected-mode yes --save "" --dir /tmp
 
 # If /workspace/pulp-service has source, install in dev mode
 if [ -d "/workspace/pulp-service/pulp_service" ]; then

--- a/dev-container/supervisord.conf
+++ b/dev-container/supervisord.conf
@@ -21,7 +21,7 @@ stdout_logfile=/var/log/pulp/postgresql-stdout.log
 stderr_logfile=/var/log/pulp/postgresql-stderr.log
 
 [program:redis]
-command=/usr/bin/redis-server --bind 127.0.0.1 --protected-mode yes
+command=/usr/bin/redis-server --bind 127.0.0.1 --protected-mode yes --save "" --dir /tmp
 autostart=true
 autorestart=true
 priority=200


### PR DESCRIPTION
Redis crashes because it tries to write dump.rdb to a non-writable directory. Fix: --save '' (disable persistence) and --dir /tmp (writable working dir).

## Summary by Sourcery

Adjust Redis startup configuration in the dev container to work in rootless environments by disabling persistence and using a writable working directory.

Bug Fixes:
- Prevent Redis from crashing in the dev container due to attempts to write dump files to a non-writable directory.

Enhancements:
- Align Redis startup options in both the entrypoint script and supervisord configuration to consistently disable persistence and use /tmp as the working directory.