### PR TITLE
Add alcove-shim to dev container for agent command execution

### DIFF
--- a/dev-container/Dockerfile
+++ b/dev-container/Dockerfile
@@ -1,3 +1,9 @@
+# Stage 0: Build the alcove-shim binary
+FROM docker.io/library/golang:1.25 AS shim-builder
+WORKDIR /src
+RUN git clone --depth=1 https://github.com/bmbouter/alcove.git . && \
+    CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o /out/alcove-shim ./cmd/shim
+
 FROM registry.access.redhat.com/ubi9/ubi
 
 ARG PYTHON_VERSION=3.11
@@ -130,7 +136,11 @@ COPY dev-container/settings.py /etc/pulp/settings.py
 COPY dev-container/supervisord.conf /etc/supervisord.conf
 COPY dev-container/entrypoint.sh /entrypoint.sh
 COPY dev-container/scripts/ /usr/local/bin/
-RUN chmod +x /entrypoint.sh /usr/local/bin/pulp-*
+
+# Install the alcove-shim binary for dev container communication
+COPY --from=shim-builder /out/alcove-shim /usr/local/bin/alcove-shim
+
+RUN chmod +x /entrypoint.sh /usr/local/bin/pulp-* /usr/local/bin/alcove-shim
 
 # Run as pulp user — no root required at runtime
 USER 700

--- a/dev-container/supervisord.conf
+++ b/dev-container/supervisord.conf
@@ -12,6 +12,14 @@ supervisor.rpcinterface_factory=supervisor.rpcinterface:make_main_rpcinterface
 [supervisorctl]
 serverurl=unix:///var/run/supervisord/supervisor.sock
 
+[program:alcove-shim]
+command=/usr/local/bin/alcove-shim
+autostart=true
+autorestart=true
+priority=50
+stdout_logfile=/var/log/pulp/alcove-shim-stdout.log
+stderr_logfile=/var/log/pulp/alcove-shim-stderr.log
+
 [program:postgresql]
 command=/usr/pgsql-16/bin/postgres -D /var/lib/pgsql/16/data
 autostart=true


### PR DESCRIPTION
## Summary

- Adds a multi-stage Go build that compiles the alcove-shim binary from [bmbouter/alcove](https://github.com/bmbouter/alcove) source
- Installs the binary at `/usr/local/bin/alcove-shim` in the dev container image
- Adds a supervisord `[program:alcove-shim]` section with priority 50 (starts before PostgreSQL/Redis/Pulp services)

## What is alcove-shim?

The shim provides two HTTP endpoints:
- `GET /healthz` — health check
- `POST /exec` — execute commands with NDJSON streaming output

These endpoints allow Skiff (the Alcove agent worker) to run build, test, and management commands (`pip install`, `pytest`, `pulpcore-manager`) inside the dev container remotely.

## Test plan

- [ ] Build the dev container image: `podman build -f dev-container/Dockerfile .`
- [ ] Verify the shim binary exists: `podman run --rm <image> ls -la /usr/local/bin/alcove-shim`
- [ ] Verify supervisord starts the shim: `podman run --rm <image> supervisorctl status alcove-shim`
- [ ] Verify healthz responds: `curl http://localhost:9090/healthz` (from within the container)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add the alcove-shim service to the dev container image to enable remote command execution via HTTP.

New Features:
- Build the alcove-shim Go binary in a multi-stage Docker build and include it in the dev container image.
- Run alcove-shim under supervisord in the dev container to provide HTTP health and command execution endpoints for remote agents.

Enhancements:
- Extend dev container startup configuration so alcove-shim is managed alongside existing services with appropriate startup priority.