### PR TITLE
Add VERTEX_SA_JSON support in agent-splunk

### DIFF
--- a/tools/agents/agent-splunk/anthropic-client/client.go
+++ b/tools/agents/agent-splunk/anthropic-client/client.go
@@ -2,6 +2,7 @@ package anthropicClient
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -16,9 +17,10 @@ import (
 // It intercepts HTTP requests meant for the Anthropic API and rewrites
 // them to target the Vertex AI endpoint, using gcloud credentials for auth.
 type VertexClient struct {
-	ProjectID string
-	Region    string
-	Model     string
+	ProjectID    string
+	Region       string
+	Model        string
+	SACredential []byte // Raw service account JSON; if set, used instead of ADC.
 
 	once    sync.Once
 	creds   *google.Credentials
@@ -33,12 +35,17 @@ const (
 func (v *VertexClient) Do(req *http.Request) (*http.Response, error) {
 	ctx := req.Context()
 
-	// run the function to get gcloud credentials only once and store/cache the credentials in
-	// VertexClient struct (creds)
 	v.once.Do(func() {
-		creds, err := google.FindDefaultCredentials(ctx, GOOGLE_API_AUTH_URL)
+		initCtx := context.Background()
+		var creds *google.Credentials
+		var err error
+		if len(v.SACredential) > 0 {
+			creds, err = google.CredentialsFromJSON(initCtx, v.SACredential, GOOGLE_API_AUTH_URL)
+		} else {
+			creds, err = google.FindDefaultCredentials(initCtx, GOOGLE_API_AUTH_URL)
+		}
 		if err != nil {
-			v.initErr = fmt.Errorf("find default credentials: %w", err)
+			v.initErr = fmt.Errorf("obtain credentials: %w", err)
 			return
 		}
 		v.creds = creds

--- a/tools/agents/agent-splunk/main.go
+++ b/tools/agents/agent-splunk/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"flag"
 	"fmt"
 	"log"
@@ -30,9 +31,27 @@ func run() error {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
+	var saCredential []byte
+	if saJSON := os.Getenv("VERTEX_SA_JSON"); saJSON != "" {
+		saCredential = []byte(saJSON)
+		fmt.Fprintf(os.Stderr, "[auth] using VERTEX_SA_JSON for Vertex AI authentication\n")
+	}
+
 	projectID := os.Getenv("ANTHROPIC_VERTEX_PROJECT_ID")
+	if projectID == "" && len(saCredential) > 0 {
+		var sa struct {
+			ProjectID string `json:"project_id"`
+		}
+		if err := json.Unmarshal(saCredential, &sa); err != nil {
+			return fmt.Errorf("VERTEX_SA_JSON is not valid JSON: %w", err)
+		}
+		if sa.ProjectID == "" {
+			return fmt.Errorf("VERTEX_SA_JSON does not contain a project_id field")
+		}
+		projectID = sa.ProjectID
+	}
 	if projectID == "" {
-		return fmt.Errorf("ANTHROPIC_VERTEX_PROJECT_ID environment variable is required")
+		return fmt.Errorf("ANTHROPIC_VERTEX_PROJECT_ID environment variable is required (or set VERTEX_SA_JSON with a service account that contains project_id)")
 	}
 
 	region := os.Getenv("CLOUD_ML_REGION")
@@ -97,9 +116,10 @@ func run() error {
 	switch *inputModel {
 	case "claude-opus-4-6":
 		model = models.Claude{
-			Model:     *inputModel,
-			ProjectID: projectID,
-			Region:    region,
+			Model:        *inputModel,
+			ProjectID:    projectID,
+			Region:       region,
+			SACredential: saCredential,
 		}
 	case "gemini-2.5-pro":
 		model = models.Gemini{

--- a/tools/agents/agent-splunk/models/anthropic.go
+++ b/tools/agents/agent-splunk/models/anthropic.go
@@ -10,9 +10,10 @@ import (
 )
 
 type Claude struct {
-	Model     string
-	ProjectID string
-	Region    string
+	Model        string
+	ProjectID    string
+	Region       string
+	SACredential []byte
 }
 
 func (claude Claude) ModelRun(ctx context.Context, cfg RunConfig) (string, error) {
@@ -22,9 +23,10 @@ func (claude Claude) ModelRun(ctx context.Context, cfg RunConfig) (string, error
 		anthropic.WithModel(claude.Model),
 		anthropic.WithToken("vertex-ai"),
 		anthropic.WithHTTPClient(&anthropicClient.VertexClient{
-			ProjectID: claude.ProjectID,
-			Region:    claude.Region,
-			Model:     claude.Model,
+			ProjectID:    claude.ProjectID,
+			Region:       claude.Region,
+			Model:        claude.Model,
+			SACredential: claude.SACredential,
 		}),
 	)
 	if err != nil {


### PR DESCRIPTION
Allow agent-splunk to authenticate using a service account JSON string passed via the VERTEX_SA_JSON environment variable, enabling Alcove's credential injection to provide Vertex AI credentials directly instead of relying on Application Default Credentials (ADC).

When VERTEX_SA_JSON is set, the project_id is extracted from the JSON automatically, making ANTHROPIC_VERTEX_PROJECT_ID optional. ADC remains the fallback when no service account JSON is provided.

Assisted By: claude-opus-4.6

## Summary by Sourcery

Add support for authenticating agent-splunk's Vertex AI (Anthropic via Vertex) calls using a service account JSON string provided via environment variable instead of only Application Default Credentials.

New Features:
- Allow configuring Vertex AI authentication via the VERTEX_SA_JSON environment variable containing service account JSON.
- Automatically derive the Vertex project ID from the provided service account JSON when ANTHROPIC_VERTEX_PROJECT_ID is not set.

Enhancements:
- Propagate optional service account credentials through the Claude model configuration into the Vertex HTTP client, which now chooses between service account credentials and ADC at runtime.

Documentation:
- Clarify the error message to document that either ANTHROPIC_VERTEX_PROJECT_ID or a VERTEX_SA_JSON with project_id must be provided.