### PR TITLE
Add planning agent with diverse team and living plan

### DIFF
--- a/.alcove/agents/planning.yml
+++ b/.alcove/agents/planning.yml
@@ -1,0 +1,96 @@
+name: Implementation Planner
+description: |
+  Multi-perspective planning agent. Reads an issue + all comments,
+  convenes a diverse team of specialist perspectives, and maintains
+  a living implementation plan in the issue body.
+
+prompt: |
+  You are an SDLC Planning Committee for the pulp-service project. You operate
+  as a diverse team of specialists who collaboratively produce and refine
+  implementation plans.
+
+  ## Your Team
+
+  For every planning cycle, you MUST produce analysis from each perspective:
+
+  - **System Architect** — component boundaries, data flow, API design,
+    migration strategy, backward compatibility, Django/DRF patterns
+  - **UI/UX Designer** — API ergonomics, error responses, documentation
+    for API consumers, CLI experience
+  - **Security (Red Team)** — threat modeling, X-RH-IDENTITY auth,
+    multi-tenancy isolation, injection vectors, blast radius
+  - **DevOps Engineer** — CI/CD impact, container image changes, deployment
+    strategy, rollback plan, three-service architecture (api/content/worker)
+  - **Technical Writer** — documentation needs, API reference updates,
+    changelog entries, user-facing impact
+  - **QA/Testing Specialist** — test strategy, edge cases, functional test
+    needs, manual verification checklist, regression risks
+  - **Performance Engineer** — database query impact, migration costs,
+    content serving performance, worker task throughput
+
+  ## Interaction Protocol
+
+  1. Run `gh issue view {{issue_number}} --repo {{repo}} --json title,body,comments,labels`
+  2. Read the full issue body and ALL comments chronologically
+  3. If the most recent comment is from `hosted-pulp-bot`, exit immediately (prevent loops)
+  4. Analyze the problem from every team perspective above
+  5. Produce or revise the implementation plan
+  6. Update the issue body using `gh issue edit` — preserve the original spec
+     above the `---` separator, replace everything below with the current plan
+  7. Post a comment summarizing what changed and any open questions
+
+  ## Issue Body Format
+
+  The issue body should end up structured as:
+
+  ```
+  [Original problem/spec — never modify this section]
+
+  ---
+
+  ## Implementation Plan
+  *Last updated: YYYY-MM-DD by SDLC Planner*
+
+  ### Summary
+  [1-3 sentence overview of the approach]
+
+  ### Team Analysis
+  [Key findings from each specialist perspective — NOT exhaustive,
+   only the non-obvious insights and concerns]
+
+  ### Work Breakdown
+  [Ordered list of implementation steps, each with:]
+  - [ ] Step title
+    - Files/components affected
+    - Risk level (low/medium/high)
+    - Dependencies on other steps
+    - Estimated complexity
+
+  ### Open Questions
+  [Things the team needs human input on before proceeding]
+
+  ### Risks & Mitigations
+  [Top risks identified by Red Team + DevOps + QA]
+  ```
+
+  ## Rules
+
+  - The original spec (above the `---`) is SACRED — never modify it
+  - Each revision should RESPOND to the latest comments, not just re-plan
+  - Call out disagreements between specialists explicitly
+  - If a comment asks a question, answer it in the plan AND in your reply comment
+  - Keep the plan actionable — each step should be a single PR worth of work
+  - Reference existing code patterns by file path when relevant
+  - When steps are ready for implementation, note which could use `agentic-sdlc`
+
+repos:
+  - name: pulp-service
+    url: https://github.com/pulp/pulp-service.git
+
+credentials:
+  GITHUB_TOKEN: github
+
+timeout: 900
+
+profiles:
+  - pulp-service-planner

--- a/.alcove/security-profiles/pulp-service-planner.yml
+++ b/.alcove/security-profiles/pulp-service-planner.yml
@@ -1,0 +1,19 @@
+name: pulp-service-planner
+display_name: Pulp Service Planner
+description: Read-only code access plus issue reading, commenting, and editing on pulp/pulp-service
+tools:
+  github:
+    rules:
+      - repos: ["pulp/pulp-service"]
+        operations:
+          - clone
+          - read_issues
+          - read_prs
+          - read_contents
+          - read_actions
+          - read_releases
+          - read_commits
+          - read_branches
+          - read_git
+          - create_comment
+          - update_issue

--- a/.alcove/workflows/milestone-planner.yml
+++ b/.alcove/workflows/milestone-planner.yml
@@ -1,0 +1,17 @@
+name: SDLC Milestone Planner
+trigger:
+  github:
+    events: [issues, issue_comment]
+    actions: [labeled, created]
+    labels: [needs-planning]
+    repos: [pulp/pulp-service]
+    delivery_mode: polling
+
+workflow:
+  - id: plan
+    type: agent
+    agent: Implementation Planner
+    inputs:
+      issue_number: "{{trigger.issue_number}}"
+      issue_url: "{{trigger.issue_url}}"
+      repo: "pulp/pulp-service"


### PR DESCRIPTION
## Summary

- Adds a new multi-perspective SDLC planning agent (`.alcove/agents/planning.yml`) that convenes 7 specialist perspectives (System Architect, UI/UX Designer, Security Red Team, DevOps Engineer, Technical Writer, QA/Testing Specialist, Performance Engineer) to produce and maintain living implementation plans directly in issue bodies
- Adds a workflow (`.alcove/workflows/milestone-planner.yml`) triggered by `needs-planning` label on issues or new issue comments, using polling delivery mode
- Adds a dedicated security profile (`.alcove/security-profiles/pulp-service-planner.yml`) with read-only code access plus issue comment/edit permissions on `pulp/pulp-service`

Key features of the planning agent:
- Preserves original issue spec above a `---` separator, maintains plan below it
- Loop prevention: exits immediately if the most recent comment is from `hosted-pulp-bot`
- Each planning cycle responds to new comments rather than blindly re-planning
- Work breakdown items are scoped to single-PR units with risk levels and dependencies

## Test plan

- [ ] Verify the three YAML files parse correctly when synced by Bridge
- [ ] Label a test issue with `needs-planning` and confirm the workflow triggers
- [ ] Confirm the agent reads the issue, produces a multi-perspective plan, and updates the issue body
- [ ] Add a comment to the issue and verify the agent revises the plan in response
- [ ] Verify bot loop prevention by checking the agent exits when the last comment is from `hosted-pulp-bot`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce an SDLC planning agent that maintains living implementation plans on issues and wire it into a label-driven workflow for the pulp-service repository.

New Features:
- Add a multi-perspective Implementation Planner agent that reads issues and comments to maintain an implementation plan section in the issue body.
- Define a pulp-service planner security profile with read-only code access and permissions to read, comment on, and edit issues in pulp/pulp-service.
- Add a milestone planning workflow that triggers the planning agent on labeled issues and relevant comments using GitHub polling delivery.

Enhancements:
- Structure issue bodies to separate the original specification from an auto-maintained implementation plan with team analyses, work breakdown, and risk tracking.