### PR TITLE
Support Gate proxy authentication via ANTHROPIC_API_KEY and ANTHROPIC…

### DIFF
--- a/tools/agents/agent-splunk/main.go
+++ b/tools/agents/agent-splunk/main.go
@@ -31,12 +31,19 @@ func run() error {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
+	// Auth mode 1: Proxy (ANTHROPIC_API_KEY + ANTHROPIC_BASE_URL).
+	// Gate handles real credentials; the agent sends requests to the proxy.
+	apiKey := os.Getenv("ANTHROPIC_API_KEY")
+	baseURL := os.Getenv("ANTHROPIC_BASE_URL")
+
+	// Auth mode 2: Service account JSON for direct Vertex AI access.
 	var saCredential []byte
 	if saJSON := os.Getenv("VERTEX_SA_JSON"); saJSON != "" {
 		saCredential = []byte(saJSON)
 		fmt.Fprintf(os.Stderr, "[auth] using VERTEX_SA_JSON for Vertex AI authentication\n")
 	}
 
+	// Resolve project ID (required for Vertex AI modes, not for proxy mode).
 	projectID := os.Getenv("ANTHROPIC_VERTEX_PROJECT_ID")
 	if projectID == "" && len(saCredential) > 0 {
 		var sa struct {
@@ -50,8 +57,13 @@ func run() error {
 		}
 		projectID = sa.ProjectID
 	}
-	if projectID == "" {
-		return fmt.Errorf("ANTHROPIC_VERTEX_PROJECT_ID environment variable is required (or set VERTEX_SA_JSON with a service account that contains project_id)")
+
+	if apiKey == "" && projectID == "" {
+		return fmt.Errorf("set ANTHROPIC_API_KEY (proxy mode) or ANTHROPIC_VERTEX_PROJECT_ID / VERTEX_SA_JSON (Vertex AI mode)")
+	}
+
+	if apiKey != "" {
+		fmt.Fprintf(os.Stderr, "[auth] using proxy mode (ANTHROPIC_BASE_URL=%s)\n", baseURL)
 	}
 
 	region := os.Getenv("CLOUD_ML_REGION")
@@ -59,7 +71,12 @@ func run() error {
 		region = "us-east5"
 	}
 
-	inputModel := flag.String("model", "claude-opus-4-6", "Define the model (claude-opus-4-6,gemini-2.5-pro). Default: claude-opus-4-6")
+	defaultModel := "claude-opus-4-6"
+	if envModel := os.Getenv("CLAUDE_MODEL"); envModel != "" {
+		defaultModel = envModel
+	}
+
+	inputModel := flag.String("model", defaultModel, fmt.Sprintf("Define the model (claude-opus-4-6,gemini-2.5-pro). Default: %s", defaultModel))
 	inputQuestion := flag.String("question", "", "Question to ask the model")
 	flag.Parse()
 
@@ -120,6 +137,8 @@ func run() error {
 			ProjectID:    projectID,
 			Region:       region,
 			SACredential: saCredential,
+			APIKey:       apiKey,
+			BaseURL:      baseURL,
 		}
 	case "gemini-2.5-pro":
 		model = models.Gemini{

--- a/tools/agents/agent-splunk/models/anthropic.go
+++ b/tools/agents/agent-splunk/models/anthropic.go
@@ -14,21 +14,32 @@ type Claude struct {
 	ProjectID    string
 	Region       string
 	SACredential []byte
+	APIKey       string
+	BaseURL      string
 }
 
 func (claude Claude) ModelRun(ctx context.Context, cfg RunConfig) (string, error) {
+	var opts []anthropic.Option
+	opts = append(opts, anthropic.WithModel(claude.Model))
 
-	// Claude via Vertex AI.
-	llm, err := anthropic.New(
-		anthropic.WithModel(claude.Model),
-		anthropic.WithToken("vertex-ai"),
-		anthropic.WithHTTPClient(&anthropicClient.VertexClient{
-			ProjectID:    claude.ProjectID,
-			Region:       claude.Region,
-			Model:        claude.Model,
-			SACredential: claude.SACredential,
-		}),
-	)
+	if claude.APIKey != "" {
+		opts = append(opts, anthropic.WithToken(claude.APIKey))
+		if claude.BaseURL != "" {
+			opts = append(opts, anthropic.WithBaseURL(claude.BaseURL))
+		}
+	} else {
+		opts = append(opts,
+			anthropic.WithToken("vertex-ai"),
+			anthropic.WithHTTPClient(&anthropicClient.VertexClient{
+				ProjectID:    claude.ProjectID,
+				Region:       claude.Region,
+				Model:        claude.Model,
+				SACredential: claude.SACredential,
+			}),
+		)
+	}
+
+	llm, err := anthropic.New(opts...)
 	if err != nil {
 		return "", fmt.Errorf("init anthropic client: %w", err)
 	}


### PR DESCRIPTION
…_BASE_URL

When running inside Alcove, Gate proxies all LLM traffic and injects real credentials. This change lets agent-splunk use that flow by reading ANTHROPIC_API_KEY and ANTHROPIC_BASE_URL to send requests through Gate instead of authenticating directly to Vertex AI.

Also adds CLAUDE_MODEL env var to control the default model, and VERTEX_SA_JSON for direct Vertex AI auth via service account JSON.

Three auth modes are now supported:
- Proxy: ANTHROPIC_API_KEY + ANTHROPIC_BASE_URL (Alcove/Gate)
- Service account: VERTEX_SA_JSON (direct Vertex AI)
- ADC: ANTHROPIC_VERTEX_PROJECT_ID (original behavior)

Assisted By: claude-opus-4.6

## Summary by Sourcery

Add support for proxy-based Anthropic authentication in agent-splunk alongside existing Vertex AI modes and make the default Claude model configurable via environment variables.

New Features:
- Support proxy-based Anthropic authentication via ANTHROPIC_API_KEY and ANTHROPIC_BASE_URL in agent-splunk.
- Allow configuring the default Claude model through the CLAUDE_MODEL environment variable.

Enhancements:
- Extend Claude model configuration to choose between proxy and Vertex AI-backed clients at runtime based on environment variables.
- Relax mandatory Vertex AI project ID requirements when running in proxy mode and improve startup auth-mode logging.