### PR TITLE
Update Splunk agent to latest release, remove Vertex credentials

### DIFF
--- a/.alcove/agents/splunk-analyzer.yml
+++ b/.alcove/agents/splunk-analyzer.yml
@@ -4,15 +4,13 @@ description: |
   Runs as a pre-compiled agent binary from GitHub Releases.
 
 executable:
-  url: https://github.com/pulp/pulp-service/releases/download/agent-splunk-20260423-1cfe8d9/agent-splunk
+  url: https://github.com/pulp/pulp-service/releases/download/agent-splunk-20260423-ffffb0b/agent-splunk
   args: ["--model", "claude-opus-4-6"]
   env:
     SPLUNK_INSECURE_SKIP_VERIFY: "true"
     SPLUNK_URL: "https://splunk-api.corp.redhat.com:8089/"
     JIRA_URL: "https://redhat.atlassian.net/"
     JIRA_USERNAME: "dkliban+pulp-sre-agent@redhat.com"
-    ANTHROPIC_VERTEX_PROJECT_ID: "itpc-gcp-core-pe-eng-claude"
-    CLOUD_ML_REGION: "us-east5"
 
 timeout: 1800
 
@@ -21,7 +19,6 @@ direct_outbound: true
 credentials:
   SPLUNK_TOKEN: splunk
   JIRA_API_TOKEN: jira
-  VERTEX_SA_JSON: google-vertex
 
 schedule:
   cron: "0 * * * *"


### PR DESCRIPTION
## Summary
- Bump Splunk agent binary to `agent-splunk-20260423-ffffb0b` (latest release)
- Remove `VERTEX_SA_JSON` credential — agent gets LLM credentials through normal env vars
- Remove `ANTHROPIC_VERTEX_PROJECT_ID` and `CLOUD_ML_REGION` env vars (no longer needed)

## Test plan
- [ ] Sync agent definitions on hcmai after merge
- [ ] Trigger Splunk analyzer and verify it starts successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Update the Splunk analyzer agent configuration to use the latest agent binary and remove obsolete Vertex-related credentials and environment variables.

Enhancements:
- Point the Splunk analyzer agent to the latest released Splunk agent binary.
- Simplify the Splunk analyzer configuration by removing no-longer-needed Anthropic Vertex environment variables and credentials.