### PR TITLE
Bump Splunk agent to agent-splunk-20260423-b5d37e0

### DIFF
--- a/.alcove/agents/splunk-analyzer.yml
+++ b/.alcove/agents/splunk-analyzer.yml
@@ -4,7 +4,7 @@ description: |
   Runs as a pre-compiled agent binary from GitHub Releases.
 
 executable:
-  url: https://github.com/pulp/pulp-service/releases/download/agent-splunk-20260423-ffffb0b/agent-splunk
+  url: https://github.com/pulp/pulp-service/releases/download/agent-splunk-20260423-b5d37e0/agent-splunk
   args: ["--model", "claude-opus-4-6"]
   env:
     SPLUNK_INSECURE_SKIP_VERIFY: "true"


### PR DESCRIPTION
Update to latest release.

## Summary by Sourcery

Enhancements:
- Point the Splunk analyzer agent executable URL at the new agent-splunk-20260423-b5d37e0 GitHub release artifact.