### PR TITLE
Add GitHub credentials to agents

### DIFF
--- a/.alcove/agents/reviewer.yml
+++ b/.alcove/agents/reviewer.yml
@@ -21,6 +21,8 @@ repos:
     name: pulp-service
 
 timeout: 1800
+credentials:
+  GITHUB_TOKEN: github
 enforcement_mode: monitor
 
 outputs:

--- a/.alcove/agents/sdlc-developer.yml
+++ b/.alcove/agents/sdlc-developer.yml
@@ -32,6 +32,8 @@ prompt: |
   Output: {"summary": "what you implemented"}
 
 timeout: 3600
+credentials:
+  GITHUB_TOKEN: github
 enforcement_mode: monitor
 
 dev_container:

--- a/.alcove/agents/upgrade-deps.yml
+++ b/.alcove/agents/upgrade-deps.yml
@@ -18,6 +18,8 @@ prompt: |
   Do NOT create a PR — the pipeline handles that automatically.
 
 timeout: 7200
+credentials:
+  GITHUB_TOKEN: github
 enforcement_mode: monitor
 
 schedule:


### PR DESCRIPTION
Agents need credentials for gh CLI.

## Summary by Sourcery

New Features:
- Configure a GITHUB_TOKEN credential for the reviewer, sdlc-developer, and upgrade-deps agents to enable authenticated GitHub CLI usage.