### PR TITLE
Remove stale profile from planning agent

### DIFF
--- a/.alcove/agents/planning.yml
+++ b/.alcove/agents/planning.yml
@@ -92,6 +92,3 @@ credentials:
 
 timeout: 900
 enforcement_mode: monitor
-
-profiles:
-  - pulp-service-planner


### PR DESCRIPTION
Profile was deleted.

## Summary by Sourcery

Enhancements:
- Clean up planning agent configuration by removing an obsolete profile entry.