### PR TITLE
Remove leaked GitHub credentials from agents

### DIFF
--- a/.alcove/agents/reviewer.yml
+++ b/.alcove/agents/reviewer.yml
@@ -21,8 +21,6 @@ repos:
     name: pulp-service
 
 timeout: 1800
-credentials:
-  GITHUB_TOKEN: github
 enforcement_mode: monitor
 
 outputs:

--- a/.alcove/agents/sdlc-developer.yml
+++ b/.alcove/agents/sdlc-developer.yml
@@ -32,8 +32,6 @@ prompt: |
   Output: {"summary": "what you implemented"}
 
 timeout: 3600
-credentials:
-  GITHUB_TOKEN: github
 enforcement_mode: monitor
 
 dev_container:

--- a/.alcove/agents/upgrade-deps.yml
+++ b/.alcove/agents/upgrade-deps.yml
@@ -18,8 +18,6 @@ prompt: |
   Do NOT create a PR — the pipeline handles that automatically.
 
 timeout: 7200
-credentials:
-  GITHUB_TOKEN: github
 enforcement_mode: monitor
 
 schedule:


### PR DESCRIPTION
Repos-based derivation handles tokens.

## Summary by Sourcery

Enhancements:
- Rely on repo-based token derivation by deleting explicit GITHUB_TOKEN credentials from reviewer, SDLC developer, and upgrade-deps agent configs.