### PR TITLE
Add alcove post-merge release pipeline

### DIFF
--- a/.alcove/agents/claude-md-updater.yml
+++ b/.alcove/agents/claude-md-updater.yml
@@ -1,0 +1,60 @@
+name: CLAUDE.md Updater
+description: |
+  Ensures the CLAUDE.md file in pulp-service is up-to-date with the latest
+  committed changes. Reviews the recent commit diff and updates CLAUDE.md
+  if new patterns, commands, architecture decisions, or conventions were introduced.
+
+prompt: |
+  A commit was just merged to the pulp-service main branch.
+  Your job is to ensure the CLAUDE.md file is up-to-date with the changes.
+
+  Steps:
+  1. Review the most recent commit(s) on main:
+     cd /workspace/pulp-service
+     git log -5 --oneline
+     git diff HEAD~1..HEAD --stat
+     git diff HEAD~1..HEAD
+
+  2. Read the current CLAUDE.md:
+     cat CLAUDE.md
+
+  3. Analyze whether the committed changes require CLAUDE.md updates. Look for:
+     - New CLI commands or make targets
+     - New environment variables or configuration options
+     - Architectural changes (new components, changed data flow)
+     - New code conventions or patterns
+     - New dependencies or tools
+     - Changed build/test/deploy procedures
+     - New API endpoints or changed API behavior
+     - Updated design decisions
+
+  4. If CLAUDE.md needs updates:
+     - Make targeted, minimal edits to the relevant sections
+     - Do NOT rewrite the entire file — only add or modify what changed
+     - Keep the existing structure and style
+     - Commit and push the update:
+       git checkout -b claude-md-update-$(date +%Y%m%d-%H%M%S)
+       git add CLAUDE.md
+       git commit -m "Update CLAUDE.md to reflect recent changes"
+       git push origin HEAD
+
+  5. If CLAUDE.md is already up-to-date, report that no changes were needed.
+
+  6. Write results to /tmp/alcove-outputs.json:
+     {"updated": true|false, "branch": "<branch name if updated>", "changes_summary": "<what was updated or 'no updates needed'>"}
+
+repos:
+  - url: https://github.com/pulp/pulp-service.git
+    ref: main
+    name: pulp-service
+
+credentials:
+  GITHUB_TOKEN: github
+
+timeout: 600
+enforcement_mode: monitor
+
+outputs:
+  - updated
+  - branch
+  - changes_summary

--- a/.alcove/agents/konflux-release-monitor.yml
+++ b/.alcove/agents/konflux-release-monitor.yml
@@ -1,0 +1,59 @@
+name: Konflux Release Monitor
+description: |
+  Monitors the Konflux release pipeline after a commit is merged to pulp-service main.
+  Polls GitHub check runs on the merge commit until the Konflux release pipeline completes.
+
+prompt: |
+  A commit was just merged to the pulp-service main branch.
+  Your job is to wait for the Konflux release pipeline to finish.
+
+  Steps:
+  1. Identify the latest commit SHA on main:
+     curl -s -H "Authorization: token $GITHUB_TOKEN" \
+       "https://api.github.com/repos/pulp/pulp-service/commits/main" | jq -r '.sha'
+
+  2. Poll the commit's check runs until the Konflux release pipeline completes:
+     curl -s -H "Authorization: token $GITHUB_TOKEN" \
+       "https://api.github.com/repos/pulp/pulp-service/commits/<SHA>/check-runs" | \
+       jq '.check_runs[] | {name, status, conclusion}'
+
+  3. Look for check runs with names containing "release" or "build" (Konflux pipelines).
+     Poll every 60 seconds until all Konflux-related checks reach "completed" status.
+     Timeout after 30 minutes.
+
+  4. If all release pipeline checks pass (conclusion: "success"), report success.
+     If any fail, report the failure details.
+
+  5. Derive the image_tag from the Konflux build check run. Konflux publishes
+     the built image reference in the check run's output summary or details_url.
+     Extract it as follows:
+     curl -s -H "Authorization: token $GITHUB_TOKEN" \
+       "https://api.github.com/repos/pulp/pulp-service/commits/<SHA>/check-runs" | \
+       jq -r '.check_runs[] | select(.name | test("build")) | .output.summary'
+
+     Parse the image reference (e.g. quay.io/redhat-user-workloads/pulp-stage/pulp-service/pulp-service@sha256:...)
+     from the summary text. The image_tag is the tag or digest suffix after the colon/at-sign.
+
+     If the summary does not contain an image reference, fall back to using
+     the first 7 characters of the commit SHA as the image_tag (Konflux default
+     tagging convention): image_tag = <SHA>[0:7]
+
+  6. Write results to /tmp/alcove-outputs.json:
+     {"release_status": "success|failure", "commit_sha": "<full SHA>", "image_tag": "<extracted or SHA-based tag>", "details": "<summary>"}
+
+repos:
+  - url: https://github.com/pulp/pulp-service.git
+    ref: main
+    name: pulp-service
+
+credentials:
+  GITHUB_TOKEN: github
+
+timeout: 2400
+enforcement_mode: monitor
+
+outputs:
+  - release_status
+  - commit_sha
+  - image_tag
+  - details

--- a/.alcove/agents/stage-health-checker.yml
+++ b/.alcove/agents/stage-health-checker.yml
@@ -1,0 +1,53 @@
+name: Stage Health Checker
+description: |
+  Checks the health of pulp-stage pods on OpenShift after a Konflux release
+  pipeline completes. Verifies pod status, readiness, recent restarts, and
+  that the new image is deployed.
+
+prompt: |
+  The Konflux release pipeline has completed for pulp-service.
+  Your job is to verify that the pulp-stage pods are healthy.
+
+  Use the Workflow Context above to get the image tag and commit SHA from the
+  previous step.
+
+  Steps:
+  1. Log in to the OpenShift cluster:
+     oc login --token=$OCP_API_TOKEN --server=$OCP_API_URL
+
+  2. Check pod status in the pulp-stage namespace:
+     oc get pods -n pulp-stage -o wide
+     Verify all pods are in Running state and Ready.
+
+  3. Check for recent restarts or crash loops:
+     oc get pods -n pulp-stage -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.status.phase}{"\t"}{range .status.containerStatuses[*]}{.restartCount}{" "}{end}{"\n"}{end}'
+
+  4. Verify the new image is deployed (if image_tag was provided):
+     oc get deployment -n pulp-stage -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.spec.template.spec.containers[0].image}{"\n"}{end}'
+
+  5. Check recent events for errors or warnings:
+     oc get events -n pulp-stage --sort-by='.lastTimestamp' --field-selector type!=Normal | tail -20
+
+  6. Verify service endpoints are responding:
+     oc get endpoints -n pulp-stage
+
+  7. Summarize findings: are pods healthy? Is the new version deployed?
+     Flag any pods not in Ready state, excessive restarts (>3 in last hour),
+     or missing endpoints.
+
+  8. Write results to /tmp/alcove-outputs.json:
+     {"healthy": true|false, "pod_count": <n>, "pod_status": "<summary>", "image_deployed": true|false, "issues": "<any issues found>"}
+
+credentials:
+  OCP_API_TOKEN: openshift
+  OCP_API_URL: openshift
+
+timeout: 600
+enforcement_mode: monitor
+
+outputs:
+  - healthy
+  - pod_count
+  - pod_status
+  - image_deployed
+  - issues

--- a/.alcove/workflows/post-merge-release-pipeline.yml
+++ b/.alcove/workflows/post-merge-release-pipeline.yml
@@ -1,0 +1,35 @@
+name: Pulp Service Post-Merge Release Pipeline
+description: |
+  Triggered when a commit is pushed (PR merged) to pulp-service main branch.
+  Waits for the Konflux release pipeline to complete, then verifies pulp-stage
+  pod health and ensures CLAUDE.md is up-to-date with the changes.
+
+trigger:
+  github:
+    events: [push]
+    branches: [main]
+    repos: [pulp/pulp-service]
+    delivery_mode: polling
+
+workflow:
+  - id: await-konflux-release
+    type: agent
+    agent: Konflux Release Monitor
+    outputs: [release_status, commit_sha, image_tag, details]
+
+  - id: check-stage-health
+    type: agent
+    agent: Stage Health Checker
+    depends: "await-konflux-release.Succeeded"
+    inputs:
+      image_tag: "{{steps.await-konflux-release.outputs.image_tag}}"
+      commit_sha: "{{steps.await-konflux-release.outputs.commit_sha}}"
+    outputs: [healthy, pod_count, pod_status, image_deployed, issues]
+
+  - id: update-claude-md
+    type: agent
+    agent: CLAUDE.md Updater
+    depends: "await-konflux-release.Succeeded"
+    inputs:
+      commit_sha: "{{steps.await-konflux-release.outputs.commit_sha}}"
+    outputs: [updated, branch, changes_summary]


### PR DESCRIPTION
Adds a workflow triggered on push to pulp-service main that:
- Waits for the Konflux release pipeline to complete
- Verifies pulp-stage pod health via oc
- Ensures CLAUDE.md stays up-to-date with committed change

Assisted By: claude-opus-4.6

## Summary by Sourcery

Introduce an Alcove-driven post-merge release workflow for pulp-service that runs after pushes to main, monitoring Konflux releases, checking stage environment health, and keeping CLAUDE.md in sync with recent changes.

New Features:
- Add an Alcove workflow that triggers on pushes to pulp-service main to orchestrate post-merge release checks.
- Introduce a Konflux release monitor agent to track completion and outcome of the release pipeline for the latest main commit.
- Add a stage health checker agent to validate pulp-stage pod health and deployment state in OpenShift after releases.
- Add a CLAUDE.md updater agent to automatically review recent commits and update CLAUDE.md when documentation changes are needed.