### PR TITLE
Remove leaked GITHUB_TOKEN from planning agent

### DIFF
--- a/.alcove/agents/planning.yml
+++ b/.alcove/agents/planning.yml
@@ -87,8 +87,6 @@ repos:
   - name: pulp-service
     url: https://github.com/pulp/pulp-service.git
 
-credentials:
-  GITHUB_TOKEN: github
 
 timeout: 900
 enforcement_mode: monitor


### PR DESCRIPTION
Missed in previous cleanup.

## Summary by Sourcery

Chores:
- Clean up planning agent configuration by removing an inline GITHUB_TOKEN credential entry.