### PR TITLE
fix: use single-quoted strings in pipeline v2 condition expressions

### DIFF
--- a/.alcove/workflows/sdlc-pipeline-v2.yml
+++ b/.alcove/workflows/sdlc-pipeline-v2.yml
@@ -31,7 +31,7 @@ workflow:
     type: agent
     agent: Implementation Planner v2
     depends: "triage.Succeeded"
-    condition: "steps.triage.outputs.automatable == true"
+    condition: "steps.triage.outputs.automatable == 'true'"
     inputs:
       issue_number: "{{trigger.issue_number}}"
       issue_title: "{{trigger.issue_title}}"
@@ -133,7 +133,7 @@ workflow:
     type: bridge
     action: create-merge-request
     depends: "review-django.Succeeded && review-security.Succeeded"
-    condition: "steps.review-django.outputs.approved == true && steps.review-security.outputs.approved == true"
+    condition: "steps.review-django.outputs.approved == 'true' && steps.review-security.outputs.approved == 'true'"
     inputs:
       repo: pulp/pulp-service
       branch: "{{steps.implement.inputs.branch}}"


### PR DESCRIPTION
## Summary

- Fix condition syntax in `sdlc-pipeline-v2.yml` — Alcove's condition evaluator requires single-quoted strings for comparison values (`'true'`), not bare `true`
- Fixes the sync error: `invalid condition syntax: steps.triage.outputs.automatable == true`

## Changes

```diff
-condition: "steps.triage.outputs.automatable == true"
+condition: "steps.triage.outputs.automatable == 'true'"

-condition: "steps.review-django.outputs.approved == true && steps.review-security.outputs.approved == true"
+condition: "steps.review-django.outputs.approved == 'true' && steps.review-security.outputs.approved == 'true'"
```

## Test plan

- [x] Verify YAML syntax is valid
- [ ] Verify workflow definition parses without sync errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Fix condition expressions that compared workflow step outputs to bare booleans instead of the required single-quoted string values in the SDLC pipeline v2 workflow configuration.