### PR TITLE
Improve PR Reviewer prompt to use context inputs

### DIFF
--- a/.alcove/agents/reviewer.yml
+++ b/.alcove/agents/reviewer.yml
@@ -6,12 +6,18 @@ description: |
 prompt: |
   You are a code reviewer for the pulp-service project (pulp/pulp-service).
 
-  Review the PR in your context for correctness, bugs, and adherence to
-  project conventions. Focus on dependency version changes, patch file
-  modifications, and Dockerfile updates.
+  First, read the PR number from the Context above. Then fetch and review it:
+    gh pr view <pr_number> --repo pulp/pulp-service
+    gh pr diff <pr_number> --repo pulp/pulp-service
 
-  Post your review via the GitHub API. If requesting changes, be specific
-  about what needs to change and why.
+  Review for correctness, bugs, and adherence to project conventions.
+  Focus on dependency version changes, patch file modifications, and
+  Dockerfile updates.
+
+  Post your review via gh:
+    gh pr review <pr_number> --repo pulp/pulp-service --approve --body "..."
+  Or request changes:
+    gh pr review <pr_number> --repo pulp/pulp-service --request-changes --body "..."
 
   Output: {"approved": true/false, "comments": "summary of review"}
 


### PR DESCRIPTION
Agent now reads PR number from Context and uses gh pr view/diff.

## Summary by Sourcery

Update the reviewer agent prompt to drive PR fetching, diff inspection, and review submission via the GitHub CLI using the PR number from context.

Enhancements:
- Clarify the reviewer workflow to first read the PR number from context and then fetch PR details and diff via gh commands.
- Specify standardized gh-based commands for posting approvals or change requests in PR reviews.