### PR TITLE
fix: condition syntax in SDLC pipeline v2

### DIFF
--- a/.alcove/workflows/sdlc-pipeline-v2.yml
+++ b/.alcove/workflows/sdlc-pipeline-v2.yml
@@ -128,12 +128,11 @@ workflow:
     outputs: [summary]
 
   # Phase 6: Submit — create draft PR (human merges after review).
-  # Condition ensures both reviewers explicitly approved.
+  # Reviewers exit non-zero on rejection, so depends is sufficient for gating.
   - id: create-pr
     type: bridge
     action: create-merge-request
     depends: "review-django.Succeeded && review-security.Succeeded"
-    condition: "steps.review-django.outputs.approved == 'true' && steps.review-security.outputs.approved == 'true'"
     inputs:
       repo: pulp/pulp-service
       branch: "{{steps.implement.inputs.branch}}"


### PR DESCRIPTION
## Summary

- Fix `condition` expression on `plan` step: bare `true` → single-quoted `'true'` (Alcove requires quoted strings)
- Remove `condition` from `create-pr` step: Alcove's condition regex uses `\w+` for step IDs, which doesn't match hyphenated IDs like `review-django`. The `depends` expression + reviewers exiting non-zero on rejection is sufficient gating.

Fixes sync error:
```
Failed to parse workflow definition: invalid condition syntax: steps.triage.outputs.automatable == true
```

## Test plan

- [ ] Verify workflow syncs without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Adjust SDLC v2 workflow conditions to satisfy Alcove syntax requirements and rely on step dependencies for PR creation gating.

Bug Fixes:
- Correct the plan step condition to compare the automatable output against a quoted 'true' string to avoid workflow parse errors.

Enhancements:
- Simplify the create-pr step by removing an explicit approval condition and relying on non-zero reviewer exits combined with dependency checks for gating behavior.