### PR TITLE
fix: wait for dev container readiness before starting upgrade workflow

### DIFF
--- a/.alcove/agents/upgrade-deps/AGENT.md
+++ b/.alcove/agents/upgrade-deps/AGENT.md
@@ -16,10 +16,22 @@ curl -s -X POST http://$DEV_CONTAINER_HOST/exec \
 
 The response is NDJSON — each line is JSON with a `stream` field (`stdout`, `stderr`, or `exit`). The `exit` line has the exit `code`.
 
-Check that the dev container is ready before proceeding:
+Before doing anything else, wait for the dev container to be ready. It may take up to 2 minutes to start (PostgreSQL init, migrations, etc.). Run this retry loop FIRST:
 ```bash
-curl -s http://$DEV_CONTAINER_HOST/healthz
+for i in $(seq 1 120); do
+  if curl -s http://$DEV_CONTAINER_HOST/healthz 2>/dev/null | grep -q ok; then
+    echo "Dev container ready after ${i}s"
+    break
+  fi
+  if [ "$i" -eq 120 ]; then
+    echo "ERROR: Dev container not ready after 120s"
+    exit 1
+  fi
+  sleep 1
+done
 ```
+
+Do NOT proceed to any phase until this succeeds.
 
 The `/workspace` directory is a shared volume between Skiff and the dev container. You can edit files directly and they are visible in both environments.
 


### PR DESCRIPTION
## Summary

Adds a 120-second retry loop to the upgrade agent that polls the dev container's `/healthz` endpoint before proceeding. The dev container runs as a Kubernetes sidecar and may take up to 2 minutes to initialize (PostgreSQL, Redis, migrations, supervisord).

## Problem

The dev container was showing `Connection refused` on `localhost:9090` because Skiff starts before the sidecar is fully ready (no readiness probes in alcove — tracked in bmbouter/alcove#477). This is a prompt-level workaround.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Documentation:
- Explain that the dev container may take up to 2 minutes to become ready and document a retry loop against the /healthz endpoint that must succeed before proceeding with any upgrade phases.