### PR TITLE
fix: run all Tekton pipeline tests in the upgrade agent

### DIFF
--- a/.alcove/agents/upgrade-deps/AGENT.md
+++ b/.alcove/agents/upgrade-deps/AGENT.md
@@ -201,15 +201,53 @@ If any patch fails to apply in the dev container, go back to Phase 3 and fix it 
 
 ## Phase 6: Run Tests
 
-Run the functional tests in the dev container:
+Run the same functional tests that the Tekton pipeline in `.tekton/pulp-deploy-and-test.yaml` executes. All tests run in the dev container via the shim. The API is at `localhost:24817` with admin/password credentials.
 
-1. pulp_service functional tests:
-   ```bash
-   curl -s -X POST http://$DEV_CONTAINER_HOST/exec \
-     -H "Authorization: Bearer $DEV_TOKEN" \
-     -H "Content-Type: application/json" \
-     -d '{"cmd": "pulp-test", "timeout": 600}'
-   ```
+First, install test dependencies in the dev container:
+```bash
+curl -s -X POST http://$DEV_CONTAINER_HOST/exec \
+  -H "Authorization: Bearer $DEV_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"cmd": "pip install \"pytest<8\" pytest-django gnupg", "timeout": 120}'
+```
+
+Then run each test suite in order. For each test, use this pattern:
+```bash
+curl -s -X POST http://$DEV_CONTAINER_HOST/exec \
+  -H "Authorization: Bearer $DEV_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"cmd": "API_PROTOCOL=http API_HOST=localhost API_PORT=24817 ADMIN_USERNAME=admin ADMIN_PASSWORD=password pytest -v -r sx --color=yes --pyargs {test_spec}", "timeout": 600}'
+```
+
+### Test 1: pulp_rpm parallel tests
+```
+--pyargs pulp_rpm.tests.functional -m parallel -n 8 -k 'test_download_content'
+```
+
+### Test 2: pulp_rpm serial tests
+```
+--pyargs pulp_rpm.tests.functional -m 'not parallel' -k 'test_download_policies'
+```
+
+### Test 3: pulpcore tests
+```
+--pyargs pulpcore.tests.functional -m parallel -n 8 -k 'test_jq_header_remote_auth'
+```
+
+### Test 4: pulp_maven tests
+```
+--pyargs pulp_maven.tests.functional.api.test_download_content
+```
+
+### Test 5: pulp_npm tests
+```
+--pyargs pulp_npm.tests.functional -k 'test_pull_through_install'
+```
+
+### Test 6: pulp_service tests
+```
+--pyargs pulp_service.tests.functional -m 'not parallel'
+```
 
 If tests fail:
 - Analyze the failure to determine if it's caused by a patch, by `pulp_service/` code, or by an upstream API change


### PR DESCRIPTION
## Summary

Replaces the single `pulp-test` command in the upgrade agent with all 6 test suites from `.tekton/pulp-deploy-and-test.yaml`:

1. `pulp_rpm` parallel tests (`test_download_content`, 8 workers)
2. `pulp_rpm` serial tests (`test_download_policies`)
3. `pulpcore` tests (`test_jq_header_remote_auth`, 8 workers)
4. `pulp_maven` tests (`test_download_content`)
5. `pulp_npm` tests (`test_pull_through_install`)
6. `pulp_service` functional tests (serial)

Also installs test dependencies (`pytest<8`, `pytest-django`, `gnupg`) and configures the API connection (`localhost:24817`, admin/password).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Documentation:
- Update the upgrade agent guide to replace the single pulp_service test command with detailed instructions for installing test dependencies and running all six Tekton-aligned functional test suites via the dev container shim.