### PR TITLE
fix: remove worker aggregation and normalize http_target to fix SLI > 1

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -31,17 +31,16 @@ objects:
             metric:
             - 'name == "api.request_duration"'
 
-        attributes/remove_worker_name:
-          actions:
-          - key: worker.name
-            action: delete
+        transform/simplify_http_target:
+          error_mode: ignore
+          metric_statements:
+            - context: datapoint
+              statements:
+                - set(attributes["http.target"], "upload") where attributes["http.target"] != nil and IsMatch(attributes["http.target"], ".*upload.*")
+                - set(attributes["http.target"], "other") where attributes["http.target"] != nil and not IsMatch(attributes["http.target"], ".*upload.*")
 
         batch/api_aggregation:
           timeout: 14s
-
-        groupbyattrs/api_aggregation:
-          keys:
-          - api.request_duration
 
         batch:
         
@@ -64,9 +63,8 @@ objects:
             processors:
             - memory_limiter
             - filter/filter_pulp_api_request_duration
-            - attributes/remove_worker_name
+            - transform/simplify_http_target
             - batch/api_aggregation
-            - groupbyattrs/api_aggregation
             exporters: [prometheus]
         
           metrics/main:
@@ -373,8 +371,6 @@ objects:
             value: ${{OTEL_PYTHON_EXCLUDED_URLS}}
           - name: PULP_OTEL_PULP_API_HISTOGRAM_BUCKETS
             value: ${PULP_OTEL_PULP_API_HISTOGRAM_BUCKETS}
-          - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
-            value: "delta"
           - name: PULP_REDIS_PORT
             value: "6379"
           - name: SENTRY_DSN
@@ -545,8 +541,6 @@ objects:
             value: ${OTEL_METRIC_EXPORT_TIMEOUT}
           - name: OTEL_TRACES_EXPORTER
             value: "none"
-          - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
-            value: "delta"
           - name: PULP_REDIS_PORT
             value: "6379"
           - name: SENTRY_DSN
@@ -662,8 +656,6 @@ objects:
             value: ${{OTEL_EXPORTER_OTLP_ENDPOINT}}
           - name: OTEL_TRACES_EXPORTER
             value: "none"
-          - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
-            value: "delta"
           - name: PULP_OTEL_METRICS_DISPATCH_INTERVAL_MINUTES
             value: ${PULP_OTEL_METRICS_DISPATCH_INTERVAL_MINUTES}
           - name: PULP_REDIS_PORT


### PR DESCRIPTION
## Problem

The `APIWriteRequestLatency` SLO reports values > 1 (impossible for a valid histogram ratio). The OTel pipeline's `attributes/remove_worker_name` + `groupbyattrs/api_aggregation` sums per-worker cumulative counters into a single series. When gunicorn recycles workers (`--max-requests`), the aggregate drops, causing hidden counter resets that inflate `rate(le=1000)` relative to `rate(le=+Inf)`.

Two prior fixes failed:
- **cumulativetodelta + deltatocumulative** (#1068): `deltatocumulative` is not included in the Red Hat OTel Collector 0.107.0 build
- **SDK delta temporality** (#1068 updated): The Prometheus exporter [does not accumulate delta histograms](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/19153) — it outputs raw deltas as fake cumulative counters

## Fix

Remove the worker aggregation entirely. Each worker keeps its own `worker_name` label in Prometheus, so `rate()` handles per-worker counter resets correctly (this is what it's designed for). The existing `sum(rate(...))` pattern in SLO queries and recording rules computes `rate()` first (per worker), then `sum` aggregates — which is mathematically correct.

To offset the cardinality increase from keeping `worker_name`, a `transform` processor normalizes `http_target` from hundreds of unique URL patterns to just `"upload"` or `"other"`.

### Changes
- **Removed**: `attributes/remove_worker_name` processor definition and pipeline reference
- **Removed**: `groupbyattrs/api_aggregation` processor definition and pipeline reference
- **Removed**: `OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE=delta` from all three deployments (reverts #1068)
- **Added**: `transform/simplify_http_target` processor that normalizes `http_target` to `"upload"` or `"other"`

### Companion change required
SLO queries in app-interface need updating to match the new `http_target` values:
- `http_target!~".*/upload/"` → `http_target!="upload"`
- `http_target=~".*/upload/"` → `http_target="upload"`

## Test plan

- [ ] Deploy to ephemeral — confirm collector starts, `worker_name` label present, `http_target` values are `"upload"` or `"other"`
- [ ] Deploy to stage — confirm SLI ratio ≤ 1 with 1h window
- [ ] Deploy to production — monitor for 24h

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Adjust metrics pipeline configuration to avoid incorrect API latency SLI ratios by preserving per-worker series and simplifying HTTP target labels.

New Features:
- Introduce a transform processor that normalizes http.target metric attributes into coarse "upload" or "other" categories.

Enhancements:
- Remove worker-name stripping and aggregation processors from the metrics pipeline so Prometheus retains per-worker time series.
- Revert use of delta temporality for OTLP metrics export by dropping the OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE environment variable from all deployments.