### PR TITLE
fix: don't assume patches that create new files are upstreamed

### DIFF
--- a/.alcove/agents/upgrade-deps/AGENT.md
+++ b/.alcove/agents/upgrade-deps/AGENT.md
@@ -189,7 +189,20 @@ curl -s -X POST http://$DEV_CONTAINER_HOST/exec \
 
 If the patch succeeds, move to the next one.
 
-**If the patch fails with "Reversed (or previously applied)":**
+**If the patch fails with "already exists", "Reversed", or "previously applied":**
+
+First, check if the patch CREATES new files (look for `new file mode` or `--- /dev/null` in the patch). If it does, those files may be left over from a previous patch application — `pip install --force-reinstall` does NOT remove files that were added by patches. Delete those leftover files from site-packages, then retry the patch:
+
+```bash
+# Read the patch to find files it creates (lines starting with +++ b/ where the --- line is /dev/null)
+# Delete those files from site-packages
+curl -s -X POST http://$DEV_CONTAINER_HOST/exec \
+  -H "Authorization: Bearer $DEV_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"cmd": "rm /usr/local/lib/pulp/lib/python3.11/site-packages/{new_file_path}", "timeout": 10}'
+```
+
+If the patch only MODIFIES existing files (no new files created):
 
 1. Force-reinstall just the affected package:
    ```bash
@@ -199,7 +212,7 @@ If the patch succeeds, move to the next one.
      -d '{"cmd": "pip install --force-reinstall {package_name}", "timeout": 120}'
    ```
 2. Retry applying the patch.
-3. If it STILL shows "already applied" after force-reinstall, the patch IS upstreamed — the changes are part of the new upstream release. Delete the patch file from `images/assets/patches/`, remove the corresponding COPY and RUN lines from the `Dockerfile`, record this in your change log, and continue to the next patch.
+3. If it STILL shows "already applied" after force-reinstall AND the patch does NOT create new files, the patch IS upstreamed. Delete the patch file from `images/assets/patches/`, remove the corresponding COPY and RUN lines from the `Dockerfile`, record this in your change log, and continue to the next patch.
 
 **If the patch fails for any other reason (hunk failure, context mismatch):**
 


### PR DESCRIPTION
## Summary

Patch 0053 creates `pulp_python/app/tasks/scan_package.py` (a new file). After `pip install --force-reinstall`, the file still exists because pip only manages files from the package — it doesn't delete files added by patches. The agent saw "file already exists" and falsely concluded the patch was upstreamed.

### Fix

When a patch fails and it creates new files (`--- /dev/null` in the patch):
1. Delete the leftover files from site-packages
2. Retry the patch

Only classify as "upstreamed" for patches that modify (not create) existing files and still show "already applied" after force-reinstall.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Clarify the agent workflow for handling patches that appear already applied by distinguishing between patches that create new files and those that only modify existing ones.

Documentation:
- Document the procedure for deleting leftover files created by patches before retrying them when patches fail with an already-applied message.
- Clarify that only patches which modify existing files and still show as already applied after a force reinstall should be treated as upstreamed.