### PR TITLE
Set all new agents to enforcement_mode: monitor

### DIFF
--- a/.alcove/agents/patcher.yml
+++ b/.alcove/agents/patcher.yml
@@ -43,6 +43,7 @@ prompt: |
   }
 
 timeout: 480
+enforcement_mode: monitor
 model: claude-sonnet-4-6
 
 profiles:

--- a/.alcove/agents/planner-v2.yml
+++ b/.alcove/agents/planner-v2.yml
@@ -67,6 +67,7 @@ prompt: |
   }
 
 timeout: 600
+enforcement_mode: monitor
 # model: intentionally omitted — defaults to Opus for deep architectural reasoning
 
 profiles:

--- a/.alcove/agents/pulp-developer.yml
+++ b/.alcove/agents/pulp-developer.yml
@@ -62,6 +62,7 @@ prompt: |
   Output: {"summary": "what you implemented and key decisions made"}
 
 timeout: 1800
+enforcement_mode: monitor
 
 profiles:
   - pulp-service-developer

--- a/.alcove/agents/reviewer-django.yml
+++ b/.alcove/agents/reviewer-django.yml
@@ -84,6 +84,7 @@ prompt: |
   }
 
 timeout: 600
+enforcement_mode: monitor
 model: claude-sonnet-4-6
 
 profiles:

--- a/.alcove/agents/reviewer-security.yml
+++ b/.alcove/agents/reviewer-security.yml
@@ -90,6 +90,7 @@ prompt: |
   }
 
 timeout: 600
+enforcement_mode: monitor
 model: claude-sonnet-4-6
 
 profiles:

--- a/.alcove/agents/triage.yml
+++ b/.alcove/agents/triage.yml
@@ -78,6 +78,7 @@ prompt: |
   }
 
 timeout: 480
+enforcement_mode: monitor
 model: claude-sonnet-4-6
 
 profiles:

--- a/.alcove/agents/verifier.yml
+++ b/.alcove/agents/verifier.yml
@@ -69,6 +69,7 @@ prompt: |
   }
 
 timeout: 600
+enforcement_mode: monitor
 model: claude-sonnet-4-6
 
 profiles:


### PR DESCRIPTION
Agents without monitor mode fail silently.

## Summary by Sourcery

Enhancements:
- Standardize agent configurations by adding an explicit enforcement_mode: monitor setting across multiple agent definitions.