### PR TITLE
Temporarily disable alcove post-merge release pipeline

### DIFF
--- a/.alcove/workflows/post-merge-release-pipeline.yml
+++ b/.alcove/workflows/post-merge-release-pipeline.yml
@@ -5,11 +5,11 @@ description: |
   pod health and ensures CLAUDE.md is up-to-date with the changes.
 
 trigger:
-  github:
-    events: [push]
-    branches: [main]
-    repos: [pulp/pulp-service]
-    delivery_mode: polling
+#  github:
+#    events: [push]
+#    branches: [main]
+#    repos: [pulp/pulp-service]
+#    delivery_mode: polling
 
 workflow:
   - id: await-konflux-release


### PR DESCRIPTION
Disable the post merge pipeline to investigate some issues:
- we don't have an ocp SA account yet
- it is deploying 8 agents per execution

## Summary by Sourcery

CI:
- Comment out the GitHub push trigger configuration for the post-merge release pipeline, preventing it from running on main branch pushes.