### PR TITLE
fix: write automatable as string in triage output

### DIFF
--- a/.alcove/agents/triage.yml
+++ b/.alcove/agents/triage.yml
@@ -78,7 +78,7 @@ prompt: |
         "candidate_files": ["file1.py", "file2.py"],
         "approach": "how to implement",
         "risks": "what could go wrong",
-        "automatable": True,
+        "automatable": "true",  # must be string "true"/"false" for pipeline condition matching
         "reviewers_needed": ["django", "security"]
     }
     with open("/tmp/alcove-outputs.json", "w") as f:


### PR DESCRIPTION
## Summary

The pipeline condition `steps.triage.outputs.automatable == 'true'` compares against a string, but the triage agent was writing a Python boolean `True` which serializes as JSON `true` (unquoted). This doesn't match the string comparison in Alcove's condition evaluator.

Fix: write `"true"` / `"false"` as strings instead of booleans.

## Test plan

- [ ] Label an issue with `agentic-sdlc-v2` and verify triage passes the automatable gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Correct triage output to emit the automatable flag as the string values "true" or "false" instead of boolean values so pipeline conditions match as expected.