### PR TITLE
fix: set WORKER_TYPE=redis in dev container settings

### DIFF
--- a/dev-container/settings.py
+++ b/dev-container/settings.py
@@ -16,6 +16,7 @@ DATABASES = {
 
 REDIS_URL = "redis://localhost:6379/0"
 CACHE_ENABLED = True
+WORKER_TYPE = "redis"
 
 MEDIA_ROOT = "/var/lib/pulp/media/"
 DEFAULT_FILE_STORAGE = "pulpcore.app.models.storage.FileSystem"


### PR DESCRIPTION
## Summary

Adds `WORKER_TYPE = "redis"` to the dev container's `settings.py`. The dev container already runs Redis, but `WORKER_TYPE` defaulted to `"pulpcore"`, causing all task debug endpoints to return 400 with "This endpoint only works with Redis workers."

## Test results

Before: 14 passed, 50 failed, 5 skipped
After: **49 passed**, 15 failed, 5 skipped

The 35 fixed tests are all in `test_task_debug.py`. The remaining 15 failures are in `test_authentication.py`, `test_domain_based_permissions.py`, `test_feature_service.py`, and `test_group_based_permissions.py` — these require the X-RH-IDENTITY authentication stack which is not configured in the dev container.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Ensure task debug endpoints function correctly in the dev container by configuring WORKER_TYPE to use Redis workers.