### PR TITLE
fix: set CONTENT_PATH_PREFIX and PYPI_API_PATH_PREFIX to match production

### DIFF
--- a/dev-container/settings.py
+++ b/dev-container/settings.py
@@ -1,5 +1,6 @@
 CONTENT_ORIGIN = "http://localhost:24816"
-CONTENT_PATH_PREFIX = "/pulp/content/"
+CONTENT_PATH_PREFIX = "/api/pulp-content/"
+PYPI_API_PATH_PREFIX = "/api/pypi/"
 DOMAIN_ENABLED = True
 SECRET_KEY = "dev-secret-key-not-for-production"
 


### PR DESCRIPTION
## Summary

Sets `CONTENT_PATH_PREFIX = "/api/pulp-content/"` and `PYPI_API_PATH_PREFIX = "/api/pypi/"` to match production routing.

Test results unchanged: **60 passed, 4 failed, 5 skipped**. The 4 remaining failures are because tests hit content URLs on the API port (24817), but the content app is on 24816. Production has a reverse proxy routing these paths; the dev container doesn't.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Build:
- Update dev-container settings to use /api/pulp-content/ and /api/pypi/ path prefixes.