### PR TITLE
feat: add attestation test keys and API_ROOT to dev container

### DIFF
--- a/dev-container/Dockerfile
+++ b/dev-container/Dockerfile
@@ -113,6 +113,16 @@ RUN openssl rand -base64 32 > /etc/pulp/certs/database_fields.symmetric.key && \
     chown pulp:pulp /etc/pulp/certs/database_fields.symmetric.key && \
     chmod 600 /etc/pulp/certs/database_fields.symmetric.key
 
+RUN mkdir -p /etc/pki/attestation && \
+    python3 -c "\
+from cryptography.hazmat.primitives.asymmetric import rsa; \
+from cryptography.hazmat.primitives import serialization; \
+key = rsa.generate_private_key(65537, 4096); \
+open('/etc/pki/attestation/test-key-private.pem','wb').write(key.private_bytes(serialization.Encoding.PEM, serialization.PrivateFormat.PKCS8, serialization.NoEncryption())); \
+open('/etc/pki/attestation/test-key.pem','wb').write(key.public_key().public_bytes(serialization.Encoding.PEM, serialization.PublicFormat.SubjectPublicKeyInfo))" && \
+    chmod 600 /etc/pki/attestation/test-key-private.pem && \
+    chmod 644 /etc/pki/attestation/test-key.pem
+
 RUN dnf -y install java-17-openjdk-headless && dnf clean all
 
 RUN curl -L -o /opt/openapi-generator-cli.jar \

--- a/dev-container/settings.py
+++ b/dev-container/settings.py
@@ -1,7 +1,9 @@
 CONTENT_ORIGIN = "http://localhost:24816"
 CONTENT_PATH_PREFIX = "/api/pulp-content/"
-PYPI_API_PATH_PREFIX = "/api/pypi/"
+PYPI_PATH_PREFIX = "/api/pypi/"
+PYPI_API_HOSTNAME = "http://localhost:24817"
 DOMAIN_ENABLED = True
+API_ROOT = "/api/pulp/"
 SECRET_KEY = "dev-secret-key-not-for-production"
 
 DATABASES = {
@@ -46,3 +48,5 @@ REST_FRAMEWORK__DEFAULT_PERMISSION_CLASSES = (
 
 AUTHENTICATION_JSON_HEADER = "HTTP_X_RH_IDENTITY"
 AUTHENTICATION_JSON_HEADER_JQ_FILTER = ".identity.user.username"
+
+ATTESTATION_VERIFICATION_KEY = "/etc/pki/attestation/test-key.pem"


### PR DESCRIPTION
## Summary

- **Dockerfile**: generates RSA-4096 attestation test keypair at build time (`/etc/pki/attestation/test-key-private.pem` and `test-key.pem`)
- **settings.py**: adds `API_ROOT = "/api/pulp/"` and `ATTESTATION_VERIFICATION_KEY`

This should un-skip the 5 attestation verification tests, bringing results from 62 passed / 5 skipped to ~67 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Generate attestation test keys in the dev container and configure application settings for API and attestation verification in the development environment.

New Features:
- Create an RSA-4096 attestation test keypair during dev container build and store it under /etc/pki/attestation.
- Introduce configuration for API root, PyPI service host, and attestation verification key in the dev settings.

Tests:
- Enable previously skipped attestation verification tests by providing the required keys and configuration in the dev environment.