### PR TITLE
fix: update pulp-test URLs to use /api/pulp/ API_ROOT

### DIFF
--- a/dev-container/scripts/pulp-test
+++ b/dev-container/scripts/pulp-test
@@ -11,7 +11,7 @@ API_PROTOCOL="${API_PROTOCOL:-http}"
 wait_for_api() {
     echo "Waiting for Pulp API at ${API_PROTOCOL}://${API_HOST}:${API_PORT}..."
     for i in $(seq 1 60); do
-        if curl -s -f "${API_PROTOCOL}://${API_HOST}:${API_PORT}/pulp/api/v3/status/" > /dev/null 2>&1; then
+        if curl -s -f "${API_PROTOCOL}://${API_HOST}:${API_PORT}/api/pulp/api/v3/status/" > /dev/null 2>&1; then
             echo "API ready after ${i}s"
             return 0
         fi
@@ -35,7 +35,7 @@ generate_bindings() {
             COMPONENT="${PACKAGE#pulp_}"
         fi
 
-        SCHEMA_URL="${API_PROTOCOL}://${API_HOST}:${API_PORT}/pulp/api/v3/docs/api.json?bindings&component=${COMPONENT}"
+        SCHEMA_URL="${API_PROTOCOL}://${API_HOST}:${API_PORT}/api/pulp/api/v3/docs/api.json?bindings&component=${COMPONENT}"
         SCHEMA_FILE="$BINDINGS_DIR/api-${PACKAGE//_/-}.json"
 
         echo "Fetching schema for $PACKAGE ($COMPONENT)..."


### PR DESCRIPTION
## Summary

The `API_ROOT` was changed to `/api/pulp/` in PR #1146, but `pulp-test` still used `/pulp/api/v3/` for the health check and schema fetch URLs. This caused:
- `wait_for_api()` to time out (404 on `/pulp/api/v3/status/`)
- Bindings generation to fail (can't fetch schemas)
- All tests to be skipped

Fixes both URLs to use `/api/pulp/api/v3/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Update pulp-test dev-container script to match the new API root and restore test health checks and schema fetching.

Bug Fixes:
- Fix pulp-test API health check URL to use the updated /api/pulp/ API root.
- Fix pulp-test schema fetch URL so bindings generation succeeds and tests are executed instead of skipped.

Tests:
- Restore functional pulp-test execution by ensuring the test harness can reach the API and fetch schemas.