### PR TITLE
fix: disable gunicorn worker recycling for pulp-api, raise for pulp-content

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -294,7 +294,7 @@ objects:
           annotations:
             "kubectl.kubernetes.io/default-container": pulp-api
         image: ${IMAGE}:${IMAGE_TAG}
-        command: ['pulpcore-api', '-b', '0.0.0.0:8000', '--timeout', '${PULP_API_GUNICORN_TIMEOUT}', '--max-requests', '${PULP_API_GUNICORN_MAX_REQUESTS}', '--max-requests-jitter', '${PULP_API_GUNICORN_MAX_REQUESTS_JITTER}', '--workers', '${PULP_API_GUNICORN_WORKERS}', '--access-logfile', '-', '--access-logformat', '(pulp [%({correlation-id}o)s]: %(h)s %(l)s user:%({REMOTE_USER}e)s org_id:%({ORG_ID}e)s %(t)s "%(r)s" %(s)s %(b)s "%(f)s" "%(a)s" %(M)s x_forwarded_for:"%({X_FORWARDED_FOR}e)s")']
+        command: ['pulpcore-api', '-b', '0.0.0.0:8000', '--timeout', '${PULP_API_GUNICORN_TIMEOUT}', '--workers', '${PULP_API_GUNICORN_WORKERS}', '--access-logfile', '-', '--access-logformat', '(pulp [%({correlation-id}o)s]: %(h)s %(l)s user:%({REMOTE_USER}e)s org_id:%({ORG_ID}e)s %(t)s "%(r)s" %(s)s %(b)s "%(f)s" "%(a)s" %(M)s x_forwarded_for:"%({X_FORWARDED_FOR}e)s")']
         volumeMounts:
         - name: secret-volume
           mountPath: "/etc/pulp/keys"
@@ -1372,18 +1372,12 @@ parameters:
   - name: PULP_API_GUNICORN_WORKERS
     description: Number of gunicorn workers in the API pods
     value: "1"
-  - name: PULP_API_GUNICORN_MAX_REQUESTS
-    description: The maximum number of requests an API worker will process before restarting.
-    value: "20"
-  - name: PULP_API_GUNICORN_MAX_REQUESTS_JITTER
-    description: The maximum jitter to add to the API max_requests setting for each worker.
-    value: "5"
   - name: PULP_CONTENT_GUNICORN_MAX_REQUESTS
     description: The maximum number of requests a content worker will process before restarting.
-    value: "20"
+    value: "10000"
   - name: PULP_CONTENT_GUNICORN_MAX_REQUESTS_JITTER
     description: The maximum jitter to add to the Content max_requests setting for each worker.
-    value: "5"
+    value: "500"
   - name: PULP_CONTENT_GUNICORN_TIMEOUT
     description: Workers silent for more than this many seconds are killed and restarted.
     value: "90"


### PR DESCRIPTION
## Problem

Gunicorn `--max-requests=20` causes workers to recycle after every 20 requests. With only 1 worker per pod, this creates frequent counter resets in Prometheus histogram metrics. When the post-reset counter value coincidentally equals the pre-reset value (common with small counters in the 0–20 range), Prometheus cannot detect the reset — producing SLI ratios > 1 for the `APIWriteRequestLatency` SLO.

This is the root cause behind the histogram invariant violations. The OTel pipeline fix in #1127 (removing `groupbyattrs` worker aggregation) reduced the problem but couldn't eliminate it because the counter values are too small for reliable reset detection.

## Fix

- **pulp-api**: Remove `--max-requests` and `--max-requests-jitter` entirely. Memory analysis over 24h shows no leak — usage oscillates 825–1004 MiB against a 5120 MiB limit (4x headroom) with no upward drift.
- **pulp-content**: Raise `--max-requests` from 20 to 10000 (jitter 500) as a memory safety net. Counter values will reach ~10000 before reset, making coincidental value matches statistically negligible.

## Test plan

- [ ] Deploy to ephemeral — confirm pulp-api and pulp-content start correctly
- [ ] Deploy to stage — monitor memory usage over 24h, confirm no OOM
- [ ] Deploy to production — confirm `APIWriteRequestLatency` SLI stays ≤ 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Adjust Gunicorn worker recycling settings for pulp-api and pulp-content to improve metric stability and operational behavior.

Build:
- Remove Gunicorn max-requests and jitter configuration from the pulp-api deployment command.
- Increase Gunicorn max-requests and jitter defaults for pulp-content to allow many more requests before workers are recycled.