### PR TITLE
Add Pulp Stack repo group for multi-repo agent sessions

### DIFF
--- a/.alcove/agents/upgrade-deps.yml
+++ b/.alcove/agents/upgrade-deps.yml
@@ -27,8 +27,5 @@ schedule:
 dev_container:
   image: ghcr.io/pulp/hosted-pulp-dev-env:main
 
-repos:
-  - url: https://github.com/pulp/pulp-service
-    ref: main
-    name: pulp-service
+repo_group: Pulp Stack
 

--- a/.alcove/repo-groups/pulp-stack.yml
+++ b/.alcove/repo-groups/pulp-stack.yml
@@ -1,0 +1,23 @@
+name: Pulp Stack
+description: |
+  All Pulp platform repos: pulpcore and the plugins deployed in pulp-service.
+  Derived from pulp_service/requirements.txt pinned dependencies.
+repos:
+  - url: https://github.com/pulp/pulp-service
+    name: pulp-service
+  - url: https://github.com/pulp/pulpcore
+    name: pulpcore
+  - url: https://github.com/pulp/pulp_rpm
+    name: pulp_rpm
+  - url: https://github.com/pulp/pulp-python
+    name: pulp_python
+  - url: https://github.com/pulp/pulp_container
+    name: pulp_container
+  - url: https://github.com/pulp/pulp-gem
+    name: pulp_gem
+  - url: https://github.com/pulp/pulp_npm
+    name: pulp_npm
+  - url: https://github.com/pulp/pulp-maven
+    name: pulp_maven
+  - url: https://github.com/pulp/pulp_hugging_face
+    name: pulp_hugging_face


### PR DESCRIPTION
## Summary
- New `.alcove/repo-groups/pulp-stack.yml` defining all Pulp platform repos (pulpcore + 7 plugins from requirements.txt)
- Updated `upgrade-deps` agent to use `repo_group: Pulp Stack` instead of single repo, so all plugin source code is available at `/workspace/` during upgrades

## Repos in the group
pulp-service, pulpcore, pulp_rpm, pulp_python, pulp_container, pulp_gem, pulp_npm, pulp_maven, pulp_hugging_face

## Requires
Alcove Bridge v0.40.0+ (deployed to staging)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Define a shared repo group for the Pulp platform and switch the upgrade-deps agent to use it so all related repositories are available during runs.

New Features:
- Introduce a Pulp Stack repo group aggregating pulpcore and all deployed plugin repositories for coordinated workflows.

Enhancements:
- Configure the upgrade-deps agent to use the Pulp Stack repo group instead of a single repository, ensuring all relevant code is checked out together.