### PR TITLE
Fix repo group URLs: underscores not hyphens

### DIFF
--- a/.alcove/repo-groups/pulp-stack.yml
+++ b/.alcove/repo-groups/pulp-stack.yml
@@ -9,15 +9,15 @@ repos:
     name: pulpcore
   - url: https://github.com/pulp/pulp_rpm
     name: pulp_rpm
-  - url: https://github.com/pulp/pulp-python
+  - url: https://github.com/pulp/pulp_python
     name: pulp_python
   - url: https://github.com/pulp/pulp_container
     name: pulp_container
-  - url: https://github.com/pulp/pulp-gem
+  - url: https://github.com/pulp/pulp_gem
     name: pulp_gem
   - url: https://github.com/pulp/pulp_npm
     name: pulp_npm
-  - url: https://github.com/pulp/pulp-maven
+  - url: https://github.com/pulp/pulp_maven
     name: pulp_maven
   - url: https://github.com/pulp/pulp_hugging_face
     name: pulp_hugging_face


### PR DESCRIPTION
pulp_python, pulp_gem, pulp_maven use underscores in their GitHub repo names.

## Summary by Sourcery

Chores:
- Update pulp_python, pulp_gem, and pulp_maven entries in the pulp-stack repo group to point to their correct GitHub repository names with underscores.