### PR TITLE
fix: use string-only values in sdlc-v2 agent outputs

### DIFF
--- a/.alcove/agents/patcher.yml
+++ b/.alcove/agents/patcher.yml
@@ -42,10 +42,11 @@ prompt: |
     python3 - <<'PYEOF'
     import json
     output = {
-        "fixes_applied": ["description of fix 1"],
-        "too_complex": False,
+        "fixes_applied": "description of fix 1, description of fix 2",  # comma-separated string, NOT a list
+        "too_complex": "false",  # string "true" or "false", NOT a boolean
         "too_complex_reason": ""
     }
+    # ALL values MUST be strings. Non-string values (booleans, arrays) silently discard ALL outputs.
     with open("/tmp/alcove-outputs.json", "w") as f:
         json.dump(output, f)
     PYEOF

--- a/.alcove/agents/planner-v2.yml
+++ b/.alcove/agents/planner-v2.yml
@@ -68,9 +68,10 @@ prompt: |
     output = {
         "plan": """Your detailed implementation plan here.
     Can span multiple lines safely.""",
-        "verification_commands": ["black --check --line-length 100 pulp_service/", "pytest pulp_service/pulp_service/tests/functional/"],
-        "reviewers_needed": ["django", "security"]
+        "verification_commands": "black --check --line-length 100 pulp_service/, pytest pulp_service/pulp_service/tests/functional/",  # comma-separated string, NOT a list
+        "reviewers_needed": "django, security"  # comma-separated string, NOT a list
     }
+    # ALL values MUST be strings. Non-string values (booleans, arrays) silently discard ALL outputs.
     with open("/tmp/alcove-outputs.json", "w") as f:
         json.dump(output, f)
     PYEOF

--- a/.alcove/agents/reviewer-django.yml
+++ b/.alcove/agents/reviewer-django.yml
@@ -84,10 +84,11 @@ prompt: |
     import json, sys
     approved = True  # set to False if critical/major issues found
     output = {
-        "approved": approved,
+        "approved": "true" if approved else "false",  # string "true" or "false", NOT a boolean
         "comments": "Summary of review findings.",
-        "issues": []
+        "issues": ""  # semicolon-separated issue descriptions, or empty string if none
     }
+    # ALL values MUST be strings. Non-string values (booleans, arrays) silently discard ALL outputs.
     with open("/tmp/alcove-outputs.json", "w") as f:
         json.dump(output, f)
     if not approved:

--- a/.alcove/agents/reviewer-security.yml
+++ b/.alcove/agents/reviewer-security.yml
@@ -90,10 +90,11 @@ prompt: |
     import json, sys
     approved = True  # set to False if critical/major security issues found
     output = {
-        "approved": approved,
+        "approved": "true" if approved else "false",  # string "true" or "false", NOT a boolean
         "comments": "Summary of security review findings.",
-        "issues": []
+        "issues": ""  # semicolon-separated issue descriptions, or empty string if none
     }
+    # ALL values MUST be strings. Non-string values (booleans, arrays) silently discard ALL outputs.
     with open("/tmp/alcove-outputs.json", "w") as f:
         json.dump(output, f)
     if not approved:

--- a/.alcove/agents/triage.yml
+++ b/.alcove/agents/triage.yml
@@ -78,7 +78,7 @@ prompt: |
         "candidate_files": ["file1.py", "file2.py"],
         "approach": "how to implement",
         "risks": "what could go wrong",
-        "automatable": True,
+        "automatable": "true",  # must be string "true"/"false" for pipeline condition matching
         "reviewers_needed": ["django", "security"]
     }
     with open("/tmp/alcove-outputs.json", "w") as f:

--- a/.alcove/agents/triage.yml
+++ b/.alcove/agents/triage.yml
@@ -75,12 +75,14 @@ prompt: |
     output = {
         "complexity": "small",  # or "medium" or "large"
         "target_area": "description of affected area",
-        "candidate_files": ["file1.py", "file2.py"],
+        "candidate_files": "file1.py, file2.py",  # comma-separated string, NOT a list
         "approach": "how to implement",
         "risks": "what could go wrong",
-        "automatable": "true",  # must be string "true"/"false" for pipeline condition matching
-        "reviewers_needed": ["django", "security"]
+        "automatable": "true",  # string "true" or "false", NOT a boolean
+        "reviewers_needed": "django, security"  # comma-separated string, NOT a list
     }
+    # ALL values MUST be strings. The pipeline deserializes into map[string]string;
+    # non-string values (booleans, arrays) silently discard ALL outputs.
     with open("/tmp/alcove-outputs.json", "w") as f:
         json.dump(output, f)
     PYEOF

--- a/.alcove/agents/verifier.yml
+++ b/.alcove/agents/verifier.yml
@@ -70,9 +70,10 @@ prompt: |
     verdict = "pass"  # or "fail"
     output = {
         "verdict": verdict,
-        "fixes_required": [],
-        "code_issues": []
+        "fixes_required": "",  # comma-separated descriptions, or empty string if none
+        "code_issues": ""  # comma-separated descriptions, or empty string if none
     }
+    # ALL values MUST be strings. Non-string values (booleans, arrays) silently discard ALL outputs.
     with open("/tmp/alcove-outputs.json", "w") as f:
         json.dump(output, f)
     if verdict == "fail":


### PR DESCRIPTION
## Summary

- All 6 sdlc-pipeline-v2 agent output templates now use string-only values
- Converts arrays to comma-separated strings and booleans to `"true"`/`"false"` strings
- Adds inline comments warning against non-string values

## Why

Alcove's `readOutputArtifact()` in skiff-init deserializes `/tmp/alcove-outputs.json` into `map[string]string`. Any non-string JSON value (boolean, array) causes `json.Unmarshal` to fail, silently discarding **all** outputs — including valid string values. This broke the sdlc-pipeline-v2: triage completed successfully but the plan step's condition (`steps.triage.outputs.automatable == 'true'`) always evaluated false because outputs were never persisted.

Ref: bmbouter/alcove#491 (proper fix on the Alcove side)

## Affected agents

| Agent | Fixed values |
|-------|-------------|
| triage | `candidate_files`, `reviewers_needed` |
| planner-v2 | `verification_commands`, `reviewers_needed` |
| patcher | `fixes_applied`, `too_complex` |
| verifier | `fixes_required`, `code_issues` |
| reviewer-django | `approved`, `issues` |
| reviewer-security | `approved`, `issues` |

## Test plan

- [ ] Re-trigger sdlc-pipeline-v2 on issue #1101 and verify triage→plan→implement progression
- [ ] Verify triage outputs appear in workflow step outputs via Bridge dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Ensure all sdlc-pipeline-v2 agents emit string-only JSON outputs to prevent Alcove output deserialization failures.

Bug Fixes:
- Convert non-string agent output fields (arrays and booleans) to string representations so outputs are reliably persisted across pipeline steps.

Enhancements:
- Document string-only output requirements inline in all affected agent templates to prevent future schema drift.