### PR TITLE
feat: add configurable gunicorn worker count for content pods

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -470,7 +470,7 @@ objects:
           annotations:
             "kubectl.kubernetes.io/default-container": pulp-content
         image: ${IMAGE}:${IMAGE_TAG}
-        command: ['pulpcore-content', '-b', '0.0.0.0:8000', '--max-requests', '${PULP_CONTENT_GUNICORN_MAX_REQUESTS}', '--max-requests-jitter', '${PULP_CONTENT_GUNICORN_MAX_REQUESTS_JITTER}', '--timeout', '${PULP_CONTENT_GUNICORN_TIMEOUT}', '--graceful-timeout', '${PULP_CONTENT_GUNICORN_GRACEFUL_TIMEOUT}', '--access-logfile', '-', '--access-logformat', '%a %t "%r" %s %b "%{Referer}i" "%{User-Agent}i" cache:"%{X-PULP-CACHE}o" artifact_size:"%{X-PULP-ARTIFACT-SIZE}o" rh_org_id:"%{X-RH-ORG-ID}o" x_forwarded_for:"%{X-Forwarded-For}i"']
+        command: ['pulpcore-content', '-b', '0.0.0.0:8000', '--workers', '${PULP_CONTENT_GUNICORN_WORKERS}', '--max-requests', '${PULP_CONTENT_GUNICORN_MAX_REQUESTS}', '--max-requests-jitter', '${PULP_CONTENT_GUNICORN_MAX_REQUESTS_JITTER}', '--timeout', '${PULP_CONTENT_GUNICORN_TIMEOUT}', '--graceful-timeout', '${PULP_CONTENT_GUNICORN_GRACEFUL_TIMEOUT}', '--access-logfile', '-', '--access-logformat', '%a %t "%r" %s %b "%{Referer}i" "%{User-Agent}i" cache:"%{X-PULP-CACHE}o" artifact_size:"%{X-PULP-ARTIFACT-SIZE}o" rh_org_id:"%{X-RH-ORG-ID}o" x_forwarded_for:"%{X-Forwarded-For}i"']
         volumeMounts:
           - name: secret-volume
             mountPath: "/etc/pulp/keys"
@@ -1372,6 +1372,9 @@ parameters:
   - name: PULP_API_GUNICORN_WORKERS
     description: Number of gunicorn workers in the API pods
     value: "1"
+  - name: PULP_CONTENT_GUNICORN_WORKERS
+    description: Number of gunicorn workers in the Content pods
+    value: "2"
   - name: PULP_CONTENT_GUNICORN_MAX_REQUESTS
     description: The maximum number of requests a content worker will process before restarting.
     value: "10000"


### PR DESCRIPTION
The content pod command was missing the --workers flag, unlike the API pod, so worker count could not be tuned per environment. Add the PULP_CONTENT_GUNICORN_WORKERS template parameter (default: 2) and pass it to pulpcore-content via --workers.

ref: https://redhat.atlassian.net/browse/PULP-1361

## Summary by Sourcery

Make the Gunicorn worker count for content pods configurable via a new template parameter and pass it to the pulpcore-content command.

New Features:
- Introduce the PULP_CONTENT_GUNICORN_WORKERS template parameter to control Gunicorn workers for content pods.

Enhancements:
- Update the content pod command to pass the configured worker count to pulpcore-content via the --workers flag.