### PR TITLE
feat: add django-storages and oras-py to agent repo mapping

### DIFF
--- a/.alcove/agents/upgrade-deps/AGENT.md
+++ b/.alcove/agents/upgrade-deps/AGENT.md
@@ -74,10 +74,14 @@ The patch file paths tell you which package it targets:
 - `pulp_file/` → https://github.com/pulp/pulp_file
 - `pulp_npm/` → https://github.com/pulp/pulp_npm
 - `pulp_gem/` → https://github.com/pulp/pulp_gem
+- `oras/` → https://github.com/oras-project/oras-py
+- `storages/` → https://github.com/jschneier/django-storages
 
-Determine the OLD version (from `git show HEAD:pulp_service/requirements.txt`) and the NEW version (from Phase 2).
+Determine the OLD and NEW versions for each patched package:
+- For packages pinned in `requirements.txt`: OLD version from `git show HEAD:pulp_service/requirements.txt`, NEW version from Phase 2.
+- For transitive dependencies (e.g. django-storages): run `pip show {package}` in the dev container BEFORE upgrading to get the OLD version. After Phase 4 installs new packages, run `pip show` again to get the NEW version.
 
-If the package was NOT upgraded, skip the patch — it will still apply cleanly.
+If the package was NOT upgraded (OLD == NEW), skip the patch — it will still apply cleanly.
 
 ### Step 2: Clone and test the patch against both versions
 


### PR DESCRIPTION
## Summary

Adds two third-party repos to the Phase 3 repo mapping:
- `oras/` → https://github.com/oras-project/oras-py (patch 0010)
- `storages/` → https://github.com/jschneier/django-storages (patch 0031)

Also adds instructions for determining versions of transitive dependencies using `pip show` in the dev container before and after upgrading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Expand the dependency upgrade agent documentation to cover additional third-party repositories and clarify how to determine old and new versions for patched packages, including transitive dependencies.

Documentation:
- Document mapping for the oras-py and django-storages repositories in the Phase 3 patch directory layout.
- Clarify instructions for deriving old and new versions of both pinned and transitive dependencies using requirements.txt and pip show during the upgrade process.