### PR TITLE
fix: skip feature service tests and require all tests to pass

### DIFF
--- a/.alcove/agents/upgrade-deps/AGENT.md
+++ b/.alcove/agents/upgrade-deps/AGENT.md
@@ -268,7 +268,9 @@ This runs:
 5. pulp_npm tests (test_pull_through_install)
 6. pulp_service functional tests
 
-If tests fail:
+Note: two feature service tests (`test_forbidden_feature_service`, `test_entitled_feature_service`) are excluded because they require a Red Hat mTLS certificate and access to `feature.stage.api.redhat.com`, which are not available in the dev container.
+
+ALL tests MUST pass. If any test fails, the workflow is NOT complete. Do NOT proceed to Phase 7 with failing tests. Instead:
 - Analyze the failure to determine if it's caused by a patch, by `pulp_service/` code, or by an upstream API change
 - Fix the patch or code accordingly (edit files on /workspace — they're shared)
 - Restart services if needed and re-run the failing tests with `pulp-test --pyargs {test_spec}`

--- a/dev-container/scripts/pulp-test
+++ b/dev-container/scripts/pulp-test
@@ -121,7 +121,10 @@ run_tests() {
 
     echo "--- Test 6/6: pulp_service functional ---"
     pytest -v -r sx --color=yes --pyargs pulp_service.tests.functional \
-        -m 'not parallel' || FAILED=$((FAILED + 1))
+        -m 'not parallel' \
+        --deselect pulp_service/tests/functional/test_feature_service.py::test_forbidden_feature_service \
+        --deselect pulp_service/tests/functional/test_feature_service.py::test_entitled_feature_service \
+        || FAILED=$((FAILED + 1))
 
     echo "=== Results: $((6 - FAILED))/6 test suites passed ==="
     [ "$FAILED" -eq 0 ]


### PR DESCRIPTION
## Summary

- **pulp-test**: deselects `test_forbidden_feature_service` and `test_entitled_feature_service` (require mTLS cert + access to `feature.stage.api.redhat.com`)
- **AGENT.md**: ALL tests must pass — the agent cannot proceed to commit with failing tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Clarify test requirements for the upgrade-deps agent and document the exclusion of specific feature service tests in the dev container environment.

Documentation:
- Document the exclusion of two feature service tests that require mTLS and external access in the dev container.
- Clarify that all remaining tests must pass before proceeding to the next phase of the upgrade-deps workflow.