### PR TITLE
fix: set pulp-api --max-requests to 5000 to prevent OOM

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -294,7 +294,7 @@ objects:
           annotations:
             "kubectl.kubernetes.io/default-container": pulp-api
         image: ${IMAGE}:${IMAGE_TAG}
-        command: ['pulpcore-api', '-b', '0.0.0.0:8000', '--timeout', '${PULP_API_GUNICORN_TIMEOUT}', '--workers', '${PULP_API_GUNICORN_WORKERS}', '--access-logfile', '-', '--access-logformat', '(pulp [%({correlation-id}o)s]: %(h)s %(l)s user:%({REMOTE_USER}e)s org_id:%({ORG_ID}e)s %(t)s "%(r)s" %(s)s %(b)s "%(f)s" "%(a)s" %(M)s x_forwarded_for:"%({X_FORWARDED_FOR}e)s")']
+        command: ['pulpcore-api', '-b', '0.0.0.0:8000', '--timeout', '${PULP_API_GUNICORN_TIMEOUT}', '--max-requests', '${PULP_API_GUNICORN_MAX_REQUESTS}', '--max-requests-jitter', '${PULP_API_GUNICORN_MAX_REQUESTS_JITTER}', '--workers', '${PULP_API_GUNICORN_WORKERS}', '--access-logfile', '-', '--access-logformat', '(pulp [%({correlation-id}o)s]: %(h)s %(l)s user:%({REMOTE_USER}e)s org_id:%({ORG_ID}e)s %(t)s "%(r)s" %(s)s %(b)s "%(f)s" "%(a)s" %(M)s x_forwarded_for:"%({X_FORWARDED_FOR}e)s")']
         volumeMounts:
         - name: secret-volume
           mountPath: "/etc/pulp/keys"
@@ -1369,6 +1369,12 @@ parameters:
   - name: PULP_API_GUNICORN_TIMEOUT
     description: Workers silent for more than this many seconds are killed and restarted.
     value: "1800"
+  - name: PULP_API_GUNICORN_MAX_REQUESTS
+    description: The maximum number of requests an API worker will process before restarting.
+    value: "5000"
+  - name: PULP_API_GUNICORN_MAX_REQUESTS_JITTER
+    description: The maximum jitter to add to the API max_requests setting for each worker.
+    value: "500"
   - name: PULP_API_GUNICORN_WORKERS
     description: Number of gunicorn workers in the API pods
     value: "1"


### PR DESCRIPTION
## Problem

After removing the explicit `--max-requests=20` override (which was causing SLI histogram corruption), pulp-api workers rely on pulpcore's default. However, there is a memory leak (~60 MiB/hr) that causes workers to grow from ~850 MiB to 3.8+ GiB within 24 hours, resulting in OOMKilled events (observed on pod `pulp-api-5864b7b559-zfczh` at 2026-04-29T00:01:41Z).

## Fix

Set `--max-requests=5000` (jitter 500) explicitly on the pulp-api command. This:

- **Prevents OOM**: Workers recycle well before hitting the 5120 MiB limit
- **Preserves SLI accuracy**: Counter values reach ~5000 before reset, making coincidental value matches (the root cause of SLI > 1) statistically negligible compared to the previous value of 20

## Test plan

- [ ] Deploy to stage — monitor memory usage, confirm no OOM over 24h
- [ ] Deploy to production — confirm `APIWriteRequestLatency` SLI stays ≤ 1 and no OOMKilled events

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Configure pulp-api Gunicorn workers to recycle after a bounded number of requests to mitigate memory growth and OOM events while preserving metrics accuracy.

Enhancements:
- Add configurable max-requests and jitter settings to the pulp-api Gunicorn command in the ClowdApp deployment manifest.
- Introduce new PULP_API_GUNICORN_MAX_REQUESTS and PULP_API_GUNICORN_MAX_REQUESTS_JITTER parameters with defaults tuned to balance memory usage and SLI accuracy.