### PR TITLE
fix: parse JIRA_API_TOKEN as email:token composite credential

### DIFF
--- a/.alcove/agents/splunk-analyzer.yml
+++ b/.alcove/agents/splunk-analyzer.yml
@@ -10,7 +10,6 @@ executable:
     SPLUNK_INSECURE_SKIP_VERIFY: "true"
     SPLUNK_URL: "https://splunk-api.corp.redhat.com:8089/"
     JIRA_URL: "https://redhat.atlassian.net/"
-    JIRA_USERNAME: "dkliban+pulp-sre-agent@redhat.com"
 
 timeout: 1800
 enforcement_mode: monitor

--- a/tools/agents/agent-splunk/README.md
+++ b/tools/agents/agent-splunk/README.md
@@ -18,8 +18,7 @@ An AI agent that queries Splunk for 5xx errors, analyzes them using an LLM (Clau
 | `SPLUNK_URL` | Splunk instance URL |
 | `SPLUNK_TOKEN` | Splunk auth token |
 | `JIRA_URL` | Jira instance URL (e.g. `https://redhat.atlassian.net`) |
-| `JIRA_USERNAME` | Jira username (email) for API authentication |
-| `JIRA_API_TOKEN` | Jira API token for authentication |
+| `JIRA_API_TOKEN` | Jira credentials in `email:api_token` format (e.g. `user@company.com:ATATT3x...`) |
 
 ## Usage
 

--- a/tools/agents/agent-splunk/main.go
+++ b/tools/agents/agent-splunk/main.go
@@ -115,10 +115,13 @@ func run() error {
 
 	// --- Jira (native tool) ---
 	if jiraURL := os.Getenv("JIRA_URL"); jiraURL != "" {
-		jiraUsername := os.Getenv("JIRA_USERNAME")
-		jiraToken := os.Getenv("JIRA_API_TOKEN")
-		if jiraUsername == "" || jiraToken == "" {
-			return fmt.Errorf("JIRA_USERNAME and JIRA_API_TOKEN are required when JIRA_URL is set")
+		jiraCredential := os.Getenv("JIRA_API_TOKEN")
+		if jiraCredential == "" {
+			return fmt.Errorf("JIRA_API_TOKEN is required when JIRA_URL is set (format: email:api_token)")
+		}
+		jiraUsername, jiraToken, found := strings.Cut(jiraCredential, ":")
+		if !found || jiraUsername == "" || jiraToken == "" {
+			return fmt.Errorf("JIRA_API_TOKEN must be in email:api_token format")
 		}
 		jiraClient := jira.NewClient(jiraURL, jiraUsername, jiraToken)
 		jiraTools := jiraClient.RegisterTools(mcpMgr)


### PR DESCRIPTION
Alcove now stores Jira credentials in email:api_token format. Parse JIRA_API_TOKEN by splitting on the first colon to extract the email (used as username) and token, removing the need for a separate JIRA_USERNAME env var.

 ref: https://redhat.atlassian.net/browse/PULP-1671