### PR TITLE
Update agent-splunk release version in alcove agent

### DIFF
--- a/.alcove/agents/splunk-analyzer.yml
+++ b/.alcove/agents/splunk-analyzer.yml
@@ -4,7 +4,7 @@ description: |
   Runs as a pre-compiled agent binary from GitHub Releases.
 
 executable:
-  url: https://github.com/pulp/pulp-service/releases/download/agent-splunk-20260423-b5d37e0/agent-splunk
+  url: https://github.com/pulp/pulp-service/releases/download/agent-splunk-20260429-7055927/agent-splunk
   args: ["--model", "claude-opus-4-6"]
   env:
     SPLUNK_INSECURE_SKIP_VERIFY: "true"


### PR DESCRIPTION
## Summary by Sourcery

Chores:
- Bump the agent-splunk GitHub release URL in the Splunk analyzer Alcove agent config.