### PR TITLE
reducing the number of requests due to oom kills

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -1371,7 +1371,7 @@ parameters:
     value: "1800"
   - name: PULP_API_GUNICORN_MAX_REQUESTS
     description: The maximum number of requests an API worker will process before restarting.
-    value: "5000"
+    value: "2500"
   - name: PULP_API_GUNICORN_MAX_REQUESTS_JITTER
     description: The maximum jitter to add to the API max_requests setting for each worker.
     value: "500"
@@ -1383,7 +1383,7 @@ parameters:
     value: "2"
   - name: PULP_CONTENT_GUNICORN_MAX_REQUESTS
     description: The maximum number of requests a content worker will process before restarting.
-    value: "10000"
+    value: "5000"
   - name: PULP_CONTENT_GUNICORN_MAX_REQUESTS_JITTER
     description: The maximum jitter to add to the Content max_requests setting for each worker.
     value: "500"


### PR DESCRIPTION
We are still seeing OOM kills with the new settings, decreasing the count by half to see if this is good enough. We can slowly increase afterwards.

## Summary by Sourcery

Reduce Gunicorn max_requests thresholds for Pulp API and content workers to mitigate OOM kills under load.

Deployment:
- Lower the PULP_API_GUNICORN_MAX_REQUESTS value from 5000 to 2500 to reduce worker memory growth.
- Lower the PULP_CONTENT_GUNICORN_MAX_REQUESTS value from 10000 to 5000 to reduce worker memory growth.