### PR TITLE
SDLC pipeline: claim issue before starting work

### DIFF
--- a/.alcove/workflows/sdlc-pipeline-v2.yml
+++ b/.alcove/workflows/sdlc-pipeline-v2.yml
@@ -12,11 +12,22 @@ trigger:
     labels: [agentic-sdlc-v2]
 
 workflow:
+  # Phase 0: Claim — assign the bot and remove the trigger label.
+  - id: claim-issue
+    type: bridge
+    action: update-issue
+    inputs:
+      repo: pulp/pulp-service
+      issue: "{{trigger.issue_number}}"
+      add_assignees: ["alcove-bot"]
+      remove_labels: ["agentic-sdlc-v2"]
+
   # Phase 1: Triage — assess issue feasibility and complexity.
   # Exits with failure if the issue is not automatable, halting the pipeline.
   - id: triage
     type: agent
     agent: Issue Triage
+    depends: "claim-issue.Succeeded"
     inputs:
       issue_number: "{{trigger.issue_number}}"
       issue_title: "{{trigger.issue_title}}"


### PR DESCRIPTION
Adds claim-issue bridge step using update-issue action. Requires Alcove v0.42.1+.

## Summary by Sourcery

Claim the issue in the SDLC pipeline before running the triage agent.

New Features:
- Introduce a claim-issue bridge step that assigns the issue to alcove-bot and removes the SDLC trigger label before pipeline execution begins.

Enhancements:
- Make the triage agent step depend on the successful completion of the claim-issue step.