### PR TITLE
livez endpoint shouldn't relly on db

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -191,6 +191,9 @@ RUN patch -p1 -d /usr/local/lib/pulp/lib/python${PYTHON_VERSION}/site-packages <
 COPY images/assets/patches/0054-defer-contentid-cleanup-old-versions.patch /tmp/
 RUN patch -p1 -d /usr/local/lib/pulp/lib/python${PYTHON_VERSION}/site-packages < /tmp/0054-defer-contentid-cleanup-old-versions.patch
 
+COPY images/assets/patches/0055-decouple-livez-from-db.patch /tmp/
+RUN patch -p1 -d /usr/local/lib/pulp/lib/python${PYTHON_VERSION}/site-packages < /tmp/0055-decouple-livez-from-db.patch
+
 RUN mkdir /licenses
 COPY LICENSE /licenses/LICENSE
 

--- a/images/assets/patches/0055-decouple-livez-from-db.patch
+++ b/images/assets/patches/0055-decouple-livez-from-db.patch
@@ -1,0 +1,43 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Pulp Service <pulp-service@redhat.com>
+Date: Sun, 4 May 2026 00:00:00 +0000
+Subject: [PATCH] Decouple /livez endpoint from the database
+
+The LivezView itself has no DB calls, but DomainMiddleware.process_view
+runs Domain.objects.get() on every request, including /livez/. This
+causes the liveness probe to fail whenever the database is unavailable,
+defeating its purpose.
+
+Add a skip_domain_middleware marker to LivezView and honour it in
+DomainMiddleware so the probe depends only on the gunicorn worker being
+alive.
+---
+ pulpcore/app/views/status.py | 3 +++
+ pulpcore/middleware.py       | 5 +++++
+ 2 files changed, 8 insertions(+)
+
+diff --git a/pulpcore/app/views/status.py b/pulpcore/app/views/status.py
+--- a/pulpcore/app/views/status.py
++++ b/pulpcore/app/views/status.py
+@@ -143,6 +143,9 @@ class LivezView(APIView):
+     # allow anyone to access the liveness api
+     authentication_classes = []
+     permission_classes = []
++    # Skip domain DB lookup so this probe stays independent of the database
++    skip_domain_middleware = True
+ 
+     @extend_schema(
+         summary="Inspect liveness of Pulp's REST API.",
+diff --git a/pulpcore/middleware.py b/pulpcore/middleware.py
+--- a/pulpcore/middleware.py
++++ b/pulpcore/middleware.py
+@@ -39,6 +39,11 @@ class DomainMiddleware:
+     def process_view(self, request, view_func, view_args, view_kwargs):
+         """Remove the domain name if present, called right before view_func is called."""
++        view_class = getattr(view_func, "view_class", None) or getattr(view_func, "cls", None)
++        if view_class and getattr(view_class, "skip_domain_middleware", False):
++            view_kwargs.pop("pulp_domain", None)
++            return None
+         domain_name = view_kwargs.pop("pulp_domain", "default")
+         try:
+             domain = Domain.objects.get(name=domain_name)

--- a/images/assets/patches/0055-decouple-livez-from-db.patch
+++ b/images/assets/patches/0055-decouple-livez-from-db.patch
@@ -12,14 +12,15 @@ Add a skip_domain_middleware marker to LivezView and honour it in
 DomainMiddleware so the probe depends only on the gunicorn worker being
 alive.
 ---
- pulpcore/app/views/status.py | 3 +++
- pulpcore/middleware.py       | 5 +++++
- 2 files changed, 8 insertions(+)
+ pulpcore/app/views/status.py | 2 ++
+ pulpcore/middleware.py       | 4 ++++
+ 2 files changed, 6 insertions(+)
 
 diff --git a/pulpcore/app/views/status.py b/pulpcore/app/views/status.py
+index 77a448693..7d494e272 100644
 --- a/pulpcore/app/views/status.py
 +++ b/pulpcore/app/views/status.py
-@@ -143,6 +143,9 @@ class LivezView(APIView):
+@@ -145,6 +145,8 @@ class LivezView(APIView):
      # allow anyone to access the liveness api
      authentication_classes = []
      permission_classes = []
@@ -29,9 +30,11 @@ diff --git a/pulpcore/app/views/status.py b/pulpcore/app/views/status.py
      @extend_schema(
          summary="Inspect liveness of Pulp's REST API.",
 diff --git a/pulpcore/middleware.py b/pulpcore/middleware.py
+index 0a778f0c0..dd6c98a6f 100644
 --- a/pulpcore/middleware.py
 +++ b/pulpcore/middleware.py
-@@ -39,6 +39,11 @@ class DomainMiddleware:
+@@ -38,6 +38,10 @@ class DomainMiddleware:
+ 
      def process_view(self, request, view_func, view_args, view_kwargs):
          """Remove the domain name if present, called right before view_func is called."""
 +        view_class = getattr(view_func, "view_class", None) or getattr(view_func, "cls", None)


### PR DESCRIPTION
## Summary by Sourcery

Apply a new patch to decouple the service liveness endpoint from database availability.

Bug Fixes:
- Prevent the /livez health endpoint from failing when the database is unavailable by decoupling it from DB checks.

Enhancements:
- Include a new Pulp patch in the Docker image build to adjust liveness probe behavior.