### PR TITLE
fix: install packaging module before running swamp workflow

### DIFF
--- a/.alcove/agents/upgrade-deps/AGENT.md
+++ b/.alcove/agents/upgrade-deps/AGENT.md
@@ -57,10 +57,12 @@ The `/workspace` directory is a shared volume between Skiff and the dev containe
 
 Do NOT try to analyze or regenerate patches manually. Use the `pulp-upgrade-workflow` swamp workflow which automates patch testing, regeneration, and upstreamed detection deterministically.
 
-### Step 1: Install swamp
+### Step 1: Install swamp and dependencies
 
 ```bash
 curl -fsSL https://swamp-club.com/install.sh | sh
+export PATH="$HOME/.swamp/bin:$PATH"
+pip install packaging
 ```
 
 ### Step 2: Clone the upgrade workflow


### PR DESCRIPTION
## Summary

The swamp workflow failed because `from packaging.version import Version` was not available. Added `pip install packaging` and `export PATH` to Phase 3 Step 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Update the upgrade-deps agent instructions to ensure the swamp workflow has required tooling available.

Documentation:
- Document exporting the swamp binary directory to PATH when installing swamp in the upgrade-deps agent workflow.
- Document installing the Python packaging module as a dependency before running the swamp-based upgrade workflow.