### PR TITLE
fix: batch-delete published artifacts during repo/version deletion

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -194,6 +194,9 @@ RUN patch -p1 -d /usr/local/lib/pulp/lib/python${PYTHON_VERSION}/site-packages <
 COPY images/assets/patches/0055-decouple-livez-from-db.patch /tmp/
 RUN patch -p1 -d /usr/local/lib/pulp/lib/python${PYTHON_VERSION}/site-packages < /tmp/0055-decouple-livez-from-db.patch
 
+COPY images/assets/patches/0056-repo-publication-delete.patch /tmp/
+RUN patch -p1 -d /usr/local/lib/pulp/lib/python${PYTHON_VERSION}/site-packages < /tmp/0056-repo-publication-delete.patch
+
 RUN mkdir /licenses
 COPY LICENSE /licenses/LICENSE
 

--- a/images/assets/patches/0056-repo-publication-delete.patch
+++ b/images/assets/patches/0056-repo-publication-delete.patch
@@ -1,0 +1,64 @@
+diff --git a/pulpcore/app/models/repository.py b/pulpcore/app/models/repository.py
+index b9f4b8985..d7eb80f34 100644
+--- a/pulpcore/app/models/repository.py
++++ b/pulpcore/app/models/repository.py
+@@ -484,20 +484,25 @@ class Repository(MasterModel):
+         #
+         # [0] https://docs.djangoproject.com/en/4.2/ref/models/querysets/#delete
+         with transaction.atomic():
+-            repo_versions = RepositoryVersion.objects.filter(repository=self)
+             repo_contents = RepositoryContent.objects.filter(repository=self)
+-            publications = Publication.objects.filter(
+-                repository_version__in=repo_versions.values_list("pk", flat=True)
+-            )
+-            published_artifacts = PublishedArtifact.objects.filter(
+-                publication__in=publications.values_list("pk", flat=True)
++
++            # Materialize publication PKs to avoid nested IN subqueries that
++            # produce poor execution plans in PostgreSQL.
++            publication_pks = list(
++                Publication.objects.filter(
++                    repository_version__repository=self,
++                ).values_list("pk", flat=True)
+             )
+ 
+-            # PublishedArtifact and RepositoryContent are the two most numerous object types
+-            # PublishedMetadata would be trickier to delete because it's a Content subclass
+-            # that is ignored by orphan cleanup, so to delete those in this way would require
+-            # manual intervention
+-            published_artifacts._raw_delete(published_artifacts.db)
++            # PublishedArtifact and RepositoryContent are the two most numerous object types.
++            # Delete published artifacts in batches to limit per-statement WAL size.
++            batch_size = 500
++            for start in range(0, len(publication_pks), batch_size):
++                batch = publication_pks[start : start + batch_size]
++                PublishedArtifact.objects.filter(
++                    publication_id__in=batch
++                )._raw_delete(PublishedArtifact.objects.db)
++
+             repo_contents._raw_delete(repo_contents.db)
+ 
+             # Anything not deleted manually above will be caught up in Django cascade. Deleting
+@@ -1318,6 +1323,22 @@ class RepositoryVersion(BaseModel):
+                 if base_paths:
+                     Cache().delete(base_key=cache_key(base_paths))
+ 
++            from .publication import Publication, PublishedArtifact  # circular import avoidance
++
++            # Pre-delete PublishedArtifacts outside the select_for_update block to avoid
++            # holding RepositoryContent row locks during the slow bulk delete.
++            publication_pks = list(
++                Publication.objects.filter(
++                    repository_version=self,
++                ).values_list("pk", flat=True)
++            )
++            batch_size = 500
++            for start in range(0, len(publication_pks), batch_size):
++                batch = publication_pks[start : start + batch_size]
++                PublishedArtifact.objects.filter(
++                    publication_id__in=batch
++                )._raw_delete(PublishedArtifact.objects.db)
++
+             # Handle the manipulation of the repository version content and its final deletion in
+             # the same transaction.
+             with transaction.atomic():


### PR DESCRIPTION
Patch pulpcore to avoid slow nested IN subqueries and excessive WAL growth when deleting repositories or repository versions with many publications. Materializes publication PKs upfront and deletes PublishedArtifacts in batches of 500.

ref: https://redhat.atlassian.net/browse/PULP-1361

## Summary by Sourcery

Build:
- Add application of the 0056-repo-publication-delete pulpcore patch in the Docker image build.