### PR TITLE
fix: disable gunicorn worker recycling in dev container

### DIFF
--- a/dev-container/Dockerfile
+++ b/dev-container/Dockerfile
@@ -87,7 +87,9 @@ COPY images/assets/wait_on_database_migrations.sh /usr/bin/wait_on_database_migr
 COPY images/assets/set_init_password.sh /usr/bin/set_init_password.sh
 COPY images/assets/add_signing_service.sh /usr/bin/add_signing_service.sh
 COPY images/assets/pulp-api /usr/bin/pulp-api
+RUN sed -i 's/--access-logfile -/--access-logfile - --max-requests 0/' /usr/bin/pulp-api
 COPY images/assets/pulp-content /usr/bin/pulp-content
+RUN sed -i 's/--access-logfile -/--access-logfile - --max-requests 0/' /usr/bin/pulp-content
 COPY images/assets/pulp-resource-manager /usr/bin/pulp-resource-manager
 COPY images/assets/pulp-worker /usr/bin/pulp-worker
 COPY images/assets/log_middleware.py /usr/bin/log_middleware.py


### PR DESCRIPTION
## Summary

Pulpcore sets `max_requests=10000` by default, causing gunicorn to kill and restart workers after 10000 requests. During upgrade agent test runs, this causes `Connection refused` errors when the content app worker gets recycled mid-test (the alcove sessions showed 1/6 test suites passing due to this).

Adds `--max-requests 0` to both `pulp-api` and `pulp-content` startup scripts in the dev container Dockerfile to disable worker recycling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)