### PR TITLE
style: apply ruff format (line-length 120, py311)

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# ruff format adoption (line-length 100 -> 120, py36/py37 -> py311)
+6a2a194f4818cac64528836c973711890c826cc7

--- a/pulp_service/pulp_service/app/admin.py
+++ b/pulp_service/pulp_service/app/admin.py
@@ -19,36 +19,36 @@ from pulpcore.plugin.models import Domain, Group
 from pulpcore.app.models import Task
 from pulp_service.app.constants import CONTENT_SOURCES_LABEL_NAME
 
-USERNAME_PATTERN = r'^[\w.@+=/\-|]+$'
+USERNAME_PATTERN = r"^[\w.@+=/\-|]+$"
 USERNAME_ERROR_MSG = "Username can only contain letters, numbers, and these special characters: @, ., +, -, =, /, _, |"
-USERNAME_HELP_TEXT = "Required. 150 characters or fewer. Letters, numbers, and these special characters: @, ., +, -, =, /, _, |"
-
-
-# Override Django's username validator
-pulp_username_validator = RegexValidator(
-    USERNAME_PATTERN,
-    USERNAME_ERROR_MSG,
-    'invalid'
+USERNAME_HELP_TEXT = (
+    "Required. 150 characters or fewer. Letters, numbers, and these special characters: @, ., +, -, =, /, _, |"
 )
 
 
+# Override Django's username validator
+pulp_username_validator = RegexValidator(USERNAME_PATTERN, USERNAME_ERROR_MSG, "invalid")
+
+
 # Apply the new validator to the User model
-User._meta.get_field('username').validators = [pulp_username_validator]
+User._meta.get_field("username").validators = [pulp_username_validator]
 # Update the help_text as well
-User._meta.get_field('username').help_text = USERNAME_HELP_TEXT
+User._meta.get_field("username").help_text = USERNAME_HELP_TEXT
+
 
 # Custom/Pulp forms to allow additional characters
 class PulpUserFormMixin:
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         # Override help_text in the form field
-        self.fields['username'].help_text = USERNAME_HELP_TEXT
-        
+        self.fields["username"].help_text = USERNAME_HELP_TEXT
+
     def clean_username(self):
-        username = self.cleaned_data['username']
+        username = self.cleaned_data["username"]
         if not re.match(USERNAME_PATTERN, username):
             raise forms.ValidationError(USERNAME_ERROR_MSG)
         return username
+
 
 class PulpUserCreationForm(PulpUserFormMixin, UserCreationForm):
     pass
@@ -66,38 +66,38 @@ class PulpUserAdmin(HijackUserAdminMixin, UserAdmin):
 class PulpGroupForm(forms.ModelForm):
     users = forms.ModelMultipleChoiceField(
         queryset=User.objects.all(),
-        widget=admin.widgets.FilteredSelectMultiple('Users', False),
+        widget=admin.widgets.FilteredSelectMultiple("Users", False),
         required=False,
-        help_text='Select users to add to this group.'
+        help_text="Select users to add to this group.",
     )
 
     class Meta:
         model = Group
-        fields = ['name']
+        fields = ["name"]
 
     def __init__(self, *args, **kwargs):
         # Extract the request object if passed
-        self.request = kwargs.pop('request', None)
+        self.request = kwargs.pop("request", None)
         super().__init__(*args, **kwargs)
 
         if self.instance.pk:
             # Existing group - populate with current members
-            self.fields['users'].initial = self.instance.user_set.all()
+            self.fields["users"].initial = self.instance.user_set.all()
         elif self.request and self.request.user.is_authenticated:
             # New group - prepopulate with current user
-            self.fields['users'].initial = [self.request.user.pk]
+            self.fields["users"].initial = [self.request.user.pk]
             # Store the current user for validation
             self._current_user = self.request.user
 
     def clean_users(self):
-        users = self.cleaned_data.get('users')
+        users = self.cleaned_data.get("users")
 
         # For new groups, ensure the creating user is included (unless they're a superuser)
-        if not self.instance.pk and hasattr(self, '_current_user'):
+        if not self.instance.pk and hasattr(self, "_current_user"):
             if not self._current_user.is_superuser and self._current_user not in users:
                 raise ValidationError(
-                    f'You must include yourself ({self._current_user.username}) in the group members. '
-                    'This ensures you maintain access to the group after creation.'
+                    f"You must include yourself ({self._current_user.username}) in the group members. "
+                    "This ensures you maintain access to the group after creation."
                 )
 
         return users
@@ -106,7 +106,7 @@ class PulpGroupForm(forms.ModelForm):
         group = super().save(commit=False)
 
         def save_m2m():
-            group.user_set.set(self.cleaned_data['users'])
+            group.user_set.set(self.cleaned_data["users"])
 
         if commit:
             group.save()
@@ -119,7 +119,7 @@ class PulpGroupForm(forms.ModelForm):
 
 class PulpGroupAdmin(GroupAdmin):
     form = PulpGroupForm
-    fields = ('name', 'users')  # Show name and users fields
+    fields = ("name", "users")  # Show name and users fields
 
     def get_queryset(self, request):
         """
@@ -132,7 +132,7 @@ class PulpGroupAdmin(GroupAdmin):
 
         # Regular users can only see their own groups
         user_groups = request.user.groups.all()
-        return qs.filter(pk__in=user_groups.values_list('pk', flat=True))
+        return qs.filter(pk__in=user_groups.values_list("pk", flat=True))
 
     def has_change_permission(self, request, obj=None):
         """
@@ -179,12 +179,12 @@ class PulpGroupAdmin(GroupAdmin):
         if not request.user.is_superuser:
             # Non-superusers can see all users in the form
             # but can only save groups they belong to (checked in has_change_permission)
-            form_class.base_fields['users'].queryset = User.objects.all().order_by('username')
+            form_class.base_fields["users"].queryset = User.objects.all().order_by("username")
 
         # Create a wrapper to inject request into form instantiation
         class FormWithRequest(form_class):
             def __init__(self, *args, **form_kwargs):
-                form_kwargs['request'] = request
+                form_kwargs["request"] = request
                 super().__init__(*args, **form_kwargs)
 
         return FormWithRequest
@@ -195,12 +195,14 @@ class PulpGroupAdmin(GroupAdmin):
         """
         return request.user.is_authenticated and request.user.is_active
 
+
 class PulpAuthenticationForm(AuthenticationForm):
     def confirm_login_allowed(self, user):
         """
         This override allows non-staff users to login into pulp-mgmt.
         """
         super().confirm_login_allowed(user)
+
 
 class PulpAdminSite(admin.AdminSite):
     site_header = "Pulp administration"
@@ -214,8 +216,8 @@ class PulpAdminSite(admin.AdminSite):
 
 
 class ContentSourceDomainFilter(admin.SimpleListFilter):
-    title = 'ContentSource Domains'
-    parameter_name = 'content_source_filter'
+    title = "ContentSource Domains"
+    parameter_name = "content_source_filter"
 
     def lookups(self, request, model_admin):
         return [
@@ -238,14 +240,14 @@ class ContentSourceDomainFilter(admin.SimpleListFilter):
 class DomainOrgForm(forms.ModelForm):
     class Meta:
         model = DomainOrg
-        fields = '__all__'
+        fields = "__all__"
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         # Make user and group field optional since it can be null
-        self.fields['org_id'].required = False
-        self.fields['user'].required = False
-        self.fields['group'].required = False
+        self.fields["org_id"].required = False
+        self.fields["user"].required = False
+        self.fields["group"].required = False
 
 
 class DomainOrgAdmin(admin.ModelAdmin):
@@ -261,11 +263,11 @@ class DomainOrgAdmin(admin.ModelAdmin):
 
         links = []
         for domain in domains:
-            url = reverse('admin:core_domain_change', args=[domain.pk])
+            url = reverse("admin:core_domain_change", args=[domain.pk])
             label = domain.name if domain.name else "Unnamed domain"
             links.append(format_html('<a href="{}">{}</a>', url, label))
 
-        return format_html(', '.join(links))
+        return format_html(", ".join(links))
 
     def get_queryset(self, request):
         """
@@ -370,7 +372,7 @@ class DomainOrgAdmin(admin.ModelAdmin):
 class DomainAdminForm(forms.ModelForm):
     class Meta:
         model = Domain
-        fields = '__all__'
+        fields = "__all__"
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -399,7 +401,7 @@ class DomainAdmin(admin.ModelAdmin):
 
         links = []
         for domain_org in domain_orgs:
-            url = reverse('myadmin:service_domainorg_change', args=[domain_org.pk])
+            url = reverse("myadmin:service_domainorg_change", args=[domain_org.pk])
             parts = []
             if domain_org.org_id:
                 parts.append(f"Org: {domain_org.org_id}")
@@ -411,7 +413,7 @@ class DomainAdmin(admin.ModelAdmin):
             label = " | ".join(parts) if parts else f"DomainOrg #{domain_org.pk}"
             links.append(format_html('<a href="{}">{}</a>', url, label))
 
-        return format_html('<br>'.join(links))
+        return format_html("<br>".join(links))
 
     def domain_orgs_detail(self, obj):
         """Display related DomainOrg entries with links in detail view."""
@@ -421,7 +423,7 @@ class DomainAdmin(admin.ModelAdmin):
 
         links = []
         for domain_org in domain_orgs:
-            url = reverse('myadmin:service_domainorg_change', args=[domain_org.pk])
+            url = reverse("myadmin:service_domainorg_change", args=[domain_org.pk])
             parts = []
             if domain_org.org_id:
                 parts.append(f"Org: {domain_org.org_id}")
@@ -433,7 +435,7 @@ class DomainAdmin(admin.ModelAdmin):
             label = " | ".join(parts) if parts else f"DomainOrg #{domain_org.pk}"
             links.append(format_html('<a href="{}">{}</a>', url, label))
 
-        return format_html('<br>'.join(links))
+        return format_html("<br>".join(links))
 
     def get_queryset(self, request):
         """
@@ -508,6 +510,7 @@ class TaskAdmin(admin.ModelAdmin):
     Admin interface for Task model - restricted to superusers only.
     Only the state field is editable.
     """
+
     list_display = ["pk", "name", "state", "domain_name", "pulp_created"]
     list_filter = ["state", "pulp_domain", "pulp_created", "started_at"]
     search_fields = ["name", "pk"]
@@ -545,27 +548,27 @@ class TaskAdmin(admin.ModelAdmin):
     @admin.display(description="Created")
     def pulp_created_display(self, obj):
         """Display pulp_created with full precision."""
-        return obj.pulp_created.strftime('%Y-%m-%d %H:%M:%S.%f %Z') if obj.pulp_created else "-"
+        return obj.pulp_created.strftime("%Y-%m-%d %H:%M:%S.%f %Z") if obj.pulp_created else "-"
 
     @admin.display(description="Last Updated")
     def pulp_last_updated_display(self, obj):
         """Display pulp_last_updated with full precision."""
-        return obj.pulp_last_updated.strftime('%Y-%m-%d %H:%M:%S.%f %Z') if obj.pulp_last_updated else "-"
+        return obj.pulp_last_updated.strftime("%Y-%m-%d %H:%M:%S.%f %Z") if obj.pulp_last_updated else "-"
 
     @admin.display(description="Unblocked At")
     def unblocked_at_display(self, obj):
         """Display unblocked_at with full precision."""
-        return obj.unblocked_at.strftime('%Y-%m-%d %H:%M:%S.%f %Z') if obj.unblocked_at else "-"
+        return obj.unblocked_at.strftime("%Y-%m-%d %H:%M:%S.%f %Z") if obj.unblocked_at else "-"
 
     @admin.display(description="Started At")
     def started_at_display(self, obj):
         """Display started_at with full precision."""
-        return obj.started_at.strftime('%Y-%m-%d %H:%M:%S.%f %Z') if obj.started_at else "-"
+        return obj.started_at.strftime("%Y-%m-%d %H:%M:%S.%f %Z") if obj.started_at else "-"
 
     @admin.display(description="Finished At")
     def finished_at_display(self, obj):
         """Display finished_at with full precision."""
-        return obj.finished_at.strftime('%Y-%m-%d %H:%M:%S.%f %Z') if obj.finished_at else "-"
+        return obj.finished_at.strftime("%Y-%m-%d %H:%M:%S.%f %Z") if obj.finished_at else "-"
 
     def has_view_permission(self, request, obj=None):
         """Only superusers can view tasks."""

--- a/pulp_service/pulp_service/app/authentication.py
+++ b/pulp_service/pulp_service/app/authentication.py
@@ -14,7 +14,6 @@ _logger = logging.getLogger(__name__)
 
 
 class RHServiceAccountCertAuthentication(JSONHeaderRemoteAuthentication):
-
     header = "HTTP_X_RH_IDENTITY"
     jq_filter = ".identity.x509.subject_dn"
 
@@ -23,12 +22,9 @@ class RHServiceAccountCertAuthentication(JSONHeaderRemoteAuthentication):
 
 
 class RHTermsBasedRegistryAuthentication(JSONHeaderRemoteAuthentication):
-
     header = "HTTP_X_RH_IDENTITY"
     # Combines org_id with username - falls back to "|username" if org_id is missing
-    jq_filter = (
-        '.identity | if .user.username then "\(.org_id // "")|\(.user.username)" else null end'
-    )
+    jq_filter = '.identity | if .user.username then "\(.org_id // "")|\(.user.username)" else null end'
 
     def authenticate_header(self, request):
         return "Bearer"
@@ -52,7 +48,7 @@ class TurnpikeTermsBasedRegistryAuthentication(JSONHeaderRemoteAuthentication):
     jq_filter = (
         'if .identity.auth_type == "registry-auth" and .identity.registry.username '
         'then "\(.identity.registry.org_id // "")|\(.identity.registry.username)" '
-        'else null end'
+        "else null end"
     )
 
     def authenticate_header(self, request):

--- a/pulp_service/pulp_service/app/authorization.py
+++ b/pulp_service/pulp_service/app/authorization.py
@@ -14,7 +14,7 @@ import logging
 
 
 _logger = logging.getLogger(__name__)
-org_id_var = ContextVar('org_id')
+org_id_var = ContextVar("org_id")
 org_id_json_path = jq.compile(".identity.internal.org_id")
 
 user_id_var = ContextVar("user_id")
@@ -77,11 +77,11 @@ class DomainBasedPermission(BasePermission):
             return True
         elif action == "domain_update":
             # The PK is part of the URL
-            domain_pk = extract_pk(request.META['PATH_INFO'])
+            domain_pk = extract_pk(request.META["PATH_INFO"])
             return self._has_domain_access(domain_pk, org_id, user)
         elif action == "domain_delete":
             # The PK is part of the URL
-            domain_pk = extract_pk(request.META['PATH_INFO'])
+            domain_pk = extract_pk(request.META["PATH_INFO"])
             return self._has_domain_access(domain_pk, org_id, user)
         # User has permission if the org_id matches the domain's org_id
         # The user that created the domain has permission to access that domain
@@ -91,19 +91,19 @@ class DomainBasedPermission(BasePermission):
 
     def get_user_action(self, request):
         view_name = request.resolver_match.view_name
-        method = request.META['REQUEST_METHOD']
+        method = request.META["REQUEST_METHOD"]
 
         # Map view names to actions
         if view_name in ["domains-list"]:
-            if method == 'POST':
+            if method == "POST":
                 return "domain_create"
-            if method == 'GET':
+            if method == "GET":
                 return "domain_list"
         elif view_name in ["domains-set-label", "domains-unset-label"]:
             return "domain_update"
         elif view_name == "domains-detail":
-            if method in ['PATCH', 'DELETE']:
-                return "domain_update" if method == 'PATCH' else "domain_delete"
+            if method in ["PATCH", "DELETE"]:
+                return "domain_update" if method == "PATCH" else "domain_delete"
         elif view_name in ["create-domain", "pulp_service.app.viewsets.CreateDomainView"]:
             return "domain_create"
         else:
@@ -111,7 +111,7 @@ class DomainBasedPermission(BasePermission):
 
     def get_decoded_identity_header(self, request):
         try:
-            header_content = request.META.get('HTTP_X_RH_IDENTITY')
+            header_content = request.META.get("HTTP_X_RH_IDENTITY")
             if header_content:
                 header_decoded_content = b64decode(header_content)
                 return header_decoded_content

--- a/pulp_service/pulp_service/app/constants.py
+++ b/pulp_service/pulp_service/app/constants.py
@@ -3,9 +3,7 @@ from types import SimpleNamespace
 OSV_QUERY_URL = "https://api.osv.dev/v1/query"
 OSV_QUERY_BATCH_URL = "https://api.osv.dev/v1/querybatch"
 RH_REPO_TO_CPE_URL = "https://www.redhat.com/security/data/metrics/repository-to-cpe.json"
-PKG_ECOSYSTEM = SimpleNamespace(
-    rpm="Red Hat", npm="npm", maven="Maven", python="PyPI", gem="RubyGems"
-)
+PKG_ECOSYSTEM = SimpleNamespace(rpm="Red Hat", npm="npm", maven="Maven", python="PyPI", gem="RubyGems")
 
 # Labels used in RPM repositories for vulnerability report tasks
 OSV_RH_ECOSYSTEM_LABEL = "osv_dev ecosystem"

--- a/pulp_service/pulp_service/app/content.py
+++ b/pulp_service/pulp_service/app/content.py
@@ -28,6 +28,7 @@ class HeadersWithModifiedXForwardedFor:
     This allows us to prepend True-Client-IP to X-Forwarded-For without
     modifying the immutable headers object or using private APIs.
     """
+
     def __init__(self, original_headers, modified_xff):
         self._original = original_headers
         self._modified_xff = modified_xff
@@ -93,10 +94,7 @@ async def add_true_client_ip_to_forwarded_for(request, handler):
             modified_xff = true_client_ip.strip()
 
         # Replace request.headers with wrapper that returns modified X-Forwarded-For
-        request._cache['headers'] = HeadersWithModifiedXForwardedFor(
-            request.headers,
-            modified_xff
-        )
+        request._cache["headers"] = HeadersWithModifiedXForwardedFor(request.headers, modified_xff)
 
     return await handler(request)
 
@@ -122,8 +120,4 @@ async def add_rh_org_id_resp_header(request, handler):
     return response
 
 
-app._middlewares = FrozenList([
-    add_true_client_ip_to_forwarded_for,
-    add_rh_org_id_resp_header,
-    *app.middlewares
-])
+app._middlewares = FrozenList([add_true_client_ip_to_forwarded_for, add_rh_org_id_resp_header, *app.middlewares])

--- a/pulp_service/pulp_service/app/middleware.py
+++ b/pulp_service/pulp_service/app/middleware.py
@@ -20,12 +20,11 @@ from pulpcore.plugin.util import extract_pk, get_artifact_url, resolve_prn
 from pulp_service.app.authentication import RHSamlAuthentication
 
 
-
 _logger = logging.getLogger(__name__)
-repository_name_var = ContextVar('repository_name')
-x_quay_auth_var = ContextVar('x_quay_auth')
-x_task_diagnostics_var = ContextVar('x_profile_task')
-request_path_var = ContextVar('request_path', default=None)
+repository_name_var = ContextVar("repository_name")
+x_quay_auth_var = ContextVar("x_quay_auth")
+x_task_diagnostics_var = ContextVar("x_profile_task")
+request_path_var = ContextVar("request_path", default=None)
 
 
 def _is_valid_ip(ip_str):
@@ -49,10 +48,11 @@ class ProfilerMiddleware(MiddlewareMixin):
     This is adapted from an example found here:
     https://github.com/omarish/django-cprofile-middleware/blob/master/django_cprofile_middleware/middleware.py
     """
-    PROFILER_REQUEST_ATTR_NAME = '_django_cprofile_middleware_profiler'
+
+    PROFILER_REQUEST_ATTR_NAME = "_django_cprofile_middleware_profiler"
 
     def can(self, request):
-        if 'HTTP_X_PROFILE_REQUEST' in request.META:
+        if "HTTP_X_PROFILE_REQUEST" in request.META:
             return True
         return False
 
@@ -62,8 +62,7 @@ class ProfilerMiddleware(MiddlewareMixin):
             setattr(request, self.PROFILER_REQUEST_ATTR_NAME, profiler)
             args = (request,) + callback_args
             try:
-                return profiler.runcall(
-                    callback, *args, **callback_kwargs)
+                return profiler.runcall(callback, *args, **callback_kwargs)
             except Exception:
                 # we want the process_exception middleware to fire
                 # https://code.djangoproject.com/ticket/12250
@@ -97,6 +96,7 @@ class TrueClientIPMiddleware(MiddlewareMixin):
 
     Validates True-Client-IP is a valid IP address before using it.
     """
+
     def process_view(self, request, *args, **kwargs):
         true_client_ip = request.META.get("HTTP_TRUE_CLIENT_IP")
         if true_client_ip and _is_valid_ip(true_client_ip):
@@ -117,7 +117,7 @@ class RhEdgeHostMiddleware(MiddlewareMixin):
 
 class RHSamlAuthHeaderMiddleware(MiddlewareMixin):
     def process_view(self, request, *args, **kwargs):
-        if '/pulp-mgmt/' in request.path:
+        if "/pulp-mgmt/" in request.path:
             if "HTTP_X_RH_IDENTITY" in request.META:
                 _logger.debug(f"{request.META['HTTP_X_RH_IDENTITY']}")
 
@@ -127,7 +127,7 @@ class RHSamlAuthHeaderMiddleware(MiddlewareMixin):
                     user, _ = backend.authenticate(request)
 
                     if user:
-                        login(request, user, backend='pulp_service.app.authentication.RHSamlAuthentication')
+                        login(request, user, backend="pulp_service.app.authentication.RHSamlAuthentication")
                         request.session.modified = True
                         # Update request.user for the current request
                         request.user = user

--- a/pulp_service/pulp_service/app/models.py
+++ b/pulp_service/pulp_service/app/models.py
@@ -34,9 +34,7 @@ class DomainOrg(models.Model):
     """
 
     org_id = models.CharField(null=True, db_index=True)
-    domains = models.ManyToManyField(
-        Domain, related_name="domain_orgs"
-    )
+    domains = models.ManyToManyField(Domain, related_name="domain_orgs")
     user = models.ForeignKey(
         settings.AUTH_USER_MODEL,
         related_name="users",
@@ -64,18 +62,12 @@ class FeatureContentGuard(HeaderContentGuard, AutoAddObjPermsMixin):
         cert_context.load_cert_chain(certfile=settings.FEATURE_SERVICE_API_CERT_PATH)
 
         account_id_query_param = f"accountId={account_id}"
-        features_query_param = "&".join(
-            f"features={feature}" for feature in self.features
-        )
-        feature_service_api_url = (
-            f"{settings.FEATURE_SERVICE_API_URL}?{account_id_query_param}&{features_query_param}"
-        )
+        features_query_param = "&".join(f"features={feature}" for feature in self.features)
+        feature_service_api_url = f"{settings.FEATURE_SERVICE_API_URL}?{account_id_query_param}&{features_query_param}"
 
         async def fetch_feature():
             async with aiohttp.ClientSession() as session:
-                async with session.get(
-                    feature_service_api_url, ssl=cert_context, raise_for_status=True
-                ) as response:
+                async with session.get(feature_service_api_url, ssl=cert_context, raise_for_status=True) as response:
                     return await response.json()
 
         try:
@@ -85,9 +77,7 @@ class FeatureContentGuard(HeaderContentGuard, AutoAddObjPermsMixin):
         except aiohttp.ClientResponseError as err:
             if err.status == 400:
                 _logger.error(
-                    "Failed to request information for a user. BadRequest. URL: {}".format(
-                        err.request_info.url
-                    )
+                    "Failed to request information for a user. BadRequest. URL: {}".format(err.request_info.url)
                 )
 
             if err.status == 403:
@@ -95,23 +85,17 @@ class FeatureContentGuard(HeaderContentGuard, AutoAddObjPermsMixin):
                     "Failed to request information for a user. Permission Denied. Verify if the certificate is still valid."
                 )
 
-            _logger.warn(
-                _("Failed to fetch the Subscription feature information for a user.")
-            )
+            _logger.warn(_("Failed to fetch the Subscription feature information for a user."))
             raise PermissionError(_("Access denied."))
 
-        features_available = { feature["name"] for feature in response["features"] }
+        features_available = {feature["name"] for feature in response["features"]}
         return features_available == set(self.features)
 
     def permit(self, request):
         try:
             header_content = request.headers[self.header_name]
         except KeyError:
-            _logger.error(
-                "Access not allowed. Header {header_name} not found.".format(
-                    header_name=self.header_name
-                )
-            )
+            _logger.error("Access not allowed. Header {header_name} not found.".format(header_name=self.header_name))
             raise PermissionError(_("Access denied."))
 
         try:
@@ -125,11 +109,7 @@ class FeatureContentGuard(HeaderContentGuard, AutoAddObjPermsMixin):
             json_path = jq.compile(self.jq_filter)
 
             if settings.AUTHENTICATION_HEADER_DEBUG:
-                _logger.info(
-                    "Authentication Header Debug enabled: {header_value}".format(
-                        header_value=header_value
-                    )
-                )
+                _logger.info("Authentication Header Debug enabled: {header_value}".format(header_value=header_value))
 
             header_value = json_path.input_value(header_value).first()
 
@@ -156,9 +136,7 @@ class FeatureContentGuard(HeaderContentGuard, AutoAddObjPermsMixin):
                 account_allowed = json.loads(account_allowed)
 
             if not account_allowed:
-                _logger.warn(
-                    "Access not allowed - Features not available for the user."
-                )
+                _logger.warn("Access not allowed - Features not available for the user.")
                 raise PermissionError(_("Access denied."))
 
         except aiohttp.ClientResponseError as err:
@@ -205,12 +183,8 @@ class PyPIYankMonitor(BaseModel):
     name = models.TextField(db_index=True, unique=True)
     description = models.TextField(null=True, blank=True)
     pulp_labels = HStoreField(default=dict)
-    repository = models.ForeignKey(
-        "core.Repository", on_delete=models.CASCADE, null=True, blank=True
-    )
-    repository_version = models.ForeignKey(
-        "core.RepositoryVersion", on_delete=models.CASCADE, null=True, blank=True
-    )
+    repository = models.ForeignKey("core.Repository", on_delete=models.CASCADE, null=True, blank=True)
+    repository_version = models.ForeignKey("core.RepositoryVersion", on_delete=models.CASCADE, null=True, blank=True)
     last_checked = models.DateTimeField(null=True, blank=True)
 
     def get_repo_version_and_name(self):
@@ -238,6 +212,7 @@ class VulnerabilityReport(BaseModel):
 
     class Meta:
         default_related_name = "%(app_label)s_%(model_name)s"
+
 
 class AgentScanReport(BaseModel):
     content = models.OneToOneField(

--- a/pulp_service/pulp_service/app/serializers.py
+++ b/pulp_service/pulp_service/app/serializers.py
@@ -97,20 +97,20 @@ class PyPIYankMonitorSerializer(ModelSerializer):
                 _("Exactly one of 'repository' or 'repository_version' must be specified.")
             )
         if repo and repo.pulp_type != PYTHON_REPOSITORY_PULP_TYPE:
-            raise serializers.ValidationError(
-                _("Only Python repositories can be monitored for PyPI yanking.")
-            )
+            raise serializers.ValidationError(_("Only Python repositories can be monitored for PyPI yanking."))
         if repo_version and repo_version.repository.pulp_type != PYTHON_REPOSITORY_PULP_TYPE:
-            raise serializers.ValidationError(
-                _("Only Python repository versions can be monitored for PyPI yanking.")
-            )
+            raise serializers.ValidationError(_("Only Python repository versions can be monitored for PyPI yanking."))
         return data
 
     class Meta:
         model = PyPIYankMonitor
         fields = ModelSerializer.Meta.fields + (
-            "name", "description", "pulp_labels",
-            "repository", "repository_version", "last_checked",
+            "name",
+            "description",
+            "pulp_labels",
+            "repository",
+            "repository_version",
+            "last_checked",
         )
 
 
@@ -133,9 +133,7 @@ class ContentScanSerializer(serializers.Serializer, ValidateFieldsMixin):
     def validate(self, data):
         data = super().validate(data)
         if bool(repo_ver := data.get("repo_version")) == bool(pkg_json := data.get("package_json")):
-            raise serializers.ValidationError(
-                _("Exactly one of 'repo_version' or 'package_json' must be specified.")
-            )
+            raise serializers.ValidationError(_("Exactly one of 'repo_version' or 'package_json' must be specified."))
 
         # no more validations needed for pkg_json
         if pkg_json:

--- a/pulp_service/pulp_service/app/settings.py
+++ b/pulp_service/pulp_service/app/settings.py
@@ -10,12 +10,12 @@ FEATURE_SERVICE_API_CERT_PATH = ""
 AUTHENTICATION_HEADER_DEBUG = False
 INSTALLED_APPS = "@merge django.contrib.admin.apps.SimpleAdminConfig,hijack,hijack.contrib.admin"
 TEST_TASK_INGESTION = False
-LOGIN_REDIRECT_URL = '/api/pulp-mgmt/'
-LOGIN_URL = '/api/pulp-mgmt/login/'
+LOGIN_REDIRECT_URL = "/api/pulp-mgmt/"
+LOGIN_URL = "/api/pulp-mgmt/login/"
 
 # Django Hijack settings
-HIJACK_LOGIN_REDIRECT_URL = '/api/pulp-mgmt/'
-HIJACK_LOGOUT_REDIRECT_URL = '/api/pulp-mgmt/'
+HIJACK_LOGIN_REDIRECT_URL = "/api/pulp-mgmt/"
+HIJACK_LOGOUT_REDIRECT_URL = "/api/pulp-mgmt/"
 HIJACK_ALLOW_GET_REQUESTS = True
 
 # RDS Test endpoints setting

--- a/pulp_service/pulp_service/app/signals.py
+++ b/pulp_service/pulp_service/app/signals.py
@@ -29,15 +29,14 @@ def log_new_user(sender, instance, created, **kwargs):
         from pulp_service.app.middleware import request_path_var
 
         request_path = request_path_var.get(None)
-        _logger.info(
-            f"New user created: username={instance.username}, route={request_path or 'unknown'}"
-        )
+        _logger.info(f"New user created: username={instance.username}, route={request_path or 'unknown'}")
 
 
 @receiver(post_save, sender=Domain)
 def post_create_domain(sender, **kwargs):
-    if kwargs['created']:
+    if kwargs["created"]:
         from pulp_service.app.authorization import org_id_var, user_id_var
+
         org_id = org_id_var.get(None)
         org_id_var.set(None)
         user_id = user_id_var.get(None)
@@ -52,4 +51,4 @@ def post_create_domain(sender, **kwargs):
                 do = DomainOrg.objects.create(org_id=org_id, group=group)
             else:
                 do = DomainOrg.objects.create(org_id=org_id, user=user)
-            do.domains.add(kwargs['instance'])
+            do.domains.add(kwargs["instance"])

--- a/pulp_service/pulp_service/app/storage.py
+++ b/pulp_service/pulp_service/app/storage.py
@@ -12,14 +12,13 @@ import base64
 
 
 class OCIStorage(BaseStorage):
-
     def get_default_settings(self):
         return {
             "username": setting("username"),
             "password": setting("password"),
             "repository": setting("repository"),
         }
-    
+
     @property
     def registry(self):
         """Registry is always quay.io"""
@@ -28,26 +27,20 @@ class OCIStorage(BaseStorage):
     def _get_token_with_push_scope(self, client, registry, repository, username, password):
         """
         Manually request a token with push scope.
-        
+
         This is necessary because the automatic auth flow only gets 'pull' scope,
         but we need 'push' scope to upload blobs.
         """
         token_url = f"https://{registry}/v2/auth"
-        token_params = {
-            "service": registry,
-            "scope": f"repository:{repository}:pull,push"
-        }
+        token_params = {"service": registry, "scope": f"repository:{repository}:pull,push"}
         basic_auth = base64.b64encode(f"{username}:{password}".encode()).decode()
         token_response = requests.get(
-            token_url,
-            params=token_params,
-            headers={"Authorization": f"Basic {basic_auth}"},
-            timeout=30
+            token_url, params=token_params, headers={"Authorization": f"Basic {basic_auth}"}, timeout=30
         )
-        
+
         if token_response.status_code == 200:
             token_data = token_response.json()
-            token = token_data.get('token') or token_data.get('access_token')
+            token = token_data.get("token") or token_data.get("access_token")
             client.auth.set_token_auth(token)
             return True
         return False
@@ -55,144 +48,125 @@ class OCIStorage(BaseStorage):
     def _save(self, name, content):
         """
         Save content as a blob and return the blob reference (registry/repo@digest).
-        
+
         :param name: The name/path for the content (not used for blob storage)
         :param content: Django File object with content to upload
         :return: Blob reference in format: registry/repository@sha256:digest
         """
         # Create ORAS client
         client = oras.client.OrasClient()
-        
+
         # Login to save credentials
         client.login(
             username=self.username,
             password=self.password,
             hostname=self.registry,
-            config_path="/tmp/.docker/config.json"
+            config_path="/tmp/.docker/config.json",
         )
-        
+
         # Get token with push scope
-        self._get_token_with_push_scope(
-            client, 
-            self.registry, 
-            self.repository, 
-            self.username, 
-            self.password
-        )
-        
+        self._get_token_with_push_scope(client, self.registry, self.repository, self.username, self.password)
+
         # Get the file path from the content object
         # The content parameter is a Django File object with a 'name' attribute
         file_path = content.file.name
-        
+
         # Create layer metadata (calculates digest, size)
-        layer = oras.oci.NewLayer(
-            file_path,
-            media_type=oras.defaults.default_blob_media_type,
-            is_dir=False
-        )
-        
+        layer = oras.oci.NewLayer(file_path, media_type=oras.defaults.default_blob_media_type, is_dir=False)
+
         # Get container reference
         container = client.get_container(f"{self.registry}/{self.repository}")
-        
+
         # Load auth configs
         client.auth.load_configs(container, configs=["/tmp/.docker/config.json"])
-        
+
         # Upload the blob
-        response = client.upload_blob(
-            blob=file_path,
-            container=container,
-            layer=layer
-        )
-        
+        response = client.upload_blob(blob=file_path, container=container, layer=layer)
+
         if response.status_code not in [200, 201, 202]:
             raise ValueError(f"Blob upload failed: {response.status_code} - {response.text}")
-        
+
         # Return blob reference: registry/repository@digest
         blob_ref = f"{self.registry}/{self.repository}@{layer['digest']}"
         return blob_ref
 
-    def _open(self, name, mode='rb'):
+    def _open(self, name, mode="rb"):
         """
         Download a blob and return it as a Django File object.
-        
+
         :param name: Blob reference in format: registry/repository@sha256:digest
         :param mode: File open mode (default 'rb')
         :return: Django File object
         """
         # Parse the blob reference to extract digest
         # Format: registry/repository@sha256:digest
-        if '@' not in name:
+        if "@" not in name:
             raise ValueError(f"Invalid blob reference format: {name}")
-        
-        digest = name.split('@')[1]  # Extract sha256:digest
-        
+
+        digest = name.split("@")[1]  # Extract sha256:digest
+
         # Create ORAS client
         client = oras.client.OrasClient()
-        
+
         # Login
         client.login(
             username=self.username,
             password=self.password,
             hostname=self.registry,
-            config_path="/tmp/.docker/config.json"
+            config_path="/tmp/.docker/config.json",
         )
-        
+
         # Get container reference
         container = client.get_container(f"{self.registry}/{self.repository}")
-        
+
         # Load auth configs
         client.auth.load_configs(container, configs=["/tmp/.docker/config.json"])
-        
+
         # Create temporary file path for download
-        tmp_file = tempfile.NamedTemporaryFile(delete=False, suffix='.blob')
+        tmp_file = tempfile.NamedTemporaryFile(delete=False, suffix=".blob")
         tmp_path = tmp_file.name
         tmp_file.close()
-        
+
         # Download the blob
-        client.download_blob(
-            container=container,
-            digest=digest,
-            outfile=tmp_path,
-            return_blob_url=False
-        )
-        
+        client.download_blob(container=container, digest=digest, outfile=tmp_path, return_blob_url=False)
+
         # Return as Django File object
         return File(open(tmp_path, mode))
 
     def exists(self, name):
         """
         Check if a blob exists in the registry.
-        
+
         :param name: Blob reference in format: registry/repository@sha256:digest
         :return: True if blob exists, False otherwise
         """
         try:
             # Parse the digest from the blob reference
-            if '@' not in name:
+            if "@" not in name:
                 return False
-            
-            digest = name.split('@')[1]
-            
+
+            digest = name.split("@")[1]
+
             # Create ORAS client
             client = oras.client.OrasClient()
-            
+
             # Login
             client.login(
                 username=self.username,
                 password=self.password,
                 hostname=self.registry,
-                config_path="/tmp/.docker/config.json"
+                config_path="/tmp/.docker/config.json",
             )
-            
+
             # Get container reference
             container = client.get_container(f"{self.registry}/{self.repository}")
-            
+
             # Load auth configs
             client.auth.load_configs(container, configs=["/tmp/.docker/config.json"])
-            
+
             # Create a minimal layer dict with just the digest
             layer = {"digest": digest}
-            
+
             # Check if blob exists
             return client.blob_exists(layer, container)
         except Exception:
@@ -201,80 +175,79 @@ class OCIStorage(BaseStorage):
     def size(self, name):
         """
         Get the size of a blob.
-        
+
         :param name: Blob reference in format: registry/repository@sha256:digest
         :return: Size in bytes
         """
         # Parse the digest from the blob reference
-        if '@' not in name:
+        if "@" not in name:
             raise ValueError(f"Invalid blob reference format: {name}")
-        
-        digest = name.split('@')[1]
-        
+
+        digest = name.split("@")[1]
+
         # Create ORAS client
         client = oras.client.OrasClient()
-        
+
         # Login
         client.login(
             username=self.username,
             password=self.password,
             hostname=self.registry,
-            config_path="/tmp/.docker/config.json"
+            config_path="/tmp/.docker/config.json",
         )
-        
+
         # Get container reference
         container = client.get_container(f"{self.registry}/{self.repository}")
-        
+
         # Load auth configs
         client.auth.load_configs(container, configs=["/tmp/.docker/config.json"])
-        
+
         # Use HEAD request to get Content-Length
         response = client.get_blob(container=container, digest=digest, head=True)
-        
+
         if response.status_code == 200:
-            return int(response.headers.get('Content-Length', 0))
-        
+            return int(response.headers.get("Content-Length", 0))
+
         raise ValueError(f"Failed to get blob size: {response.status_code}")
 
     def url(self, artifact_name, parameters={}, **kwargs):
         """
         Get the direct URL to a blob.
-        
+
         :param artifact_name: Blob reference in format: registry/repository@sha256:digest
         :return: Direct URL to the blob
         """
         if parameters is None:
             parameters = {}
         # Parse the digest from the blob reference
-        if '@' not in artifact_name:
+        if "@" not in artifact_name:
             raise ValueError(f"Invalid blob reference format: {artifact_name}")
-        
-        digest = artifact_name.split('@')[1]
-        
+
+        digest = artifact_name.split("@")[1]
+
         # Create ORAS client
         client = oras.client.OrasClient()
-        
+
         # Login
         client.login(
             username=self.username,
             password=self.password,
             hostname=self.registry,
-            config_path="/tmp/.docker/config.json"
+            config_path="/tmp/.docker/config.json",
         )
-        
+
         # Get container reference
         container = client.get_container(f"{self.registry}/{self.repository}")
-        
+
         # Load auth configs
         client.auth.load_configs(container, configs=["/tmp/.docker/config.json"])
-        
+
         # Use download_blob with return_blob_url=True to get the URL
         blob_url = client.download_blob(
             container=container,
             digest=digest,
             outfile="",  # Not used when return_blob_url=True
-            return_blob_url=True
+            return_blob_url=True,
         )
-        
-        return blob_url
 
+        return blob_url

--- a/pulp_service/pulp_service/app/tasks/domain_metrics.py
+++ b/pulp_service/pulp_service/app/tasks/domain_metrics.py
@@ -45,8 +45,6 @@ def rhel_ai_repos_count():
 
 
 def _get_rhel_ai_repos_count(options):
-    rhel_ai_repos = Repository.objects.select_related("pulp_domain").filter(
-        pulp_domain__name=RHEL_AI_DOMAIN_NAME
-    )
+    rhel_ai_repos = Repository.objects.select_related("pulp_domain").filter(pulp_domain__name=RHEL_AI_DOMAIN_NAME)
     rhel_ai_repos_count = rhel_ai_repos.count()
     yield Observation(rhel_ai_repos_count)

--- a/pulp_service/pulp_service/app/tasks/package_scan.py
+++ b/pulp_service/pulp_service/app/tasks/package_scan.py
@@ -32,9 +32,7 @@ async def check_content_from_repo_version(repo_version_pk):
     make a request to osv.dev API to check the vulnerabilities.
     """
     # create a thread to collect the Contents from RepositoryVersion
-    background_thread = threading.Thread(
-        target=_get_content_from_repo_version, args=(repo_version_pk,)
-    )
+    background_thread = threading.Thread(target=_get_content_from_repo_version, args=(repo_version_pk,))
     await _start_thread_and_run_scan(background_thread)
 
 
@@ -65,9 +63,7 @@ async def _scan_packages(background_thread):
     scanned_packages = {}
     async with aiohttp.ClientSession() as session:
         try:
-            for osv_data in iter(
-                lambda: content_queue.get(timeout=VULNERABILITY_TASK_THREAD_TIMEOUT), None
-            ):
+            for osv_data in iter(lambda: content_queue.get(timeout=VULNERABILITY_TASK_THREAD_TIMEOUT), None):
                 if isinstance(osv_data, Exception):
                     raise RuntimeError(f"Background vuln report task failed to execute: {osv_data}")
                 data = json.dumps(osv_data)
@@ -134,9 +130,7 @@ def _parse_npm_pkg_dependencies(package_lock_content):
     for pkg in package_lock_content.get("packages", None):
         if not package_lock_content["packages"][pkg].get("dependencies", None):
             continue
-        for package_name, package_version in package_lock_content["packages"][pkg][
-            "dependencies"
-        ].items():
+        for package_name, package_version in package_lock_content["packages"][pkg]["dependencies"].items():
             # we will not handle version range yet, for now, we will consider
             # only the specific version
             package_version = package_version.strip("^~")

--- a/pulp_service/pulp_service/app/tasks/pypi_yank_check.py
+++ b/pulp_service/pulp_service/app/tasks/pypi_yank_check.py
@@ -15,9 +15,7 @@ _logger = logging.getLogger(__name__)
 
 async def _gather_packages(content_qs):
     """Return {name: {version, ...}} from a PythonPackageContent queryset."""
-    qs = await sync_to_async(list)(
-        content_qs.values_list("name", "version").distinct()
-    )
+    qs = await sync_to_async(list)(content_qs.values_list("name", "version").distinct())
     packages = {}
     for name, version in qs:
         if name and version:
@@ -31,10 +29,7 @@ async def _run_yank_check(packages):
     semaphore = asyncio.Semaphore(PYPI_CHECK_CONCURRENCY)
     async with aiohttp.ClientSession() as session:
         results = await asyncio.gather(
-            *[
-                _check_package(session, semaphore, name, versions)
-                for name, versions in packages.items()
-            ],
+            *[_check_package(session, semaphore, name, versions) for name, versions in packages.items()],
             return_exceptions=True,
         )
     for result in results:
@@ -45,14 +40,11 @@ async def _run_yank_check(packages):
     return yanked
 
 
-
 def dispatch_pypi_yank_checks():
     """Dispatch a per-monitor yank check task for every registered PyPIYankMonitor."""
     from pulp_service.app.models import PyPIYankMonitor
 
-    monitors = PyPIYankMonitor.objects.select_related(
-        "repository", "repository_version__repository"
-    )
+    monitors = PyPIYankMonitor.objects.select_related("repository", "repository_version__repository")
     for monitor in monitors:
         repo = monitor.repository or monitor.repository_version.repository
         dispatch(
@@ -68,21 +60,15 @@ async def check_packages_for_monitor(monitor_pk):
     from pulp_service.app.models import PyPIYankMonitor
 
     monitor = await sync_to_async(
-        PyPIYankMonitor.objects.select_related(
-            "repository", "repository_version__repository"
-        ).get
+        PyPIYankMonitor.objects.select_related("repository", "repository_version__repository").get
     )(pk=monitor_pk)
 
     repo_version, repo_name = await sync_to_async(monitor.get_repo_version_and_name)()
 
-    packages = await _gather_packages(
-        PythonPackageContent.objects.filter(pk__in=repo_version.content)
-    )
+    packages = await _gather_packages(PythonPackageContent.objects.filter(pk__in=repo_version.content))
     yanked = await _run_yank_check(packages)
 
-    await sync_to_async(YankedPackageReport.objects.create)(
-        report=yanked, monitor=monitor, repository_name=repo_name
-    )
+    await sync_to_async(YankedPackageReport.objects.create)(report=yanked, monitor=monitor, repository_name=repo_name)
     monitor.last_checked = timezone.now()
     await sync_to_async(monitor.save)(update_fields=["last_checked"])
 
@@ -109,8 +95,6 @@ async def _check_package(session, semaphore, name, versions):
     for version in versions:
         files = releases.get(version, [])
         if files and all(f.get("yanked") for f in files):
-            reason = next(
-                (f.get("yanked_reason") for f in files if f.get("yanked_reason")), None
-            )
+            reason = next((f.get("yanked_reason") for f in files if f.get("yanked_reason")), None)
             yanked[f"{name}=={version}"] = {"yanked_reason": reason}
     return yanked

--- a/pulp_service/pulp_service/app/tasks/rds_connection_tests.py
+++ b/pulp_service/pulp_service/app/tasks/rds_connection_tests.py
@@ -46,6 +46,7 @@ def rds_test_wrapper(test_name, connection_pinned=False):
     Returns:
         Decorated function that returns standardized test results
     """
+
     def decorator(test_func):
         @wraps(test_func)
         def wrapper(*args, **kwargs):
@@ -71,7 +72,7 @@ def rds_test_wrapper(test_name, connection_pinned=False):
                     log(f"Warning: Could not retrieve backend PID: {e}")
 
                 if backend_pid:
-                    extra_data['backend_pid'] = backend_pid
+                    extra_data["backend_pid"] = backend_pid
 
                 try:
                     # Run the actual test logic
@@ -89,10 +90,10 @@ def rds_test_wrapper(test_name, connection_pinned=False):
                     log(f"TEST FAILED with exception: {type(e).__name__}: {e}")
                     log(f"Exception traceback: {traceback.format_exc()}")
                     alive = False
-                    extra_data['error'] = {
-                        'type': type(e).__name__,
-                        'message': str(e),
-                        'traceback': traceback.format_exc()
+                    extra_data["error"] = {
+                        "type": type(e).__name__,
+                        "message": str(e),
+                        "traceback": traceback.format_exc(),
                     }
 
                 finished_at = datetime.now()
@@ -109,26 +110,26 @@ def rds_test_wrapper(test_name, connection_pinned=False):
                 alive = False
                 finished_at = datetime.now()
                 duration = (finished_at - started_at).total_seconds() / 60
-                extra_data['error'] = {
-                    'type': type(fatal_error).__name__,
-                    'message': str(fatal_error),
-                    'traceback': traceback.format_exc()
+                extra_data["error"] = {
+                    "type": type(fatal_error).__name__,
+                    "message": str(fatal_error),
+                    "traceback": traceback.format_exc(),
                 }
 
             # Build result dictionary
             result = {
-                'test': test_name,
-                'started_at': started_at.isoformat(),
-                'finished_at': finished_at.isoformat() if finished_at else datetime.now().isoformat(),
-                'duration_minutes': round(duration, 2),
-                'connection_alive': alive,
-                'success': alive,
-                'status': 'PASSED' if alive else 'FAILED'
+                "test": test_name,
+                "started_at": started_at.isoformat(),
+                "finished_at": finished_at.isoformat() if finished_at else datetime.now().isoformat(),
+                "duration_minutes": round(duration, 2),
+                "connection_alive": alive,
+                "success": alive,
+                "status": "PASSED" if alive else "FAILED",
             }
 
             # Add connection pinning info if applicable
             if connection_pinned:
-                result['connection_pinned'] = True
+                result["connection_pinned"] = True
 
             # Merge any extra data from the test
             result.update(extra_data)
@@ -148,6 +149,7 @@ def rds_test_wrapper(test_name, connection_pinned=False):
             return result
 
         return wrapper
+
     return decorator
 
 
@@ -233,7 +235,7 @@ def test_2_active_heartbeat(duration_minutes=50):
             time.sleep(heartbeat_interval_seconds)
 
     log("All heartbeats successful!")
-    return True, {'iterations_completed': iterations}
+    return True, {"iterations_completed": iterations}
 
 
 @rds_test_wrapper("TEST 3: LONG-RUNNING TRANSACTION (DJANGO ORM)")
@@ -279,7 +281,7 @@ def test_4_transaction_with_work(duration_minutes=50):
 
         for i in range(iterations):
             # Query 1: Count waiting tasks (Django ORM)
-            waiting_count = Task.objects.filter(state='waiting').count()
+            waiting_count = Task.objects.filter(state="waiting").count()
 
             # Query 2: Get a task
             task = Task.objects.first()
@@ -288,8 +290,10 @@ def test_4_transaction_with_work(duration_minutes=50):
             worker_count = AppStatus.objects.filter(app_type="worker").count()
 
             elapsed_minutes = (i + 1) * 2
-            log(f"Iteration {i+1}/{iterations} ({elapsed_minutes} min): "
-                f"{waiting_count} waiting tasks, {worker_count} workers")
+            log(
+                f"Iteration {i + 1}/{iterations} ({elapsed_minutes} min): "
+                f"{waiting_count} waiting tasks, {worker_count} workers"
+            )
 
             if i < iterations - 1:
                 time.sleep(120)  # 2 minutes
@@ -396,11 +400,11 @@ def _notification_sender_worker(channel_name, interval_seconds, duration_minutes
     try:
         # Create a new database connection (can't share with parent process)
         conn = psycopg.connect(
-            host=db_settings['HOST'],
-            port=db_settings.get('PORT', 5432),
-            dbname=db_settings['NAME'],
-            user=db_settings['USER'],
-            password=db_settings['PASSWORD'],
+            host=db_settings["HOST"],
+            port=db_settings.get("PORT", 5432),
+            dbname=db_settings["NAME"],
+            user=db_settings["USER"],
+            password=db_settings["PASSWORD"],
         )
         conn.autocommit = True
 
@@ -414,10 +418,10 @@ def _notification_sender_worker(channel_name, interval_seconds, duration_minutes
 
             try:
                 cursor = conn.cursor()
-                payload = f"heartbeat_{i+1}"
+                payload = f"heartbeat_{i + 1}"
                 cursor.execute(f"NOTIFY {channel_name}, '{payload}'")
                 cursor.close()
-                worker_log(f"Sent NOTIFY #{i+1}/{iterations}: '{payload}'")
+                worker_log(f"Sent NOTIFY #{i + 1}/{iterations}: '{payload}'")
             except Exception as e:
                 worker_log(f"Error sending NOTIFY: {e}")
                 break
@@ -454,7 +458,7 @@ def test_7_listen_with_activity(duration_minutes=50):
 
     notify_process = multiprocessing.Process(
         target=_notification_sender_worker,
-        args=(channel_name, 120, duration_minutes, db_settings)  # Send every 2 minutes for duration
+        args=(channel_name, 120, duration_minutes, db_settings),  # Send every 2 minutes for duration
     )
     notify_process.start()
     log(f"NOTIFY sender process started (PID: {notify_process.pid})")
@@ -466,7 +470,7 @@ def test_7_listen_with_activity(duration_minutes=50):
         for i in range(iterations):
             # Wait 60 seconds
             time.sleep(60)
-            log(f"Minute {i+1}/{iterations}: Listening for notifications...")
+            log(f"Minute {i + 1}/{iterations}: Listening for notifications...")
 
     finally:
         # Clean up LISTEN

--- a/pulp_service/pulp_service/app/tasks/redis_lock_utils.py
+++ b/pulp_service/pulp_service/app/tasks/redis_lock_utils.py
@@ -40,7 +40,7 @@ def scan_resource_locks(redis_conn, cursor=0, max_keys=None):
         cursor, keys = redis_conn.scan(cursor=cursor, match=pattern, count=200)
         for key in keys:
             key_str = key.decode("utf-8") if isinstance(key, bytes) else key
-            resource_name = key_str[len(REDIS_LOCK_PREFIX):]
+            resource_name = key_str[len(REDIS_LOCK_PREFIX) :]
 
             lock_type = redis_conn.type(key)
             if isinstance(lock_type, bytes):
@@ -57,13 +57,15 @@ def scan_resource_locks(redis_conn, cursor=0, max_keys=None):
                 members = redis_conn.smembers(key)
                 holders = sorted(m.decode("utf-8") for m in members)
 
-            locks.append({
-                "lock_key": key_str,
-                "resource": resource_name,
-                "lock_type": lock_type,
-                "holders": holders,
-                "ttl": ttl,
-            })
+            locks.append(
+                {
+                    "lock_key": key_str,
+                    "resource": resource_name,
+                    "lock_type": lock_type,
+                    "holders": holders,
+                    "ttl": ttl,
+                }
+            )
 
         if max_keys is not None and len(locks) >= max_keys:
             # Return early with the current cursor so the caller can resume.
@@ -109,13 +111,15 @@ def scan_task_locks(redis_conn, cursor=0, max_keys=None):
                 if val:
                     holder = val.decode("utf-8")
 
-            locks.append({
-                "lock_key": key_str,
-                "task_id": task_id,
-                "lock_type": lock_type,
-                "holder": holder,
-                "ttl": ttl,
-            })
+            locks.append(
+                {
+                    "lock_key": key_str,
+                    "task_id": task_id,
+                    "lock_type": lock_type,
+                    "holder": holder,
+                    "ttl": ttl,
+                }
+            )
 
         if max_keys is not None and len(locks) >= max_keys:
             return locks[:max_keys], cursor
@@ -146,10 +150,7 @@ def check_lock_holder_liveness(lock_holders):
     if not lock_holders:
         return {}
 
-    app_statuses = {
-        app.name: app
-        for app in AppStatus.objects.filter(name__in=lock_holders)
-    }
+    app_statuses = {app.name: app for app in AppStatus.objects.filter(name__in=lock_holders)}
 
     result = {}
     for holder_name in lock_holders:
@@ -167,13 +168,7 @@ def check_lock_holder_liveness(lock_holders):
                 "exists_in_db": True,
                 "online": app.online,
                 "app_type": app.app_type,
-                "last_heartbeat": (
-                    app.last_heartbeat.isoformat() if app.last_heartbeat else None
-                ),
-                "verdict": (
-                    "alive"
-                    if app.online
-                    else "DEAD: AppStatus exists but is not online, lock is orphaned"
-                ),
+                "last_heartbeat": (app.last_heartbeat.isoformat() if app.last_heartbeat else None),
+                "verdict": ("alive" if app.online else "DEAD: AppStatus exists but is not online, lock is orphaned"),
             }
     return result

--- a/pulp_service/pulp_service/app/tasks/stale_lock_cleanup.py
+++ b/pulp_service/pulp_service/app/tasks/stale_lock_cleanup.py
@@ -61,9 +61,7 @@ def cleanup_stale_locks():
 
     liveness = check_lock_holder_liveness(all_holders)
 
-    dead_holders = {
-        name for name, info in liveness.items() if not info.get("online", False)
-    }
+    dead_holders = {name for name, info in liveness.items() if not info.get("online", False)}
 
     # -- Phase 3: clean up orphaned resource locks --------------------------
     resource_locks_scanned = len(resource_locks)

--- a/pulp_service/pulp_service/app/tasks/util.py
+++ b/pulp_service/pulp_service/app/tasks/util.py
@@ -30,6 +30,7 @@ def except_catch_and_raise(queue):
     """
     Decorator to catch all exceptions, put them into a queue, and raise them again.
     """
+
     def decorator(func):
         @wraps(func)
         def wrapper(*args, **kwargs):
@@ -40,7 +41,9 @@ def except_catch_and_raise(queue):
                 queue.put(e)
                 # Re-raise the exception
                 raise
+
         return wrapper
+
     return decorator
 
 
@@ -56,4 +59,4 @@ def register_pypi_yank_monitor_schedule():
 def no_op_task():
     with connections["default"].cursor() as cursor:
         cursor.execute("SELECT 1")
-    time.sleep(0.3) # This task will not take less than 300ms to execute
+    time.sleep(0.3)  # This task will not take less than 300ms to execute

--- a/pulp_service/pulp_service/app/viewsets.py
+++ b/pulp_service/pulp_service/app/viewsets.py
@@ -181,7 +181,6 @@ class DebugAuthenticationHeadersView(APIView):
     list=extend_schema(operation_id="admin_tasks"),
 )
 class TaskViewSet(TaskViewSet):
-
     LOCKED_ROLES = {}
 
     def get_queryset(self):
@@ -204,7 +203,6 @@ class TaskViewSet(TaskViewSet):
 
 
 class VulnerabilityReport(NamedModelViewSet, ListModelMixin, RetrieveModelMixin, DestroyModelMixin):
-
     endpoint_name = "vuln_report_service"
     queryset = VulnReport.objects.all()
     serializer_class = VulnerabilityReportSerializer
@@ -223,9 +221,7 @@ class VulnerabilityReport(NamedModelViewSet, ListModelMixin, RetrieveModelMixin,
         """Dispatch a task to scan the Content Units from a Repository"""
         if repo_version := serializer.validated_data.get("repo_version", None):
             shared_resources = [repo_version.repository]
-            dispatch_task, kwargs = check_content_from_repo_version, {
-                "repo_version_pk": repo_version.pk
-            }
+            dispatch_task, kwargs = check_content_from_repo_version, {"repo_version_pk": repo_version.pk}
 
         """Dispatch a task to scan the npm dependencies' vulnerabilities"""
         if serializer.validated_data.get("package_json", None):
@@ -239,7 +235,6 @@ class VulnerabilityReport(NamedModelViewSet, ListModelMixin, RetrieveModelMixin,
 class IsSuperuser(BasePermission):
     def has_permission(self, request, view):
         return request.user and request.user.is_superuser
-
 
 
 class PyPIYankMonitorFilter(BaseFilterSet):
@@ -285,7 +280,6 @@ class PyPIYankMonitorViewSet(
 
 
 class TaskIngestionDispatcherView(APIView):
-
     authentication_classes = []
     permission_classes = []
 
@@ -374,9 +368,7 @@ class RDSConnectionTestDispatcherView(APIView):
         """
         # Check if RDS tests are enabled (similar to TEST_TASK_INGESTION check)
         if not settings.DEBUG and not settings.RDS_CONNECTION_TESTS_ENABLED:
-            _logger.warning(
-                f"Unauthorized RDS test access attempt from {request.META.get('REMOTE_ADDR', 'unknown')}"
-            )
+            _logger.warning(f"Unauthorized RDS test access attempt from {request.META.get('REMOTE_ADDR', 'unknown')}")
             return Response(
                 {
                     "error": "RDS connection tests are not enabled.",
@@ -555,9 +547,7 @@ class DatabaseTriggersView(APIView):
                 trigger_info = dict(zip(columns, row))
                 triggers.append(trigger_info)
 
-        return Response(
-            {"table": "core_task", "trigger_count": len(triggers), "triggers": triggers}
-        )
+        return Response({"table": "core_task", "trigger_count": len(triggers), "triggers": triggers})
 
 
 class ReleaseTaskLocksView(APIView):
@@ -620,15 +610,11 @@ class ReleaseTaskLocksView(APIView):
             try:
                 task = Task.objects.select_related("pulp_domain").get(pk=task_id)
             except Task.DoesNotExist:
-                return Response(
-                    {"error": f"Task {task_id} not found"}, status=status.HTTP_404_NOT_FOUND
-                )
+                return Response({"error": f"Task {task_id} not found"}, status=status.HTTP_404_NOT_FOUND)
 
             # Extract exclusive and shared resources from the task
             exclusive_resources = [
-                resource
-                for resource in task.reserved_resources_record or []
-                if not resource.startswith("shared:")
+                resource for resource in task.reserved_resources_record or [] if not resource.startswith("shared:")
             ]
 
             shared_resources = [
@@ -815,18 +801,16 @@ def _check_version_compatibility(task):
         for label, required_version in task_versions.items():
             worker_version = worker_versions.get(label)
             if worker_version is None:
-                unmatched.append(
-                    f"{label}>={required_version} (worker has: missing)"
-                )
+                unmatched.append(f"{label}>={required_version} (worker has: missing)")
             elif parse_version(worker_version) < parse_version(required_version):
-                unmatched.append(
-                    f"{label}>={required_version} (worker has: {worker_version})"
-                )
+                unmatched.append(f"{label}>={required_version} (worker has: {worker_version})")
         if unmatched:
-            incompatible.append({
-                "worker_name": worker.name,
-                "unmatched_versions": unmatched,
-            })
+            incompatible.append(
+                {
+                    "worker_name": worker.name,
+                    "unmatched_versions": unmatched,
+                }
+            )
         else:
             compatible.append(worker.name)
 
@@ -860,9 +844,9 @@ def _check_lock_holder_liveness(lock_holders):
     return check_lock_holder_liveness(lock_holders)
 
 
-def _diagnose_stuck_task(task, app_lock_info, redis_locks, queue_position,
-                         version_compat, lock_holder_liveness,
-                         fifo_analysis=None):
+def _diagnose_stuck_task(
+    task, app_lock_info, redis_locks, queue_position, version_compat, lock_holder_liveness, fifo_analysis=None
+):
     """
     Produce a human-readable diagnosis explaining WHY a task is stuck.
 
@@ -874,11 +858,13 @@ def _diagnose_stuck_task(task, app_lock_info, redis_locks, queue_position,
     diagnoses = []
 
     if task.state not in (TASK_STATES.WAITING, TASK_STATES.RUNNING, TASK_STATES.CANCELING):
-        return [{
-            "bug": None,
-            "severity": "info",
-            "summary": f"Task is in final state '{task.state}' -- not stuck.",
-        }]
+        return [
+            {
+                "bug": None,
+                "severity": "info",
+                "summary": f"Task is in final state '{task.state}' -- not stuck.",
+            }
+        ]
 
     # Bug 1: app_lock set but task is still WAITING (is_compatible returned False,
     # app_lock was never cleared)
@@ -889,30 +875,34 @@ def _diagnose_stuck_task(task, app_lock_info, redis_locks, queue_position,
         # but app_lock is NOT cleared in the DB.
         redis_task_lock_held = redis_locks["task_lock"]["held"]
         if not redis_task_lock_held:
-            diagnoses.append({
-                "bug": "BUG_1_APPLOCK_NOT_CLEARED",
-                "severity": "critical",
-                "summary": (
-                    f"Task is WAITING with app_lock set to "
-                    f"'{app_lock_info['app_status_name']}' but NO Redis task lock exists. "
-                    f"This matches Bug 1: a worker called is_compatible(), found a version "
-                    f"mismatch, released Redis locks, but did NOT clear app_lock in the DB. "
-                    f"The task is now invisible to all workers (they filter for "
-                    f"app_lock=None). REMEDIATION: clear app_lock in the DB via "
-                    f"Task.objects.filter(pk='{task.pk}').update(app_lock=None)"
-                ),
-            })
+            diagnoses.append(
+                {
+                    "bug": "BUG_1_APPLOCK_NOT_CLEARED",
+                    "severity": "critical",
+                    "summary": (
+                        f"Task is WAITING with app_lock set to "
+                        f"'{app_lock_info['app_status_name']}' but NO Redis task lock exists. "
+                        f"This matches Bug 1: a worker called is_compatible(), found a version "
+                        f"mismatch, released Redis locks, but did NOT clear app_lock in the DB. "
+                        f"The task is now invisible to all workers (they filter for "
+                        f"app_lock=None). REMEDIATION: clear app_lock in the DB via "
+                        f"Task.objects.filter(pk='{task.pk}').update(app_lock=None)"
+                    ),
+                }
+            )
         else:
-            diagnoses.append({
-                "bug": "BUG_1_VARIANT_APPLOCK_WITH_REDIS_LOCK",
-                "severity": "warning",
-                "summary": (
-                    f"Task is WAITING with app_lock set to "
-                    f"'{app_lock_info['app_status_name']}' AND Redis task lock held by "
-                    f"'{redis_locks['task_lock']['holder']}'. A worker may be in the "
-                    f"process of claiming this task, or a worker died mid-claim."
-                ),
-            })
+            diagnoses.append(
+                {
+                    "bug": "BUG_1_VARIANT_APPLOCK_WITH_REDIS_LOCK",
+                    "severity": "warning",
+                    "summary": (
+                        f"Task is WAITING with app_lock set to "
+                        f"'{app_lock_info['app_status_name']}' AND Redis task lock held by "
+                        f"'{redis_locks['task_lock']['holder']}'. A worker may be in the "
+                        f"process of claiming this task, or a worker died mid-claim."
+                    ),
+                }
+            )
 
     # Bug 2: Orphaned Redis locks (lock holder is dead, no TTL)
     for holder_name, liveness in lock_holder_liveness.items():
@@ -930,54 +920,60 @@ def _diagnose_stuck_task(task, app_lock_info, redis_locks, queue_position,
                 if res["holders"] and holder_name in res["holders"] and res.get("ttl") == -1:
                     has_no_ttl = True
 
-            diagnoses.append({
-                "bug": "BUG_2_ORPHANED_LOCK",
-                "severity": "critical",
-                "summary": (
-                    f"Redis lock held by '{holder_name}' which is "
-                    f"{liveness['verdict']}. "
-                    f"Redis locks have no TTL (they persist forever). "
-                    f"{'The lock has no expiration set. ' if has_no_ttl else ''}"
-                    f"Worker cleanup should release these locks, but may have missed "
-                    f"this case. REMEDIATION: use the release-task-locks endpoint or "
-                    f"manually delete the Redis keys."
-                ),
-            })
+            diagnoses.append(
+                {
+                    "bug": "BUG_2_ORPHANED_LOCK",
+                    "severity": "critical",
+                    "summary": (
+                        f"Redis lock held by '{holder_name}' which is "
+                        f"{liveness['verdict']}. "
+                        f"Redis locks have no TTL (they persist forever). "
+                        f"{'The lock has no expiration set. ' if has_no_ttl else ''}"
+                        f"Worker cleanup should release these locks, but may have missed "
+                        f"this case. REMEDIATION: use the release-task-locks endpoint or "
+                        f"manually delete the Redis keys."
+                    ),
+                }
+            )
 
     # Bug 3: FETCH_TASK_LIMIT starvation
     if task.state == TASK_STATES.WAITING and not queue_position["within_fetch_window"]:
-        diagnoses.append({
-            "bug": "BUG_3_FETCH_LIMIT_STARVATION",
-            "severity": "high",
-            "summary": (
-                f"Task is outside the fetch window: {queue_position['older_waiting_tasks']} "
-                f"older WAITING tasks exist but the worker only examines the oldest "
-                f"{queue_position['fetch_task_limit']} (FETCH_TASK_LIMIT). "
-                f"Of those older tasks, {queue_position.get('stuck_in_window', 'unknown')} "
-                f"are themselves stuck (have app_lock set = invisible to workers). "
-                f"This task will not be examined until older tasks are completed or "
-                f"removed. REMEDIATION: resolve or cancel stuck older tasks."
-            ),
-        })
+        diagnoses.append(
+            {
+                "bug": "BUG_3_FETCH_LIMIT_STARVATION",
+                "severity": "high",
+                "summary": (
+                    f"Task is outside the fetch window: {queue_position['older_waiting_tasks']} "
+                    f"older WAITING tasks exist but the worker only examines the oldest "
+                    f"{queue_position['fetch_task_limit']} (FETCH_TASK_LIMIT). "
+                    f"Of those older tasks, {queue_position.get('stuck_in_window', 'unknown')} "
+                    f"are themselves stuck (have app_lock set = invisible to workers). "
+                    f"This task will not be examined until older tasks are completed or "
+                    f"removed. REMEDIATION: resolve or cancel stuck older tasks."
+                ),
+            }
+        )
 
     # Bug 4: FIFO resource blocking
     if fifo_analysis and fifo_analysis.get("is_fifo_blocked"):
         blocking_resources = fifo_analysis.get("blocked_resources", [])
         blocking_task_ids = fifo_analysis.get("blocking_task_ids", [])
-        diagnoses.append({
-            "bug": "BUG_4_FIFO_RESOURCE_BLOCKING",
-            "severity": "high",
-            "summary": (
-                f"Task is FIFO-blocked: an earlier task in the fetch window failed to "
-                f"acquire locks for resources that overlap with this task's resources. "
-                f"The worker's FIFO algorithm adds ALL exclusive resources of a failed "
-                f"task to the blocked set, preventing later tasks from acquiring them "
-                f"even if different resources caused the original failure. "
-                f"Blocked resources: {blocking_resources}. "
-                f"Earlier blocking tasks: {blocking_task_ids}. "
-                f"REMEDIATION: resolve or cancel the earlier blocking tasks."
-            ),
-        })
+        diagnoses.append(
+            {
+                "bug": "BUG_4_FIFO_RESOURCE_BLOCKING",
+                "severity": "high",
+                "summary": (
+                    f"Task is FIFO-blocked: an earlier task in the fetch window failed to "
+                    f"acquire locks for resources that overlap with this task's resources. "
+                    f"The worker's FIFO algorithm adds ALL exclusive resources of a failed "
+                    f"task to the blocked set, preventing later tasks from acquiring them "
+                    f"even if different resources caused the original failure. "
+                    f"Blocked resources: {blocking_resources}. "
+                    f"Earlier blocking tasks: {blocking_task_ids}. "
+                    f"REMEDIATION: resolve or cancel the earlier blocking tasks."
+                ),
+            }
+        )
 
     # Bug 5: Split-Redis (API and workers use different Redis instances)
     if task.state == TASK_STATES.WAITING and task.immediate and task.deferred:
@@ -985,78 +981,86 @@ def _diagnose_stuck_task(task, app_lock_info, redis_locks, queue_position,
         # on the API Redis but couldn't execute (resource conflict), it clears app_lock
         # but the Redis locks might remain on the API's Redis (invisible to workers).
         # Also flag if lock holder is an API process.
-        api_holders = [
-            name for name, info in lock_holder_liveness.items()
-            if info.get("app_type") == "api"
-        ]
+        api_holders = [name for name, info in lock_holder_liveness.items() if info.get("app_type") == "api"]
         if api_holders:
-            diagnoses.append({
-                "bug": "BUG_5_SPLIT_REDIS",
-                "severity": "critical",
-                "summary": (
-                    f"Redis lock(s) held by API process(es): {api_holders}. "
-                    f"API and worker clusters use DIFFERENT Redis instances but share "
-                    f"the same database. Locks acquired by the API for immediate task "
-                    f"execution are invisible to workers. If the API process died or "
-                    f"deferred the task, these locks may be orphaned on the API Redis "
-                    f"and simultaneously absent from the worker Redis, or vice versa. "
-                    f"REMEDIATION: check both Redis instances; release orphaned locks "
-                    f"on the API Redis."
-                ),
-            })
+            diagnoses.append(
+                {
+                    "bug": "BUG_5_SPLIT_REDIS",
+                    "severity": "critical",
+                    "summary": (
+                        f"Redis lock(s) held by API process(es): {api_holders}. "
+                        f"API and worker clusters use DIFFERENT Redis instances but share "
+                        f"the same database. Locks acquired by the API for immediate task "
+                        f"execution are invisible to workers. If the API process died or "
+                        f"deferred the task, these locks may be orphaned on the API Redis "
+                        f"and simultaneously absent from the worker Redis, or vice versa. "
+                        f"REMEDIATION: check both Redis instances; release orphaned locks "
+                        f"on the API Redis."
+                    ),
+                }
+            )
         elif app_lock_info["locked"] and app_lock_info.get("app_type") == "api":
-            diagnoses.append({
-                "bug": "BUG_5_SPLIT_REDIS",
-                "severity": "warning",
-                "summary": (
-                    f"Task has app_lock held by an API process "
-                    f"('{app_lock_info['app_status_name']}'). "
-                    f"API and worker clusters use different Redis instances. If this "
-                    f"task was dispatched as immediate but deferred to workers, there "
-                    f"may be lock state on the API Redis that is invisible to workers."
-                ),
-            })
+            diagnoses.append(
+                {
+                    "bug": "BUG_5_SPLIT_REDIS",
+                    "severity": "warning",
+                    "summary": (
+                        f"Task has app_lock held by an API process "
+                        f"('{app_lock_info['app_status_name']}'). "
+                        f"API and worker clusters use different Redis instances. If this "
+                        f"task was dispatched as immediate but deferred to workers, there "
+                        f"may be lock state on the API Redis that is invisible to workers."
+                    ),
+                }
+            )
 
     # Version incompatibility (related to Bug 1 root cause)
-    if (task.state == TASK_STATES.WAITING
-            and version_compat.get("no_compatible_worker_exists")):
-        diagnoses.append({
-            "bug": "VERSION_INCOMPATIBILITY",
-            "severity": "critical",
-            "summary": (
-                f"No online worker can satisfy this task's version requirements: "
-                f"{version_compat.get('task_versions', {})}. "
-                f"All workers found incompatible: "
-                f"{version_compat.get('incompatible_workers', [])}. "
-                f"This task will never be picked up until a compatible worker comes "
-                f"online. If a worker already tried and failed is_compatible(), it "
-                f"may have triggered Bug 1 (app_lock not cleared)."
-            ),
-        })
+    if task.state == TASK_STATES.WAITING and version_compat.get("no_compatible_worker_exists"):
+        diagnoses.append(
+            {
+                "bug": "VERSION_INCOMPATIBILITY",
+                "severity": "critical",
+                "summary": (
+                    f"No online worker can satisfy this task's version requirements: "
+                    f"{version_compat.get('task_versions', {})}. "
+                    f"All workers found incompatible: "
+                    f"{version_compat.get('incompatible_workers', [])}. "
+                    f"This task will never be picked up until a compatible worker comes "
+                    f"online. If a worker already tried and failed is_compatible(), it "
+                    f"may have triggered Bug 1 (app_lock not cleared)."
+                ),
+            }
+        )
 
     if not diagnoses:
         if task.state == TASK_STATES.RUNNING:
-            diagnoses.append({
-                "bug": None,
-                "severity": "info",
-                "summary": "Task is currently running. No stuck-task indicators detected.",
-            })
+            diagnoses.append(
+                {
+                    "bug": None,
+                    "severity": "info",
+                    "summary": "Task is currently running. No stuck-task indicators detected.",
+                }
+            )
         elif task.state == TASK_STATES.WAITING:
-            diagnoses.append({
-                "bug": None,
-                "severity": "info",
-                "summary": (
-                    "Task is WAITING with no obvious stuck indicators. It may be "
-                    "legitimately waiting for resource locks held by running tasks, "
-                    "or for a worker to pick it up."
-                ),
-            })
+            diagnoses.append(
+                {
+                    "bug": None,
+                    "severity": "info",
+                    "summary": (
+                        "Task is WAITING with no obvious stuck indicators. It may be "
+                        "legitimately waiting for resource locks held by running tasks, "
+                        "or for a worker to pick it up."
+                    ),
+                }
+            )
         else:
-            diagnoses.append({
-                "bug": None,
-                "severity": "info",
-                "summary": f"Task is in state '{task.state}'. No stuck indicators detected.",
-            })
+            diagnoses.append(
+                {
+                    "bug": None,
+                    "severity": "info",
+                    "summary": f"Task is in state '{task.state}'. No stuck indicators detected.",
+                }
+            )
 
     return diagnoses
 
@@ -1090,14 +1094,11 @@ def _simulate_fifo_blocking(task, redis_conn):
     # Fetch the oldest 20 waiting tasks (same query as fetch_task) that are
     # older than our target task
     fetch_limit = 20
-    older_tasks = (
-        Task.objects.filter(
-            state=TASK_STATES.WAITING,
-            app_lock__isnull=True,
-            pulp_created__lt=task.pulp_created,
-        )
-        .order_by("pulp_created")[:fetch_limit]
-    )
+    older_tasks = Task.objects.filter(
+        state=TASK_STATES.WAITING,
+        app_lock__isnull=True,
+        pulp_created__lt=task.pulp_created,
+    ).order_by("pulp_created")[:fetch_limit]
 
     blocked_exclusive = set()
     blocked_shared = set()
@@ -1249,11 +1250,7 @@ class TaskDebugView(APIView):
                     status=status.HTTP_404_NOT_FOUND,
                 )
 
-            exclusive_resources = [
-                r
-                for r in task.reserved_resources_record or []
-                if not r.startswith("shared:")
-            ]
+            exclusive_resources = [r for r in task.reserved_resources_record or [] if not r.startswith("shared:")]
 
             # Queue position (enhanced for Bug 3)
             older_waiting = Task.objects.filter(
@@ -1289,8 +1286,7 @@ class TaskDebugView(APIView):
                     overlap = [
                         r
                         for r in bt.reserved_resources_record or []
-                        if r in exclusive_resources
-                        or r.removeprefix("shared:") in exclusive_resources
+                        if r in exclusive_resources or r.removeprefix("shared:") in exclusive_resources
                     ]
                     blocking.append(
                         {
@@ -1332,8 +1328,13 @@ class TaskDebugView(APIView):
 
             # Automated diagnosis
             diagnosis = _diagnose_stuck_task(
-                task, app_lock_info, redis_locks, queue_position,
-                version_compat, lock_holder_liveness, fifo_analysis,
+                task,
+                app_lock_info,
+                redis_locks,
+                queue_position,
+                version_compat,
+                lock_holder_liveness,
+                fifo_analysis,
             )
 
             return Response(
@@ -1344,23 +1345,15 @@ class TaskDebugView(APIView):
                         "name": task.name,
                         "logging_cid": task.logging_cid,
                         "pulp_created": task.pulp_created.isoformat(),
-                        "unblocked_at": task.unblocked_at.isoformat()
-                        if task.unblocked_at
-                        else None,
-                        "started_at": task.started_at.isoformat()
-                        if task.started_at
-                        else None,
-                        "finished_at": task.finished_at.isoformat()
-                        if task.finished_at
-                        else None,
+                        "unblocked_at": task.unblocked_at.isoformat() if task.unblocked_at else None,
+                        "started_at": task.started_at.isoformat() if task.started_at else None,
+                        "finished_at": task.finished_at.isoformat() if task.finished_at else None,
                         "immediate": task.immediate,
                         "deferred": task.deferred,
                         "error": task.error,
                         "reserved_resources_record": task.reserved_resources_record,
                         "versions": task.versions,
-                        "parent_task": str(task.parent_task_id)
-                        if task.parent_task_id
-                        else None,
+                        "parent_task": str(task.parent_task_id) if task.parent_task_id else None,
                         "domain": task.pulp_domain.name if task.pulp_domain else None,
                     },
                     "diagnosis": diagnosis,
@@ -1429,9 +1422,7 @@ class TaskQueueView(APIView):
             ).count()
 
             tasks = (
-                Task.objects.filter(
-                    state__in=[TASK_STATES.WAITING, TASK_STATES.RUNNING]
-                )
+                Task.objects.filter(state__in=[TASK_STATES.WAITING, TASK_STATES.RUNNING])
                 .select_related("pulp_domain", "app_lock")
                 .order_by("pulp_created")[:limit]
             )
@@ -1483,9 +1474,7 @@ class TaskQueueView(APIView):
                         "name": task.name,
                         "logging_cid": task.logging_cid,
                         "pulp_created": task.pulp_created.isoformat(),
-                        "started_at": task.started_at.isoformat()
-                        if task.started_at
-                        else None,
+                        "started_at": task.started_at.isoformat() if task.started_at else None,
                         "immediate": task.immediate,
                         "deferred": task.deferred,
                         "domain": task.pulp_domain.name if task.pulp_domain else None,
@@ -1499,9 +1488,7 @@ class TaskQueueView(APIView):
                             "exclusive_resources_locked": sum(
                                 1 for r in redis_locks["exclusive_resources"] if r["held"]
                             ),
-                            "shared_resources_locked": sum(
-                                1 for r in redis_locks["shared_resources"] if r["held"]
-                            ),
+                            "shared_resources_locked": sum(1 for r in redis_locks["shared_resources"] if r["held"]),
                             "blocked_by": sorted(blocked_by),
                         },
                         "diagnoses": task_diagnoses,
@@ -1515,10 +1502,7 @@ class TaskQueueView(APIView):
             }
 
             # Identify orphaned lock holders across all examined tasks
-            orphaned_holders = [
-                name for name, info in lock_holder_liveness.items()
-                if not info.get("online", True)
-            ]
+            orphaned_holders = [name for name, info in lock_holder_liveness.items() if not info.get("online", True)]
             if orphaned_holders:
                 queue_health["orphaned_lock_holders"] = orphaned_holders
 
@@ -1586,13 +1570,15 @@ def _correlate_orphaned_locks_to_tasks(orphaned_resource_locks):
 
         task_summaries = []
         for task in matching_tasks:
-            task_summaries.append({
-                "task_id": str(task.pk),
-                "state": task.state,
-                "name": task.name,
-                "pulp_created": task.pulp_created.isoformat(),
-                "app_lock": task.app_lock.name if task.app_lock else None,
-            })
+            task_summaries.append(
+                {
+                    "task_id": str(task.pk),
+                    "state": task.state,
+                    "name": task.name,
+                    "pulp_created": task.pulp_created.isoformat(),
+                    "app_lock": task.app_lock.name if task.app_lock else None,
+                }
+            )
 
         if task_summaries:
             correlations[resource] = task_summaries
@@ -1652,7 +1638,9 @@ class StaleLockScanView(APIView):
             )
 
         include_healthy = request.GET.get("include_healthy", "").lower() in (
-            "true", "1", "yes",
+            "true",
+            "1",
+            "yes",
         )
 
         # Pagination parameters
@@ -1687,12 +1675,16 @@ class StaleLockScanView(APIView):
 
             if scan_type in ("resource", "all"):
                 resource_locks, next_resource_cursor = scan_resource_locks(
-                    redis_conn, cursor=req_cursor, max_keys=page_size,
+                    redis_conn,
+                    cursor=req_cursor,
+                    max_keys=page_size,
                 )
 
             if scan_type in ("task", "all"):
                 task_locks_list, next_task_cursor = scan_task_locks(
-                    redis_conn, cursor=req_cursor, max_keys=page_size,
+                    redis_conn,
+                    cursor=req_cursor,
+                    max_keys=page_size,
                 )
 
             # Determine the combined next_cursor.  When scanning "all" we
@@ -1722,14 +1714,11 @@ class StaleLockScanView(APIView):
             healthy_resource_locks = []
             for lock_info in resource_locks:
                 orphaned_holders = [
-                    h for h in lock_info["holders"]
-                    if not lock_holder_liveness.get(h, {}).get("online", False)
+                    h for h in lock_info["holders"] if not lock_holder_liveness.get(h, {}).get("online", False)
                 ]
                 if orphaned_holders:
                     lock_info["orphaned_holders"] = orphaned_holders
-                    lock_info["healthy_holders"] = [
-                        h for h in lock_info["holders"] if h not in orphaned_holders
-                    ]
+                    lock_info["healthy_holders"] = [h for h in lock_info["holders"] if h not in orphaned_holders]
                     orphaned_resource_locks.append(lock_info)
                 else:
                     healthy_resource_locks.append(lock_info)
@@ -1738,17 +1727,13 @@ class StaleLockScanView(APIView):
             healthy_task_locks = []
             for lock_info in task_locks_list:
                 holder = lock_info["holder"]
-                if holder and not lock_holder_liveness.get(
-                    holder, {}
-                ).get("online", False):
+                if holder and not lock_holder_liveness.get(holder, {}).get("online", False):
                     orphaned_task_locks.append(lock_info)
                 else:
                     healthy_task_locks.append(lock_info)
 
             # Phase 4: Correlate orphaned resource locks to tasks
-            task_correlations = _correlate_orphaned_locks_to_tasks(
-                orphaned_resource_locks
-            )
+            task_correlations = _correlate_orphaned_locks_to_tasks(orphaned_resource_locks)
 
             # Also correlate orphaned task locks -- check if the task still
             # exists and what state it is in
@@ -1776,10 +1761,7 @@ class StaleLockScanView(APIView):
                 "orphaned_task_locks": len(orphaned_task_locks),
                 "healthy_task_locks": len(healthy_task_locks),
                 "unique_lock_holders": len(all_holders),
-                "dead_lock_holders": sum(
-                    1 for info in lock_holder_liveness.values()
-                    if not info.get("online", False)
-                ),
+                "dead_lock_holders": sum(1 for info in lock_holder_liveness.values() if not info.get("online", False)),
             }
 
             response_data = {
@@ -1842,26 +1824,27 @@ class StaleLockCleanupDispatcherView(APIView):
 
     def get(self, request):
         """Return endpoint documentation."""
-        return Response({
-            "description": (
-                "POST to dispatch a background task that scans all Redis "
-                "resource locks and task locks, identifies orphaned locks "
-                "held by dead workers, and removes them.  The task result "
-                "contains a summary with counts of scanned, orphaned, and "
-                "cleaned locks."
-            ),
-            "task_name": "pulp_service.app.tasks.stale_lock_cleanup.cleanup_stale_locks",
-            "schedule": "Runs automatically every 6 hours",
-            "usage": {
-                "endpoint": "/api/pulp/debug/cleanup-stale-locks/",
-                "method": "POST",
-                "authentication": "Admin user required",
-            },
-        })
+        return Response(
+            {
+                "description": (
+                    "POST to dispatch a background task that scans all Redis "
+                    "resource locks and task locks, identifies orphaned locks "
+                    "held by dead workers, and removes them.  The task result "
+                    "contains a summary with counts of scanned, orphaned, and "
+                    "cleaned locks."
+                ),
+                "task_name": "pulp_service.app.tasks.stale_lock_cleanup.cleanup_stale_locks",
+                "schedule": "Runs automatically every 6 hours",
+                "usage": {
+                    "endpoint": "/api/pulp/debug/cleanup-stale-locks/",
+                    "method": "POST",
+                    "authentication": "Admin user required",
+                },
+            }
+        )
 
 
 class CreateDomainView(APIView):
-
     permission_classes = [DomainBasedPermission]
     """
     Custom endpoint to create domains with service-specific logic.
@@ -1884,17 +1867,13 @@ class CreateDomainView(APIView):
         custom_group_name = request.data.get("group_name")
 
         if not domain_name:
-            return Response(
-                {"error": "Domain name is required."}, status=status.HTTP_400_BAD_REQUEST
-            )
+            return Response({"error": "Domain name is required."}, status=status.HTTP_400_BAD_REQUEST)
 
         try:
             if custom_group_name:
                 group, created = Group.objects.get_or_create(name=custom_group_name)
                 if created:
-                    _logger.info(
-                        f"Created new group '{custom_group_name}' for user {user.username}."
-                    )
+                    _logger.info(f"Created new group '{custom_group_name}' for user {user.username}.")
                     user.groups.add(group)
                     _logger.info(f"Added user {user.username} to new group '{custom_group_name}'.")
                 else:
@@ -1905,8 +1884,7 @@ class CreateDomainView(APIView):
             elif not user.groups.exists():
                 group_name = f"domain-{domain_name}"
                 _logger.info(
-                    f"User {user.username} has no groups. "
-                    f"Creating or finding group '{group_name}' for domain creation."
+                    f"User {user.username} has no groups. Creating or finding group '{group_name}' for domain creation."
                 )
                 group, created = Group.objects.get_or_create(name=group_name)
                 if created:
@@ -1957,14 +1935,9 @@ class CreateDomainView(APIView):
         return Response(response_data, status=status.HTTP_201_CREATED)
 
 
-class AgentScanReportView(
-    NamedModelViewSet, ListModelMixin, RetrieveModelMixin, DestroyModelMixin
-):
-
+class AgentScanReportView(NamedModelViewSet, ListModelMixin, RetrieveModelMixin, DestroyModelMixin):
     endpoint_name = "agent_scan_report"
-    queryset = AgentScanReport.objects.prefetch_related("repo_versions").select_related(
-        "content"
-    )
+    queryset = AgentScanReport.objects.prefetch_related("repo_versions").select_related("content")
     serializer_class = AgentScanReportSerializer
 
     @classmethod

--- a/pulp_service/pulp_service/tests/functional/conftest.py
+++ b/pulp_service/pulp_service/tests/functional/conftest.py
@@ -25,13 +25,10 @@ def vuln_report_service_api(service_bindings):
     return service_bindings.VulnReportServiceApi
 
 
-
 @pytest.fixture(scope="session")
 def pypi_yank_monitor_api(service_bindings):
     """PyPI Yank Monitor API fixture."""
     return service_bindings.PypiYankMonitorApi
-
-
 
 
 @pytest.fixture(scope="session")
@@ -43,11 +40,11 @@ def service_content_guards_api_client(service_bindings):
 @pytest.fixture
 def gen_group(pulpcore_bindings, gen_object_with_cleanup):
     """A fixture to create a group."""
+
     def _gen_group(name=None):
         name = name or str(uuid.uuid4())
-        return gen_object_with_cleanup(
-            pulpcore_bindings.GroupsApi, {"name": name}
-        )
+        return gen_object_with_cleanup(pulpcore_bindings.GroupsApi, {"name": name})
+
     return _gen_group
 
 
@@ -73,10 +70,6 @@ def cleanup_auth_headers(request, pulpcore_bindings):
     if "python_bindings" in request.fixturenames:
         python_bindings = request.getfixturevalue("python_bindings")
         if hasattr(python_bindings, "RepositoriesPythonApi"):
-            python_bindings.RepositoriesPythonApi.api_client.default_headers.pop(
-                "x-rh-identity", None
-            )
+            python_bindings.RepositoriesPythonApi.api_client.default_headers.pop("x-rh-identity", None)
         if hasattr(python_bindings, "DistributionsPypiApi"):
-            python_bindings.DistributionsPypiApi.api_client.default_headers.pop(
-                "x-rh-identity", None
-            )
+            python_bindings.DistributionsPypiApi.api_client.default_headers.pop("x-rh-identity", None)

--- a/pulp_service/pulp_service/tests/functional/constants.py
+++ b/pulp_service/pulp_service/tests/functional/constants.py
@@ -32,11 +32,11 @@ NOT_YANKED_PACKAGES = [
 ]
 
 # CONTENT GUARD CONSTANTS
-CONTENT_GUARD_HEADER_NAME="x-rh-identity"
-CONTENT_GUARD_HEADER_VALUE='eyJpZGVudGl0eSI6IHsib3JnX2lkIjogIjE5Nzk3MTAifX0=' 
-CONTENT_GUARD_FEATURES=[ "OPENSHIFT-OCP-x86_64", "RHEL-HA-x86_64" ]
-CONTENT_GUARD_FEATURES_NOT_SUBSCRIBED=[ "rhods" ]
-CONTENT_GUARD_FILTER='.identity.org_id'
+CONTENT_GUARD_HEADER_NAME = "x-rh-identity"
+CONTENT_GUARD_HEADER_VALUE = "eyJpZGVudGl0eSI6IHsib3JnX2lkIjogIjE5Nzk3MTAifX0="
+CONTENT_GUARD_FEATURES = ["OPENSHIFT-OCP-x86_64", "RHEL-HA-x86_64"]
+CONTENT_GUARD_FEATURES_NOT_SUBSCRIBED = ["rhods"]
+CONTENT_GUARD_FILTER = ".identity.org_id"
 
 # VULNERABILITY REPORT CONSTANTS
 # NPM
@@ -70,9 +70,7 @@ GEM_VULNERABILITY_PACKAGE = "rails-7.0.1"
 GEM_VULNERABILITY_IDS = ["GHSA-9822-6m93-xqf4"]
 
 # RPM
-RPM_SAMPLE_PACKAGE_URL = (
-    "https://vault.centos.org/7.0.1406/os/x86_64/Packages/kernel-3.10.0-123.el7.x86_64.rpm"
-)
+RPM_SAMPLE_PACKAGE_URL = "https://vault.centos.org/7.0.1406/os/x86_64/Packages/kernel-3.10.0-123.el7.x86_64.rpm"
 RPM_SAMPLE_RH_CPE = '["cpe:/o:redhat:enterprise_linux:7::workstation"]'
 RPM_VULNERABILITY_PACKAGE = "kernel-3.10.0"
 RPM_VULNERABILITY_IDS = [
@@ -186,18 +184,8 @@ OSV_SCHEMA = {
                                 },
                                 {
                                     "title": "last_affected and fixed events are mutually exclusive",
-                                    "if": {
-                                        "properties": {
-                                            "events": {"contains": {"required": ["last_affected"]}}
-                                        }
-                                    },
-                                    "then": {
-                                        "not": {
-                                            "properties": {
-                                                "events": {"contains": {"required": ["fixed"]}}
-                                            }
-                                        }
-                                    },
+                                    "if": {"properties": {"events": {"contains": {"required": ["last_affected"]}}}},
+                                    "then": {"not": {"properties": {"events": {"contains": {"required": ["fixed"]}}}}},
                                 },
                             ],
                             "required": ["type", "events"],
@@ -267,11 +255,7 @@ OSV_SCHEMA = {
     "allOf": [
         {
             "if": {"required": ["severity"]},
-            "then": {
-                "properties": {
-                    "affected": {"items": {"properties": {"severity": {"type": "null"}}}}
-                }
-            },
+            "then": {"properties": {"affected": {"items": {"properties": {"severity": {"type": "null"}}}}}},
         }
     ],
     "$defs": {
@@ -371,11 +355,7 @@ OSV_SCHEMA = {
                     {
                         "if": {"properties": {"type": {"const": "Ubuntu"}}},
                         "then": {
-                            "properties": {
-                                "score": {
-                                    "enum": ["negligible", "low", "medium", "high", "critical"]
-                                }
-                            }
+                            "properties": {"score": {"enum": ["negligible", "low", "medium", "high", "critical"]}}
                         },
                     },
                 ],

--- a/pulp_service/pulp_service/tests/functional/test_attestation_verification.py
+++ b/pulp_service/pulp_service/tests/functional/test_attestation_verification.py
@@ -103,10 +103,7 @@ def _make_provenance(attestation):
 def test_private_key(pulp_settings):
     """Load the CI-generated test attestation signing key."""
     if not os.path.exists(TEST_PRIVATE_KEY_PATH):
-        pytest.skip(
-            f"Test attestation private key not found at {TEST_PRIVATE_KEY_PATH} "
-            "(not running in CI container?)"
-        )
+        pytest.skip(f"Test attestation private key not found at {TEST_PRIVATE_KEY_PATH} (not running in CI container?)")
     if pulp_settings.ATTESTATION_VERIFICATION_KEY != TEST_PUBLIC_KEY_PATH:
         pytest.fail(f"ATTESTATION_VERIFICATION_KEY is not set to {TEST_PUBLIC_KEY_PATH}")
     with open(TEST_PRIVATE_KEY_PATH, "rb") as f:

--- a/pulp_service/pulp_service/tests/functional/test_authentication.py
+++ b/pulp_service/pulp_service/tests/functional/test_authentication.py
@@ -37,9 +37,7 @@ def test_authentication_with_username_and_org_id(
         assert domain.name == domain_name
 
         # Create a repository in the domain to verify permissions work
-        python_bindings.RepositoriesPythonApi.api_client.default_headers["x-rh-identity"] = (
-            auth_header
-        )
+        python_bindings.RepositoriesPythonApi.api_client.default_headers["x-rh-identity"] = auth_header
 
         repo = gen_object_with_cleanup(
             python_bindings.RepositoriesPythonApi, {"name": str(uuid4())}, pulp_domain=domain_name
@@ -77,9 +75,7 @@ def test_authentication_with_org_id_and_username(
         assert domain.name == domain_name
 
         # Create a repository in the domain to verify permissions work
-        python_bindings.RepositoriesPythonApi.api_client.default_headers["x-rh-identity"] = (
-            auth_header
-        )
+        python_bindings.RepositoriesPythonApi.api_client.default_headers["x-rh-identity"] = auth_header
 
         repo = gen_object_with_cleanup(
             python_bindings.RepositoriesPythonApi, {"name": str(uuid4())}, pulp_domain=domain_name
@@ -149,18 +145,14 @@ def test_get_requests_without_auth_to_simple_api(
         )
 
         # Create a Python repository
-        python_bindings.RepositoriesPythonApi.api_client.default_headers["x-rh-identity"] = (
-            auth_header
-        )
+        python_bindings.RepositoriesPythonApi.api_client.default_headers["x-rh-identity"] = auth_header
 
         repo = gen_object_with_cleanup(
             python_bindings.RepositoriesPythonApi, {"name": str(uuid4())}, pulp_domain=domain_name
         )
 
         # Create a Python distribution
-        python_bindings.DistributionsPypiApi.api_client.default_headers["x-rh-identity"] = (
-            auth_header
-        )
+        python_bindings.DistributionsPypiApi.api_client.default_headers["x-rh-identity"] = auth_header
         base_path = str(uuid4())
         gen_object_with_cleanup(
             python_bindings.DistributionsPypiApi,
@@ -177,9 +169,7 @@ def test_get_requests_without_auth_to_simple_api(
 
         # GET request should succeed for any domain without auth
         response = requests.get(simple_url)
-        assert (
-            response.status_code == 200
-        ), f"Expected 200 for GET on domain, got {response.status_code}"
+        assert response.status_code == 200, f"Expected 200 for GET on domain, got {response.status_code}"
 
         # POST request should be blocked (401/403) without auth
         response = requests.post(simple_url, data={})
@@ -258,9 +248,7 @@ def test_public_domain_allows_unauthenticated_get(
         )
 
         # Create a repository in the public domain
-        python_bindings.RepositoriesPythonApi.api_client.default_headers["x-rh-identity"] = (
-            auth_header
-        )
+        python_bindings.RepositoriesPythonApi.api_client.default_headers["x-rh-identity"] = auth_header
         gen_object_with_cleanup(
             python_bindings.RepositoriesPythonApi,
             {"name": str(uuid4())},
@@ -275,18 +263,12 @@ def test_public_domain_allows_unauthenticated_get(
         )
 
         api_host = pulpcore_bindings.DomainsApi.api_client.configuration.host
-        public_repos_url = (
-            f"{api_host}/api/pulp/{public_domain_name}/api/v3/repositories/python/python/"
-        )
-        private_repos_url = (
-            f"{api_host}/api/pulp/{private_domain_name}/api/v3/repositories/python/python/"
-        )
+        public_repos_url = f"{api_host}/api/pulp/{public_domain_name}/api/v3/repositories/python/python/"
+        private_repos_url = f"{api_host}/api/pulp/{private_domain_name}/api/v3/repositories/python/python/"
 
         # GET request on public domain should succeed without auth
         response = requests.get(public_repos_url)
-        assert (
-            response.status_code == 200
-        ), f"Expected 200 for GET on public domain, got {response.status_code}"
+        assert response.status_code == 200, f"Expected 200 for GET on public domain, got {response.status_code}"
 
         # GET request on non-public domain should be blocked without auth
         response = requests.get(private_repos_url)
@@ -326,4 +308,3 @@ def test_public_domain_allows_unauthenticated_get(
         # Clean up headers
         pulpcore_bindings.DomainsApi.api_client.default_headers.pop("x-rh-identity", None)
         python_bindings.RepositoriesPythonApi.api_client.default_headers.pop("x-rh-identity", None)
- 

--- a/pulp_service/pulp_service/tests/functional/test_domain_based_permissions.py
+++ b/pulp_service/pulp_service/tests/functional/test_domain_based_permissions.py
@@ -7,98 +7,55 @@ from base64 import b64encode
 
 def test_user_domain_repo_creation(pulpcore_bindings, file_bindings, anonymous_user, gen_object_with_cleanup):
 
-    user1_orgid1 = {
-        "identity": {
-            "org_id": 1,
-            "internal": {
-                "org_id": 1
-            },
-            "user": {
-                "username": "user1"
-            }
-        }
-    }
+    user1_orgid1 = {"identity": {"org_id": 1, "internal": {"org_id": 1}, "user": {"username": "user1"}}}
 
-    user2_orgid1 = {
-        "identity": {
-            "org_id": 1,
-            "internal": {
-                "org_id": 1
-            },
-            "user": {
-                "username": "user2"
-            }
-        }
-    }
+    user2_orgid1 = {"identity": {"org_id": 1, "internal": {"org_id": 1}, "user": {"username": "user2"}}}
 
     with anonymous_user:
         header_user1_orgid1 = json.dumps(user1_orgid1)
         auth_user1_orgid1 = b64encode(bytes(header_user1_orgid1, "ascii"))
 
-        pulpcore_bindings.DomainsApi.api_client.default_headers["x-rh-identity"] = (
-            auth_user1_orgid1
-        )
+        pulpcore_bindings.DomainsApi.api_client.default_headers["x-rh-identity"] = auth_user1_orgid1
 
         domain_name = str(uuid4())
         gen_object_with_cleanup(
-            pulpcore_bindings.DomainsApi, {
+            pulpcore_bindings.DomainsApi,
+            {
                 "name": domain_name,
                 "storage_class": "pulpcore.app.models.storage.FileSystem",
                 "storage_settings": {"MEDIA_ROOT": "/var/lib/pulp/media/"},
-            }
+            },
         )
 
         # Use User1 OrgID1 auth credentials
-        file_bindings.RepositoriesFileApi.api_client.default_headers["x-rh-identity"] = (
-            auth_user1_orgid1
-        )
+        file_bindings.RepositoriesFileApi.api_client.default_headers["x-rh-identity"] = auth_user1_orgid1
 
         # User1 from OrgID1 create a repo on his domain
-        gen_object_with_cleanup(
-            file_bindings.RepositoriesFileApi, {"name": str(uuid4())}, pulp_domain=domain_name
-        )
+        gen_object_with_cleanup(file_bindings.RepositoriesFileApi, {"name": str(uuid4())}, pulp_domain=domain_name)
 
         header_user2_orgid1 = json.dumps(user2_orgid1)
         auth_user2_orgid1 = b64encode(bytes(header_user2_orgid1, "ascii"))
 
         # Use User2 OrgID1 auth credentials
-        file_bindings.RepositoriesFileApi.api_client.default_headers["x-rh-identity"] = (
-            auth_user2_orgid1
-        )
+        file_bindings.RepositoriesFileApi.api_client.default_headers["x-rh-identity"] = auth_user2_orgid1
 
         # User 2 from OrgID2 create a repo on his domain
-        gen_object_with_cleanup(
-            file_bindings.RepositoriesFileApi, {"name": str(uuid4())}, pulp_domain=domain_name
-        )
+        gen_object_with_cleanup(file_bindings.RepositoriesFileApi, {"name": str(uuid4())}, pulp_domain=domain_name)
 
         # Users are not allowed to create pulp object outside of their domains
         with pytest.raises(file_bindings.ApiException) as exp:
-            gen_object_with_cleanup(
-                file_bindings.RepositoriesFileApi, {"name": str(uuid4())}
-            )
+            gen_object_with_cleanup(file_bindings.RepositoriesFileApi, {"name": str(uuid4())})
 
         assert exp.value.status == 403
 
 
 def test_user_list_domain_permissions(pulpcore_bindings, anonymous_user):
 
-    user1_orgid1 = {
-        "identity": {
-            "org_id": 1,
-            "internal": {
-                "org_id": 1
-            },
-            "user": {
-                "username": "user1"
-            }
-        }
-    }
+    user1_orgid1 = {"identity": {"org_id": 1, "internal": {"org_id": 1}, "user": {"username": "user1"}}}
 
     with anonymous_user:
         # Clear any authentication header
-        pulpcore_bindings.DomainsApi.api_client.default_headers.pop(
-            "x-rh-identity", None
-        )
+        pulpcore_bindings.DomainsApi.api_client.default_headers.pop("x-rh-identity", None)
         with pytest.raises(pulpcore_bindings.ApiException) as exp:
             pulpcore_bindings.DomainsApi.list()
 
@@ -108,68 +65,41 @@ def test_user_list_domain_permissions(pulpcore_bindings, anonymous_user):
         header_user1_orgid1 = json.dumps(user1_orgid1)
         auth_user1_orgid1 = b64encode(bytes(header_user1_orgid1, "ascii"))
 
-        pulpcore_bindings.DomainsApi.api_client.default_headers["x-rh-identity"] = (
-            auth_user1_orgid1
-        )
+        pulpcore_bindings.DomainsApi.api_client.default_headers["x-rh-identity"] = auth_user1_orgid1
 
         pulpcore_bindings.DomainsApi.list()
 
 
 def test_only_owners_can_delete_domain(pulpcore_bindings, anonymous_user, gen_object_with_cleanup, monitor_task):
-    user1_orgid1 = {
-        "identity": {
-            "org_id": 1,
-            "internal": {
-                "org_id": 1
-            },
-            "user": {
-                "username": "user1"
-            }
-        }
-    }
+    user1_orgid1 = {"identity": {"org_id": 1, "internal": {"org_id": 1}, "user": {"username": "user1"}}}
 
-    user2_orgid2 = {
-        "identity": {
-            "org_id": 2,
-            "internal": {
-                "org_id": 2
-            },
-            "user": {
-                "username": "user2"
-            }
-        }
-    }
+    user2_orgid2 = {"identity": {"org_id": 2, "internal": {"org_id": 2}, "user": {"username": "user2"}}}
 
     with anonymous_user:
         # Clear any authentication header
-        pulpcore_bindings.DomainsApi.api_client.default_headers.pop(
-            "x-rh-identity", None
-        )
+        pulpcore_bindings.DomainsApi.api_client.default_headers.pop("x-rh-identity", None)
 
         header_user1_orgid1 = json.dumps(user1_orgid1)
         auth_user1_orgid1 = b64encode(bytes(header_user1_orgid1, "ascii"))
 
-        pulpcore_bindings.DomainsApi.api_client.default_headers["x-rh-identity"] = (
-            auth_user1_orgid1
-        )
+        pulpcore_bindings.DomainsApi.api_client.default_headers["x-rh-identity"] = auth_user1_orgid1
 
         # User 1 creates a domain
         domain_name = str(uuid4())
         domain = gen_object_with_cleanup(
-            pulpcore_bindings.DomainsApi, {
+            pulpcore_bindings.DomainsApi,
+            {
                 "name": domain_name,
                 "storage_class": "pulpcore.app.models.storage.FileSystem",
                 "storage_settings": {"MEDIA_ROOT": "/var/lib/pulp/media/"},
-            }
+            },
         )
 
         # User 2 tries to delete the domain
         header_user2_orgid2 = json.dumps(user2_orgid2)
         auth_user2_orgid2 = b64encode(bytes(header_user2_orgid2, "ascii"))
 
-        pulpcore_bindings.DomainsApi.api_client.default_headers["x-rh-identity"] = (
-            auth_user2_orgid2
-        )
+        pulpcore_bindings.DomainsApi.api_client.default_headers["x-rh-identity"] = auth_user2_orgid2
 
         with pytest.raises(pulpcore_bindings.ApiException) as exp:
             pulpcore_bindings.DomainsApi.delete(domain.pulp_href)
@@ -177,81 +107,65 @@ def test_only_owners_can_delete_domain(pulpcore_bindings, anonymous_user, gen_ob
         assert exp.value.status == 403
 
         # Check if User 1 can delete his own domain
-        pulpcore_bindings.DomainsApi.api_client.default_headers["x-rh-identity"] = (
-            auth_user1_orgid1
-        )
+        pulpcore_bindings.DomainsApi.api_client.default_headers["x-rh-identity"] = auth_user1_orgid1
         pulpcore_bindings.DomainsApi.delete(domain.pulp_href)
 
 
 def test_operations_using_basic_auth(pulpcore_bindings, file_bindings, gen_user, gen_object_with_cleanup):
-    pulpcore_bindings.DomainsApi.api_client.default_headers.pop(
-        "x-rh-identity", None
-    )
+    pulpcore_bindings.DomainsApi.api_client.default_headers.pop("x-rh-identity", None)
 
     somebody = gen_user(username="somebody")
 
     with somebody:
         # Clear any authentication header
-        pulpcore_bindings.DomainsApi.api_client.default_headers.pop(
-            "x-rh-identity", None
-        )
-        file_bindings.RepositoriesFileApi.api_client.default_headers.pop(
-            "x-rh-identity", None
-        )
+        pulpcore_bindings.DomainsApi.api_client.default_headers.pop("x-rh-identity", None)
+        file_bindings.RepositoriesFileApi.api_client.default_headers.pop("x-rh-identity", None)
 
         domain_name = str(uuid4())
         gen_object_with_cleanup(
-            pulpcore_bindings.DomainsApi, {
+            pulpcore_bindings.DomainsApi,
+            {
                 "name": domain_name,
                 "storage_class": "pulpcore.app.models.storage.FileSystem",
                 "storage_settings": {"MEDIA_ROOT": "/var/lib/pulp/media/"},
-            }
+            },
         )
 
-        gen_object_with_cleanup(
-            file_bindings.RepositoriesFileApi, {"name": str(uuid4())}, pulp_domain=domain_name
-        )
+        gen_object_with_cleanup(file_bindings.RepositoriesFileApi, {"name": str(uuid4())}, pulp_domain=domain_name)
 
 
-def test_user_permissions_without_orgId(pulpcore_bindings, file_bindings, anonymous_user, gen_object_with_cleanup, monitor_task):
+def test_user_permissions_without_orgId(
+    pulpcore_bindings, file_bindings, anonymous_user, gen_object_with_cleanup, monitor_task
+):
     user1 = {
         "identity": {
             "org_id": 1,
-            "user": {
-                "username": "user1"
-            },
-            "internal": {
-                "org_id": 1
-            },
+            "user": {"username": "user1"},
+            "internal": {"org_id": 1},
         }
     }
 
     with anonymous_user:
         # Clear any authentication header
-        pulpcore_bindings.DomainsApi.api_client.default_headers.pop(
-            "x-rh-identity", None
-        )
+        pulpcore_bindings.DomainsApi.api_client.default_headers.pop("x-rh-identity", None)
 
         header_user1 = json.dumps(user1)
         auth_user1 = b64encode(bytes(header_user1, "ascii"))
 
-        pulpcore_bindings.DomainsApi.api_client.default_headers["x-rh-identity"] = (
-            auth_user1
-        )
+        pulpcore_bindings.DomainsApi.api_client.default_headers["x-rh-identity"] = auth_user1
 
         domain_name = str(uuid4())
 
         domain = gen_object_with_cleanup(
-            pulpcore_bindings.DomainsApi, {
+            pulpcore_bindings.DomainsApi,
+            {
                 "name": domain_name,
                 "storage_class": "pulpcore.app.models.storage.FileSystem",
                 "storage_settings": {"MEDIA_ROOT": "/var/lib/pulp/media/"},
-            }
+            },
         )
 
-        file_bindings.RepositoriesFileApi.api_client.default_headers["x-rh-identity"] = (
-            auth_user1
-        )
+        file_bindings.RepositoriesFileApi.api_client.default_headers["x-rh-identity"] = auth_user1
 
         repo = gen_object_with_cleanup(
             file_bindings.RepositoriesFileApi, {"name": str(uuid4())}, pulp_domain=domain_name
@@ -261,41 +175,36 @@ def test_user_permissions_without_orgId(pulpcore_bindings, file_bindings, anonym
         pulpcore_bindings.DomainsApi.delete(domain.pulp_href)
 
 
-def test_admin_user_with_header_auth(pulpcore_bindings, file_bindings, bindings_cfg, anonymous_user, gen_object_with_cleanup, monitor_task):
+def test_admin_user_with_header_auth(
+    pulpcore_bindings, file_bindings, bindings_cfg, anonymous_user, gen_object_with_cleanup, monitor_task
+):
     username = bindings_cfg.username
 
     admin = {
         "identity": {
             "org_id": 1,
-            "user": {
-                "username": username
-            },
-            "internal": {
-                "org_id": 1
-            },
+            "user": {"username": username},
+            "internal": {"org_id": 1},
         }
     }
 
     auth_header = json.dumps(admin)
     admin_auth_header = b64encode(bytes(auth_header, "ascii"))
 
-    pulpcore_bindings.DomainsApi.api_client.default_headers["x-rh-identity"] = (
-        admin_auth_header
-    )
+    pulpcore_bindings.DomainsApi.api_client.default_headers["x-rh-identity"] = admin_auth_header
 
     domain_name = str(uuid4())
     with anonymous_user:
         domain = gen_object_with_cleanup(
-            pulpcore_bindings.DomainsApi, {
+            pulpcore_bindings.DomainsApi,
+            {
                 "name": domain_name,
                 "storage_class": "pulpcore.app.models.storage.FileSystem",
                 "storage_settings": {"MEDIA_ROOT": "/var/lib/pulp/media/"},
-            }
+            },
         )
 
-        file_bindings.RepositoriesFileApi.api_client.default_headers["x-rh-identity"] = (
-            admin_auth_header
-        )
+        file_bindings.RepositoriesFileApi.api_client.default_headers["x-rh-identity"] = admin_auth_header
 
         repo = gen_object_with_cleanup(
             file_bindings.RepositoriesFileApi, {"name": str(uuid4())}, pulp_domain=domain_name

--- a/pulp_service/pulp_service/tests/functional/test_feature_service.py
+++ b/pulp_service/pulp_service/tests/functional/test_feature_service.py
@@ -39,9 +39,7 @@ def configure_guarded_content(
         add_to_cleanup(service_content_guards_api_client, content_certguard.pulp_href)
 
         # create the distribution
-        distribution = rpm_distribution_factory(
-            repository=repo.pulp_href, content_guard=content_certguard.pulp_href
-        )
+        distribution = rpm_distribution_factory(repository=repo.pulp_href, content_guard=content_certguard.pulp_href)
 
         # sync content
         repository_sync_data = RpmRepositorySyncURL(remote=remote.pulp_href)

--- a/pulp_service/pulp_service/tests/functional/test_group_based_permissions.py
+++ b/pulp_service/pulp_service/tests/functional/test_group_based_permissions.py
@@ -3,6 +3,7 @@ from base64 import b64encode
 import pytest
 from uuid import uuid4
 
+
 def test_group_domain_permission(pulpcore_bindings, file_bindings, gen_group, gen_object_with_cleanup, anonymous_user):
     """
     Tests that a user can access a domain created by another user in the same group.
@@ -14,9 +15,7 @@ def test_group_domain_permission(pulpcore_bindings, file_bindings, gen_group, ge
     # Username must match RHTermsBasedRegistryAuthentication format: "org_id|username"
     user_a_name = f"user-a-in-team-{uuid4()}"
     user_a_combined = f"1|{user_a_name}"
-    gen_object_with_cleanup(
-        pulpcore_bindings.UsersApi, {"username": user_a_combined, "groups": [test_group.pulp_href]}
-    )
+    gen_object_with_cleanup(pulpcore_bindings.UsersApi, {"username": user_a_combined, "groups": [test_group.pulp_href]})
 
     gen_object_with_cleanup(
         pulpcore_bindings.GroupsUsersApi, group_href=test_group.pulp_href, group_user={"username": user_a_combined}
@@ -41,9 +40,7 @@ def test_group_domain_permission(pulpcore_bindings, file_bindings, gen_group, ge
     # 4. Create user_b and associate with the same group
     user_b_name = f"user-b-in-team-{uuid4()}"
     user_b_combined = f"1|{user_b_name}"
-    gen_object_with_cleanup(
-        pulpcore_bindings.UsersApi, {"username": user_b_combined}
-    )
+    gen_object_with_cleanup(pulpcore_bindings.UsersApi, {"username": user_b_combined})
     gen_object_with_cleanup(
         pulpcore_bindings.GroupsUsersApi, group_href=test_group.pulp_href, group_user={"username": user_b_combined}
     )
@@ -62,9 +59,7 @@ def test_group_domain_permission(pulpcore_bindings, file_bindings, gen_group, ge
     # 6. Create user_c, not in the group (different org)
     user_c_name = f"user-c-not-in-team-{uuid4()}"
     user_c_combined = f"2|{user_c_name}"
-    gen_object_with_cleanup(
-        pulpcore_bindings.UsersApi, {"username": user_c_combined}
-    )
+    gen_object_with_cleanup(pulpcore_bindings.UsersApi, {"username": user_c_combined})
 
     # 7. Verify user_c cannot create a repository in the domain
     user_c_identity = {"identity": {"org_id": 2, "internal": {"org_id": 2}, "user": {"username": user_c_name}}}
@@ -79,7 +74,10 @@ def test_group_domain_permission(pulpcore_bindings, file_bindings, gen_group, ge
             )
         assert exp.value.status == 403
 
-def test_domain_permission_for_user_without_group(pulpcore_bindings, file_bindings, gen_object_with_cleanup, anonymous_user):
+
+def test_domain_permission_for_user_without_group(
+    pulpcore_bindings, file_bindings, gen_object_with_cleanup, anonymous_user
+):
     """
     Tests that a user without a group can manage their own domain,
     and that another user cannot access it.
@@ -88,9 +86,7 @@ def test_domain_permission_for_user_without_group(pulpcore_bindings, file_bindin
     # Username must match RHTermsBasedRegistryAuthentication format: "org_id|username"
     user_a_name = f"user-a-no-group-{uuid4()}"
     user_a_combined = f"1|{user_a_name}"
-    gen_object_with_cleanup(
-        pulpcore_bindings.UsersApi, {"username": user_a_combined}
-    )
+    gen_object_with_cleanup(pulpcore_bindings.UsersApi, {"username": user_a_combined})
 
     # 2. Create a domain as user_a
     domain_name = str(uuid4())
@@ -120,9 +116,7 @@ def test_domain_permission_for_user_without_group(pulpcore_bindings, file_bindin
     # 4. Create user_b, also not in any group (different org)
     user_b_name = f"user-b-no-group-{uuid4()}"
     user_b_combined = f"2|{user_b_name}"
-    gen_object_with_cleanup(
-        pulpcore_bindings.UsersApi, {"username": user_b_combined}
-    )
+    gen_object_with_cleanup(pulpcore_bindings.UsersApi, {"username": user_b_combined})
 
     # 5. Verify user_b cannot create a repository in user_a's domain
     user_b_identity = {"identity": {"org_id": 2, "internal": {"org_id": 2}, "user": {"username": user_b_name}}}

--- a/pulp_service/pulp_service/tests/functional/test_pypi_yank_check.py
+++ b/pulp_service/pulp_service/tests/functional/test_pypi_yank_check.py
@@ -15,9 +15,7 @@ def test_pypi_yank_monitor_crud(pypi_yank_monitor_api, python_repo_factory, add_
     repo = python_repo_factory()
 
     # Create
-    monitor = pypi_yank_monitor_api.create(
-        ServicePyPIYankMonitor(name=str(uuid4()), repository=repo.pulp_href)
-    )
+    monitor = pypi_yank_monitor_api.create(ServicePyPIYankMonitor(name=str(uuid4()), repository=repo.pulp_href))
     add_to_cleanup(pypi_yank_monitor_api, monitor.pulp_href)
     assert monitor.repository == repo.pulp_href
     assert monitor.repository_version is None
@@ -27,15 +25,11 @@ def test_pypi_yank_monitor_crud(pypi_yank_monitor_api, python_repo_factory, add_
     assert any(m.pulp_href == monitor.pulp_href for m in result.results)
 
     # Retrieve
-    retrieved = pypi_yank_monitor_api.read(
-        service_py_p_i_yank_monitor_href=monitor.pulp_href
-    )
+    retrieved = pypi_yank_monitor_api.read(service_py_p_i_yank_monitor_href=monitor.pulp_href)
     assert retrieved.repository == repo.pulp_href
 
     # Delete
-    pypi_yank_monitor_api.delete(
-        service_py_p_i_yank_monitor_href=monitor.pulp_href
-    )
+    pypi_yank_monitor_api.delete(service_py_p_i_yank_monitor_href=monitor.pulp_href)
     result = pypi_yank_monitor_api.list()
     assert not any(m.pulp_href == monitor.pulp_href for m in result.results)
 
@@ -48,9 +42,7 @@ def test_pypi_yank_monitor_create_with_repo_version(
         python_python_repository_href=repo.pulp_href
     ).latest_version_href
 
-    monitor = pypi_yank_monitor_api.create(
-        ServicePyPIYankMonitor(name=str(uuid4()), repository_version=version_href)
-    )
+    monitor = pypi_yank_monitor_api.create(ServicePyPIYankMonitor(name=str(uuid4()), repository_version=version_href))
     add_to_cleanup(pypi_yank_monitor_api, monitor.pulp_href)
     assert monitor.repository_version == version_href
     assert monitor.repository is None
@@ -62,45 +54,35 @@ def test_pypi_yank_monitor_validation_neither(pypi_yank_monitor_api):
     assert exc_info.value.status == 400
 
 
-def test_pypi_yank_monitor_validation_non_python_repo(
-    pypi_yank_monitor_api, file_bindings, gen_object_with_cleanup
-):
-    file_repo = gen_object_with_cleanup(
-        file_bindings.RepositoriesFileApi, {"name": str(uuid4())}
-    )
+def test_pypi_yank_monitor_validation_non_python_repo(pypi_yank_monitor_api, file_bindings, gen_object_with_cleanup):
+    file_repo = gen_object_with_cleanup(file_bindings.RepositoriesFileApi, {"name": str(uuid4())})
     with pytest.raises(ApiException) as exc_info:
-        pypi_yank_monitor_api.create(
-            ServicePyPIYankMonitor(name=str(uuid4()), repository=file_repo.pulp_href)
-        )
+        pypi_yank_monitor_api.create(ServicePyPIYankMonitor(name=str(uuid4()), repository=file_repo.pulp_href))
     assert exc_info.value.status == 400
 
 
-def test_pypi_yank_monitor_report_not_found(
-    pypi_yank_monitor_api, python_repo_factory, add_to_cleanup
-):
+def test_pypi_yank_monitor_report_not_found(pypi_yank_monitor_api, python_repo_factory, add_to_cleanup):
     repo = python_repo_factory()
-    monitor = pypi_yank_monitor_api.create(
-        ServicePyPIYankMonitor(name=str(uuid4()), repository=repo.pulp_href)
-    )
+    monitor = pypi_yank_monitor_api.create(ServicePyPIYankMonitor(name=str(uuid4()), repository=repo.pulp_href))
     add_to_cleanup(pypi_yank_monitor_api, monitor.pulp_href)
 
     with pytest.raises(ApiException) as exc_info:
-        pypi_yank_monitor_api.report(
-            service_py_p_i_yank_monitor_href=monitor.pulp_href
-        )
+        pypi_yank_monitor_api.report(service_py_p_i_yank_monitor_href=monitor.pulp_href)
     assert exc_info.value.status == 404
 
 
-_CREATE_YANKED_PKG_CODE = "\n".join([
-    "import hashlib",
-    "from pulp_python.app.models import PythonPackageContent",
-    "sha = hashlib.sha256(b'attrs-21.1.0-py2.py3-none-any.whl').hexdigest()",
-    "pkg, _ = PythonPackageContent.objects.get_or_create(",
-    "    sha256=sha,",
-    "    defaults=dict(name='attrs', version='21.1.0',",
-    "        filename='attrs-21.1.0-py2.py3-none-any.whl', packagetype='bdist_wheel'))",
-    "print(f'/pulp/api/v3/content/python/packages/{pkg.pk}/')",
-])
+_CREATE_YANKED_PKG_CODE = "\n".join(
+    [
+        "import hashlib",
+        "from pulp_python.app.models import PythonPackageContent",
+        "sha = hashlib.sha256(b'attrs-21.1.0-py2.py3-none-any.whl').hexdigest()",
+        "pkg, _ = PythonPackageContent.objects.get_or_create(",
+        "    sha256=sha,",
+        "    defaults=dict(name='attrs', version='21.1.0',",
+        "        filename='attrs-21.1.0-py2.py3-none-any.whl', packagetype='bdist_wheel'))",
+        "print(f'/pulp/api/v3/content/python/packages/{pkg.pk}/')",
+    ]
+)
 
 _DELETE_YANKED_PKG_CODE = (
     "import hashlib\n"
@@ -127,46 +109,36 @@ def test_pypi_yank_monitor_scoped_check(
 
     result = subprocess.run(
         ["django-admin", "shell", "-c", _CREATE_YANKED_PKG_CODE],
-        check=True, capture_output=True, text=True,
+        check=True,
+        capture_output=True,
+        text=True,
     )
     pkg_href = result.stdout.strip()
     try:
         # Add the package to the repo via the REST API (creates a new repo version)
         modify_response = python_bindings.RepositoriesPythonApi.modify(
             python_python_repository_href=repo.pulp_href,
-            repository_add_remove_content=RepositoryAddRemoveContent(
-                add_content_units=[pkg_href]
-            ),
+            repository_add_remove_content=RepositoryAddRemoveContent(add_content_units=[pkg_href]),
         )
         monitor_task(modify_response.task)
 
-        monitor = pypi_yank_monitor_api.create(
-            ServicePyPIYankMonitor(name=str(uuid4()), repository=repo.pulp_href)
-        )
+        monitor = pypi_yank_monitor_api.create(ServicePyPIYankMonitor(name=str(uuid4()), repository=repo.pulp_href))
         add_to_cleanup(pypi_yank_monitor_api, monitor.pulp_href)
 
-        check_response = pypi_yank_monitor_api.check(
-            service_py_p_i_yank_monitor_href=monitor.pulp_href
-        )
+        check_response = pypi_yank_monitor_api.check(service_py_p_i_yank_monitor_href=monitor.pulp_href)
         monitor_task(check_response.task)
 
-        report = pypi_yank_monitor_api.report(
-            service_py_p_i_yank_monitor_href=monitor.pulp_href
-        )
+        report = pypi_yank_monitor_api.report(service_py_p_i_yank_monitor_href=monitor.pulp_href)
         assert report.repository_name == repo.name
         assert "attrs==21.1.0" in report.report
         assert "attrs==23.1.0" not in report.report
 
-        updated_monitor = pypi_yank_monitor_api.read(
-            service_py_p_i_yank_monitor_href=monitor.pulp_href
-        )
+        updated_monitor = pypi_yank_monitor_api.read(service_py_p_i_yank_monitor_href=monitor.pulp_href)
         assert updated_monitor.last_checked is not None
     finally:
         # Delete the repo via REST API first so RepositoryContent associations are removed,
         # then delete the package content (RepositoryContent has a PROTECTED FK to content).
-        delete_response = python_bindings.RepositoriesPythonApi.delete(
-            python_python_repository_href=repo.pulp_href
-        )
+        delete_response = python_bindings.RepositoriesPythonApi.delete(python_python_repository_href=repo.pulp_href)
         monitor_task(delete_response.task)
         _django_admin_shell(_DELETE_YANKED_PKG_CODE)
 
@@ -184,15 +156,15 @@ def test_pypi_yank_monitor_scoped_check_repo_version(
 
     result = subprocess.run(
         ["django-admin", "shell", "-c", _CREATE_YANKED_PKG_CODE],
-        check=True, capture_output=True, text=True,
+        check=True,
+        capture_output=True,
+        text=True,
     )
     pkg_href = result.stdout.strip()
     try:
         modify_response = python_bindings.RepositoriesPythonApi.modify(
             python_python_repository_href=repo.pulp_href,
-            repository_add_remove_content=RepositoryAddRemoveContent(
-                add_content_units=[pkg_href]
-            ),
+            repository_add_remove_content=RepositoryAddRemoveContent(add_content_units=[pkg_href]),
         )
         monitor_task(modify_response.task)
 
@@ -205,24 +177,16 @@ def test_pypi_yank_monitor_scoped_check_repo_version(
         )
         add_to_cleanup(pypi_yank_monitor_api, monitor.pulp_href)
 
-        check_response = pypi_yank_monitor_api.check(
-            service_py_p_i_yank_monitor_href=monitor.pulp_href
-        )
+        check_response = pypi_yank_monitor_api.check(service_py_p_i_yank_monitor_href=monitor.pulp_href)
         monitor_task(check_response.task)
 
-        report = pypi_yank_monitor_api.report(
-            service_py_p_i_yank_monitor_href=monitor.pulp_href
-        )
+        report = pypi_yank_monitor_api.report(service_py_p_i_yank_monitor_href=monitor.pulp_href)
         assert report.repository_name == repo.name
         assert "attrs==21.1.0" in report.report
 
-        updated_monitor = pypi_yank_monitor_api.read(
-            service_py_p_i_yank_monitor_href=monitor.pulp_href
-        )
+        updated_monitor = pypi_yank_monitor_api.read(service_py_p_i_yank_monitor_href=monitor.pulp_href)
         assert updated_monitor.last_checked is not None
     finally:
-        delete_response = python_bindings.RepositoriesPythonApi.delete(
-            python_python_repository_href=repo.pulp_href
-        )
+        delete_response = python_bindings.RepositoriesPythonApi.delete(python_python_repository_href=repo.pulp_href)
         monitor_task(delete_response.task)
         _django_admin_shell(_DELETE_YANKED_PKG_CODE)

--- a/pulp_service/pulp_service/tests/functional/test_task_debug.py
+++ b/pulp_service/pulp_service/tests/functional/test_task_debug.py
@@ -338,9 +338,7 @@ class TestStaleLockScanView:
         assert summary["total_resource_locks"] == (
             summary["orphaned_resource_locks"] + summary["healthy_resource_locks"]
         )
-        assert summary["total_task_locks"] == (
-            summary["orphaned_task_locks"] + summary["healthy_task_locks"]
-        )
+        assert summary["total_task_locks"] == (summary["orphaned_task_locks"] + summary["healthy_task_locks"])
 
         # --- orphaned locks sections ---
         assert "orphaned_resource_locks" in data
@@ -408,10 +406,7 @@ class TestStaleLockScanView:
         assert resp.status_code == 200
         data = resp.json()
 
-        all_resource_locks = (
-            data["orphaned_resource_locks"]
-            + data.get("healthy_resource_locks", [])
-        )
+        all_resource_locks = data["orphaned_resource_locks"] + data.get("healthy_resource_locks", [])
         for lock_info in all_resource_locks:
             assert "lock_key" in lock_info
             assert "resource" in lock_info
@@ -431,10 +426,7 @@ class TestStaleLockScanView:
         assert resp.status_code == 200
         data = resp.json()
 
-        all_task_locks = (
-            data["orphaned_task_locks"]
-            + data.get("healthy_task_locks", [])
-        )
+        all_task_locks = data["orphaned_task_locks"] + data.get("healthy_task_locks", [])
         for lock_info in all_task_locks:
             assert "lock_key" in lock_info
             assert "task_id" in lock_info

--- a/pulp_service/pulp_service/tests/functional/test_vulnerability_report.py
+++ b/pulp_service/pulp_service/tests/functional/test_vulnerability_report.py
@@ -45,9 +45,7 @@ def run_vuln_report(add_to_cleanup, monitor_task, vuln_report_service_api):
     """Fixture to make a request to vuln report endpoint"""
 
     def _run_vuln_report(package_json=None, repo_version=None):
-        report_response = vuln_report_service_api.create(
-            package_json=package_json, repo_version=repo_version
-        )
+        report_response = vuln_report_service_api.create(package_json=package_json, repo_version=repo_version)
         task = monitor_task(report_response.task)
         vuln_report_href = task.created_resources[0]
         add_to_cleanup(vuln_report_service_api, vuln_report_href)
@@ -162,9 +160,7 @@ def test_repo_version_vuln_report(
     monitor_task(repo_binding_api.sync(repo.pulp_href, {}).task)
 
     latest_repo_version = repo_binding_api.read(
-        **{
-            repo_href_arg_name: repo.pulp_href
-        },  # unpacks the dict into kwargs for the function call
+        **{repo_href_arg_name: repo.pulp_href},  # unpacks the dict into kwargs for the function call
     ).latest_version_href
 
     report_href = run_vuln_report(repo_version=latest_repo_version)
@@ -202,9 +198,7 @@ def test_rpm__repo_version_vuln_report(
         ).task
     )
 
-    latest_repo_version = rpm_repository_api.read(
-        rpm_rpm_repository_href=repository.pulp_href
-    ).latest_version_href
+    latest_repo_version = rpm_repository_api.read(rpm_rpm_repository_href=repository.pulp_href).latest_version_href
     report_href = run_vuln_report(repo_version=latest_repo_version)
     report = vuln_report_checks(report_href)
 

--- a/pulp_service/pulp_service/tests/unit/test_create_domain_view.py
+++ b/pulp_service/pulp_service/tests/unit/test_create_domain_view.py
@@ -56,6 +56,7 @@ def _make_group(name, pk=1):
 # -- Template domain & serializer patches used by every test that reaches
 #    past the group-resolution block.
 
+
 def _patch_domain_and_serializer():
     """Return a dict of patch targets suitable for ``with`` / ``patch.multiple``."""
     template = MagicMock()
@@ -129,9 +130,7 @@ class TestGroupNameResolution:
         mock_group_objects.get_or_create.return_value = (new_group, True)
 
         user = _make_user()
-        request = _make_request(
-            {"name": "test-domain", "group_name": "my-team"}, user=user
-        )
+        request = _make_request({"name": "test-domain", "group_name": "my-team"}, user=user)
 
         response = self._call_view(request)
 
@@ -150,9 +149,7 @@ class TestGroupNameResolution:
         mock_group_objects.get_or_create.return_value = (existing_group, False)
 
         user = _make_user()
-        request = _make_request(
-            {"name": "test-domain", "group_name": "existing-team"}, user=user
-        )
+        request = _make_request({"name": "test-domain", "group_name": "existing-team"}, user=user)
 
         response = self._call_view(request)
 
@@ -174,9 +171,7 @@ class TestGroupNameResolution:
         response = self._call_view(request)
 
         assert response.status_code == 201
-        mock_group_objects.get_or_create.assert_called_once_with(
-            name="domain-test-domain"
-        )
+        mock_group_objects.get_or_create.assert_called_once_with(name="domain-test-domain")
         user.groups.add.assert_called_once_with(auto_group)
 
     # -- Path 4: no group_name, user already has a group ----------------
@@ -200,9 +195,7 @@ class TestGroupNameResolution:
         mock_group_objects.get_or_create.side_effect = Exception("DB down")
 
         user = _make_user()
-        request = _make_request(
-            {"name": "test-domain", "group_name": "bad-group"}, user=user
-        )
+        request = _make_request({"name": "test-domain", "group_name": "bad-group"}, user=user)
 
         with patch.object(CreateDomainView, "permission_classes", []):
             view = CreateDomainView.as_view()
@@ -228,9 +221,7 @@ class TestGroupVarContextVariable:
         template, serializer_inst, domain_inst = _patch_domain_and_serializer()
 
         user = _make_user()
-        request = _make_request(
-            {"name": "test-domain", "group_name": "custom-team"}, user=user
-        )
+        request = _make_request({"name": "test-domain", "group_name": "custom-team"}, user=user)
 
         captured_group = None
 


### PR DESCRIPTION
## Summary

- Apply `ruff format` to all Python files under `pulp_service/`
- Line-length changes from 100 (Black) to 120 (ruff)
- Target version changes from py36/py37 to py311
- Whitespace-only changes — no semantic modifications
- Add `.git-blame-ignore-revs` so `git blame` skips the formatting commit

30 files reformatted, net -322 lines (multi-line expressions collapsed to fit wider line-length).

## Test plan

- [ ] Verify `make format-check` passes
- [ ] Verify no semantic changes in diff (whitespace-only)
- [ ] Verify `.git-blame-ignore-revs` contains the formatting commit SHA

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Reformat Python source and tests under pulp_service to comply with ruff formatting/line-length rules and add support files for ignoring this bulk-format commit in git blame.

Enhancements:
- Normalize whitespace, line wrapping, and string/quote style across application, middleware, auth, storage, task, and serializer modules using ruff format.
- Reformat functional and unit tests for domains, authentication, feature service, PyPI yank checks, vulnerability reports, task debug, and group-based permissions to match the new style guidelines.

Chores:
- Add a .git-blame-ignore-revs configuration so the bulk formatting commit can be excluded from git blame history.