### PR TITLE
fix: use pip --target for bindings install to avoid sys.path preceden…

### DIFF
--- a/.tekton/pulp-deploy-and-test.yaml
+++ b/.tekton/pulp-deploy-and-test.yaml
@@ -687,7 +687,7 @@ spec:
               # INSTALL CLIENTS
               PULP_BINDINGS_COMPONENTS=`echo $PULP_BINDINGS_COMPONENTS|tr '_' '-'`
               for PACKAGE in $PULP_BINDINGS_COMPONENTS ; do
-                oc_wrapper exec -c pulp-api deployment/pulp-api -- bash -c "HOME=/tmp/home pip3 install /data/${PACKAGE}"
+                oc_wrapper exec -c pulp-api deployment/pulp-api -- bash -c "pip3 install --target /tmp/home/.local/lib/python3.11/site-packages /data/${PACKAGE}"
               done
 
               cat<<EOF > __tmp_init__.py

--- a/.tekton/pulp-deploy-and-test.yaml
+++ b/.tekton/pulp-deploy-and-test.yaml
@@ -687,7 +687,7 @@ spec:
               # INSTALL CLIENTS
               PULP_BINDINGS_COMPONENTS=`echo $PULP_BINDINGS_COMPONENTS|tr '_' '-'`
               for PACKAGE in $PULP_BINDINGS_COMPONENTS ; do
-                oc_wrapper exec -c pulp-api deployment/pulp-api -- bash -c "pip3 install --target /tmp/home/.local/lib/python3.11/site-packages /data/${PACKAGE}"
+                oc_wrapper exec -c pulp-api deployment/pulp-api -- bash -c "HOME=/tmp/home pip3 install --no-deps /data/${PACKAGE}"
               done
 
               cat<<EOF > __tmp_init__.py


### PR DESCRIPTION
…ce error

pip refuses user-site installs when the target would lack sys.path precedence over packages in the system-site-packages venv. This started failing intermittently because pip install --upgrade pip in the Dockerfile pulls the latest pip on every image build.

Using --target writes directly to the install directory and bypasses the user-site precedence check entirely.

## Summary by Sourcery

Adjust pipeline bindings installation to avoid pip user-site precedence issues in the pulp-api container.

Bug Fixes:
- Prevent intermittent failures in bindings installation by avoiding pip user-site precedence checks in the pulp-api container.

CI:
- Update Tekton deploy-and-test pipeline to install Python bindings with pip --target into a fixed site-packages directory instead of relying on HOME.