### PR TITLE
fix: resolve Django, datetime, line-length, and security lint violations

### DIFF
--- a/pulp_service/pulp_service/app/admin.py
+++ b/pulp_service/pulp_service/app/admin.py
@@ -240,7 +240,7 @@ class ContentSourceDomainFilter(admin.SimpleListFilter):
 class DomainOrgForm(forms.ModelForm):
     class Meta:
         model = DomainOrg
-        fields = "__all__"
+        fields = ["org_id", "domains", "user", "group"]
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -372,7 +372,15 @@ class DomainOrgAdmin(admin.ModelAdmin):
 class DomainAdminForm(forms.ModelForm):
     class Meta:
         model = Domain
-        fields = "__all__"
+        fields = [
+            "name",
+            "description",
+            "storage_class",
+            "storage_settings",
+            "redirect_to_object_storage",
+            "hide_guarded_distributions",
+            "pulp_labels",
+        ]
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/pulp_service/pulp_service/app/models.py
+++ b/pulp_service/pulp_service/app/models.py
@@ -4,7 +4,7 @@ import logging
 import ssl
 from base64 import b64decode
 from binascii import Error as Base64DecodeError
-from datetime import datetime
+from datetime import datetime, timezone
 from gettext import gettext as _
 from hashlib import sha256
 
@@ -27,7 +27,7 @@ class DomainOrg(models.Model):
     One-to-many relationship between org ids and Domains.
     """
 
-    org_id = models.CharField(null=True, db_index=True)
+    org_id = models.CharField(null=True, db_index=True)  # noqa: DJ001 — NULL semantics needed for org lookup
     domains = models.ManyToManyField(Domain, related_name="domain_orgs")
     user = models.ForeignKey(
         settings.AUTH_USER_MODEL,
@@ -41,6 +41,9 @@ class DomainOrg(models.Model):
         on_delete=models.SET_NULL,
         null=True,
     )
+
+    def __str__(self):
+        return f"DomainOrg(org_id={self.org_id})"
 
 
 class FeatureContentGuardCache(Cache):
@@ -65,16 +68,17 @@ class FeatureContentGuard(HeaderContentGuard, AutoAddObjPermsMixin):
                     return await response.json()
 
         try:
-            _logger.info("[%s] Making a request to feature service API ...", datetime.now())
+            _logger.info("[%s] Making a request to feature service API ...", datetime.now(tz=timezone.utc))
             response = asyncio.run(fetch_feature())
-            _logger.info("[%s] Got a response from feature service API!", datetime.now())
+            _logger.info("[%s] Got a response from feature service API!", datetime.now(tz=timezone.utc))
         except aiohttp.ClientResponseError as err:
             if err.status == 400:
                 _logger.exception("Failed to request information for a user. BadRequest. URL: %s", err.request_info.url)
 
             if err.status == 403:
                 _logger.exception(
-                    "Failed to request information for a user. Permission Denied. Verify if the certificate is still valid."
+                    "Failed to request information for a user. "
+                    "Permission Denied. Verify if the certificate is still valid."
                 )
 
             _logger.warning(_("Failed to fetch the Subscription feature information for a user."))
@@ -160,7 +164,7 @@ class YankedPackageReport(BaseModel):
         blank=True,
         related_name="reports",
     )
-    repository_name = models.TextField(null=True, blank=True)
+    repository_name = models.TextField(null=True, blank=True)  # noqa: DJ001
 
     class Meta:
         default_related_name = "%(app_label)s_%(model_name)s"
@@ -173,7 +177,7 @@ class PyPIYankMonitor(BaseModel):
     """
 
     name = models.TextField(db_index=True, unique=True)
-    description = models.TextField(null=True, blank=True)
+    description = models.TextField(null=True, blank=True)  # noqa: DJ001
     pulp_labels = HStoreField(default=dict)
     repository = models.ForeignKey("core.Repository", on_delete=models.CASCADE, null=True, blank=True)
     repository_version = models.ForeignKey("core.RepositoryVersion", on_delete=models.CASCADE, null=True, blank=True)

--- a/pulp_service/pulp_service/app/tasks/rds_connection_tests.py
+++ b/pulp_service/pulp_service/app/tasks/rds_connection_tests.py
@@ -11,7 +11,7 @@ import logging
 import multiprocessing
 import time
 import traceback
-from datetime import datetime
+from datetime import datetime, timezone
 from functools import wraps
 
 from django.db import connection, transaction
@@ -24,7 +24,7 @@ logger = logging.getLogger(__name__)
 
 def log(message):
     """Log with timestamp"""
-    timestamp = datetime.now().isoformat()
+    timestamp = datetime.now(tz=timezone.utc).isoformat()
     logger.info("[%s] %s", timestamp, message)
 
 
@@ -50,7 +50,7 @@ def rds_test_wrapper(test_name, connection_pinned=False):
         @wraps(test_func)
         def wrapper(*args, **kwargs):
             # Initialize all variables at the start to prevent UnboundLocalError
-            started_at = datetime.now()
+            started_at = datetime.now(tz=timezone.utc)
             finished_at = None
             duration = 0
             alive = True
@@ -95,7 +95,7 @@ def rds_test_wrapper(test_name, connection_pinned=False):
                         "traceback": traceback.format_exc(),
                     }
 
-                finished_at = datetime.now()
+                finished_at = datetime.now(tz=timezone.utc)
                 duration = (finished_at - started_at).total_seconds() / 60
 
                 log(f"Test finished at: {finished_at.isoformat()}")
@@ -107,7 +107,7 @@ def rds_test_wrapper(test_name, connection_pinned=False):
                 log(f"FATAL ERROR in test wrapper: {type(fatal_error).__name__}: {fatal_error}")
                 log(f"Traceback: {traceback.format_exc()}")
                 alive = False
-                finished_at = datetime.now()
+                finished_at = datetime.now(tz=timezone.utc)
                 duration = (finished_at - started_at).total_seconds() / 60
                 extra_data["error"] = {
                     "type": type(fatal_error).__name__,
@@ -119,7 +119,7 @@ def rds_test_wrapper(test_name, connection_pinned=False):
             result = {
                 "test": test_name,
                 "started_at": started_at.isoformat(),
-                "finished_at": finished_at.isoformat() if finished_at else datetime.now().isoformat(),
+                "finished_at": finished_at.isoformat() if finished_at else datetime.now(tz=timezone.utc).isoformat(),
                 "duration_minutes": round(duration, 2),
                 "connection_alive": alive,
                 "success": alive,
@@ -387,14 +387,14 @@ def _notification_sender_worker(channel_name, interval_seconds, duration_minutes
     """
     import logging
     import time
-    from datetime import datetime
+    from datetime import datetime, timezone
 
     import psycopg
 
     logger = logging.getLogger(__name__)
 
     def worker_log(message):
-        timestamp = datetime.now().isoformat()
+        timestamp = datetime.now(tz=timezone.utc).isoformat()
         logger.info("[NOTIFY-WORKER][%s] %s", timestamp, message)
 
     try:
@@ -478,7 +478,7 @@ def test_7_listen_with_activity(duration_minutes=50):
             with connection.cursor() as cursor:
                 cursor.execute(f"UNLISTEN {channel_name}")
                 log(f"UNLISTEN {channel_name}")
-        except Exception:
+        except Exception:  # noqa: S110 — UNLISTEN cleanup; failure is harmless
             pass
 
         # Stop the notification sender process

--- a/pulp_service/pulp_service/app/viewsets.py
+++ b/pulp_service/pulp_service/app/viewsets.py
@@ -3,7 +3,7 @@ import logging
 import random
 from base64 import b64decode
 from binascii import Error as Base64DecodeError
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from uuid import uuid4
 
 from django.conf import settings
@@ -279,10 +279,10 @@ class TaskIngestionDispatcherView(APIView):
             raise PermissionError("Access denied.")
 
         task_count = 0
-        start_time = datetime.now()
+        start_time = datetime.now(tz=timezone.utc)
         timeout = timedelta(seconds=timeout)
 
-        while datetime.now() < start_time + timeout:
+        while datetime.now(tz=timezone.utc) < start_time + timeout:
             dispatch("pulp_service.app.tasks.util.no_op_task", exclusive_resources=[str(uuid4())])
 
             task_count = task_count + 1
@@ -301,13 +301,13 @@ class TaskIngestionRandomResourceLockDispatcherView(APIView):
         exclusive_resources_list = [str(uuid4()) for _ in range(3)]
 
         task_count = 0
-        start_time = datetime.now()
+        start_time = datetime.now(tz=timezone.utc)
         timeout = timedelta(seconds=timeout)
 
-        while datetime.now() < start_time + timeout:
+        while datetime.now(tz=timezone.utc) < start_time + timeout:
             dispatch(
                 "pulp_service.app.tasks.util.no_op_task",
-                exclusive_resources=[random.choice(exclusive_resources_list)],
+                exclusive_resources=[random.choice(exclusive_resources_list)],  # noqa: S311
             )
 
             task_count = task_count + 1
@@ -447,7 +447,9 @@ class RDSConnectionTestDispatcherView(APIView):
                 "tasks": dispatched_tasks,
                 "run_sequentially": run_sequentially,
                 "duration_minutes": duration_minutes,
-                "note": f"Each test runs for approximately {duration_minutes} minutes. Monitor task status via task_href.",
+                "note": (
+                    f"Each test runs for approximately {duration_minutes} minutes. Monitor task status via task_href."
+                ),
             },
             status=status.HTTP_202_ACCEPTED,
         )
@@ -1912,7 +1914,10 @@ class CreateDomainView(APIView):
             _logger.exception("Model domain 'template-domain-s3' not found")
             return Response(
                 {
-                    "error": "Model domain 'template-domain-s3' not found. Please create it first with correct storage settings."
+                    "error": (
+                        "Model domain 'template-domain-s3' not found. "
+                        "Please create it first with correct storage settings."
+                    )
                 },
                 status=status.HTTP_500_INTERNAL_SERVER_ERROR,
             )

--- a/pulp_service/pulp_service/tests/functional/test_vulnerability_report.py
+++ b/pulp_service/pulp_service/tests/functional/test_vulnerability_report.py
@@ -92,7 +92,7 @@ def test_npm_package_lock(run_vuln_report, vuln_report_checks):
 
 
 @pytest.mark.parametrize(
-    "bindings, repo_binding_api, repo_href_arg_name, repo_factory, remote_factory, remote_url, remote_includes, expected_vuln_pkg_name, expected_vuln_ids",
+    "bindings, repo_binding_api, repo_href_arg_name, repo_factory, remote_factory, remote_url, remote_includes, expected_vuln_pkg_name, expected_vuln_ids",  # noqa: E501
     [
         (
             "python_bindings",

--- a/pulp_service/pyproject.toml
+++ b/pulp_service/pyproject.toml
@@ -144,6 +144,7 @@ max-statements = 40
 "pulp_service/app/storage.py" = ["S108"]
 "pulp_service/app/viewsets.py" = ["C901", "PLR0912", "PLR0913", "PLR0915"]
 "pulp_service/app/tasks/rds_connection_tests.py" = ["C901", "PLR0912", "PLR0915"]
+"pulp_service/tests/functional/constants.py" = ["E501"]
 
 
 


### PR DESCRIPTION
## Summary

Fix 31 ruff violations across 4 rule categories. No database migrations triggered.

| Rule | Count | Fix |
|------|-------|-----|
| **DJ007** | 2 | Replace `fields = "__all__"` with explicit field lists in admin forms |
| **DJ008** | 1 | Add `__str__` to `DomainOrg` model |
| **DJ001** | 3 | Suppressed with `# noqa` — changing `null=True` would trigger a migration |
| **DTZ005** | 12 | Add `timezone.utc` to all `datetime.now()` calls |
| **E501** | 11 | Split 3 long strings, per-file-ignore for test constants, 1 noqa |
| **S110** | 1 | Suppressed — intentional UNLISTEN cleanup |
| **S311** | 1 | Suppressed — non-cryptographic `random.choice` |

### DJ001 — why noqa instead of fix

Removing `null=True` from CharField/TextField changes the database schema (`NULL` → `NOT NULL` with default `""`). This would require a migration with data backfill for existing `NULL` rows. Deferred to a dedicated schema change PR.

### DTZ005 — safe to add timezone

All 12 `datetime.now()` calls are used for logging timestamps and duration calculations, not stored in the database. Adding `timezone.utc` is safe.

## Test plan

- [ ] Verify `ruff check --select DJ,DTZ,E501,S110,S311 pulp_service/` passes
- [ ] Verify no new Django migrations generated (`python manage.py makemigrations --check`)
- [ ] Verify `__str__` on DomainOrg displays correctly in admin

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Resolve linter violations related to datetimes, Django models/admin, line length, and security by updating code and configuration while avoiding schema changes.

Bug Fixes:
- Ensure all runtime and logging timestamps use timezone-aware datetimes in UTC.
- Add a string representation for the DomainOrg model for clearer admin display and logging.

Enhancements:
- Restrict Django admin forms for Domain and DomainOrg to explicit field lists instead of using all model fields.
- Reformat long user-facing messages and test parameter strings to comply with line-length standards without altering behavior.
- Document intentional uses of nullable text fields and non-cryptographic randomness via noqa annotations to clarify design choices.

Build:
- Update ruff configuration to ignore line-length violations in a test constants module where long strings are expected.