### PR TITLE
Remove draft:true from SDLC pipeline v1

### DIFF
--- a/.alcove/workflows/sdlc-pipeline.yml
+++ b/.alcove/workflows/sdlc-pipeline.yml
@@ -33,7 +33,6 @@ workflow:
       branch: "{{steps.implement.inputs.branch}}"
       title: "Fix #{{trigger.issue_number}}: {{trigger.issue_title}}"
       base: main
-      draft: true
       body: "Closes {{trigger.issue_url}}\n\n## Summary\n\n{{steps.implement.outputs.summary}}"
 
   - id: await-ci


### PR DESCRIPTION
## Summary
- Remove `draft: true` from the v1 SDLC pipeline's `create-pr` step
- The v1 pipeline has a merge step that auto-merges after review — draft PRs can't be merged (GitHub 405)
- The v2 pipeline keeps `draft: true` intentionally since it stops at await-ci

Discovered when #1206 pipeline failed at the merge step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Update the v1 SDLC workflow so its create-pr step opens mergeable (non-draft) PRs compatible with the existing auto-merge step.

Bug Fixes:
- Fix v1 SDLC pipeline failures where the auto-merge step could not merge draft pull requests.

CI:
- Remove the draft flag from the v1 SDLC pipeline create-pr step to ensure PRs created by the workflow are immediately mergeable.