### PR TITLE
Upgrade pulp-python 3.29.0 → 3.30.0

### DIFF
--- a/images/assets/patches/0038-readonly-pypi-endpoints.patch
+++ b/images/assets/patches/0038-readonly-pypi-endpoints.patch
@@ -2,13 +2,13 @@ diff --git a/pulp_python/app/pypi/views.py b/pulp_python/app/pypi/views.py
 index b7808a9..531d594 100644
 --- a/pulp_python/app/pypi/views.py
 +++ b/pulp_python/app/pypi/views.py
-@@ -54,6 +54,7 @@ from pulp_python.app.utils import (
- )
+@@ -31,6 +31,7 @@ from pulpcore.plugin.viewsets import OperationPostponedResponse
  
  from pulp_python.app import tasks
 +from pulp_service.app.authorization import AllowUnauthPull,DomainBasedPermission
- 
- log = logging.getLogger(__name__)
+ from pulp_python.app.models import (
+     PackageProvenance,
+     PythonDistribution,
  
 @@ -78,6 +79,8 @@ class PyPIMixin:
  

--- a/images/assets/patches/0048-Re-enable-attestation-verification-with-vendored-key.patch
+++ b/images/assets/patches/0048-Re-enable-attestation-verification-with-vendored-key.patch
@@ -219,15 +219,17 @@ index 0000005..0000006 100644
 +++ b/pulp_python/app/pypi/serializers.py
 @@ -3,10 +3,11 @@
  
- from rest_framework import serializers
+ from django.db.utils import IntegrityError
  from pydantic import TypeAdapter, ValidationError
++from pypi_attestations import AttestationError
+ from rest_framework import serializers
+ 
+ from pulpcore.plugin.models import Artifact
+ from pulpcore.plugin.util import get_domain
+ 
 -from pulp_python.app.provenance import Attestation
 +from pulp_python.app.provenance import Attestation, AnyPublisher, AttestationBundle, Provenance, verify_provenance
  from pulp_python.app.utils import DIST_EXTENSIONS, SUPPORTED_METADATA_VERSIONS
- from pulpcore.plugin.models import Artifact
- from pulpcore.plugin.util import get_domain
-+from pypi_attestations import AttestationError
- from django.db.utils import IntegrityError
  
  log = logging.getLogger(__name__)
 @@ -105,6 +106,7 @@

--- a/images/assets/patches/CLAUDE.md
+++ b/images/assets/patches/CLAUDE.md
@@ -10,7 +10,7 @@ Each patch modifies files installed into site-packages via the Dockerfile.
 | `pulpcore/`      | [pulp/pulpcore](https://github.com/pulp/pulpcore)          | pulpcore         | 3.111.0             |
 | `pulp_file/`     | [pulp/pulpcore](https://github.com/pulp/pulpcore)          | (bundled)        | 3.111.0             |
 | `pulp_container/`| [pulp/pulp_container](https://github.com/pulp/pulp_container) | pulp-container | 2.27.6              |
-| `pulp_python/`   | [pulp/pulp_python](https://github.com/pulp/pulp_python)    | pulp-python      | 3.29.0              |
+| `pulp_python/`   | [pulp/pulp_python](https://github.com/pulp/pulp_python)    | pulp-python      | 3.30.0              |
 | `pulp_maven/`    | [pulp/pulp_maven](https://github.com/pulp/pulp_maven)      | pulp-maven       | 0.12.0              |
 | `oras/`          | [oras-project/oras-py](https://github.com/oras-project/oras-py) | oras        | 0.2.38              |
 | `storages/`      | [jschneier/django-storages](https://github.com/jschneier/django-storages) | django-storages | 1.14.6 |

--- a/pulp_service/requirements.txt
+++ b/pulp_service/requirements.txt
@@ -1,7 +1,7 @@
 pulpcore==3.111.0
 pulp-rpm==3.35.2
 pulp-gem==0.7.5
-pulp-python==3.29.0
+pulp-python==3.30.0
 pulp-npm==0.8.0
 pulp-container==2.27.8
 pulp-maven==0.12.0


### PR DESCRIPTION
## Summary
- Bump pulp-python from 3.29.0 to 3.30.0
- Rebase patch 0038 (readonly PyPI endpoints) for import reordering in 3.30.0
- Rebase patch 0048 (attestation verification) for import reordering in 3.30.0

## Test plan
- [x] Local `podman build` succeeds — all patches apply cleanly
- [ ] Konflux CI build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Upgrade the embedded pulp-python dependency and integrate periodic telemetry task registration into the application’s signal handling.

Enhancements:
- Replace the previous patch-based content sources periodic telemetry wiring with in-app signal-based registration for telemetry tasks.
- Update the recorded pulp-python component version metadata to match the new dependency version.

Build:
- Bump pulp-python from 3.29.0 to 3.30.0 in the service requirements and associated patch metadata, and stop applying the obsolete telemetry patch from the Docker build.