### PR TITLE
Add PULP_DATA_UPLOAD_MAX_NUMBER_FIELDS env var to pulp-api

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -458,6 +458,8 @@ objects:
             value: ${PULP_RDS_CONNECTION_TESTS_ENABLED}
           - name: PULP_WORKER_TYPE
             value: ${PULP_WORKER_TYPE}
+          - name: PULP_DATA_UPLOAD_MAX_NUMBER_FIELDS
+            value: ${PULP_DATA_UPLOAD_MAX_NUMBER_FIELDS}
 
     - name: content
       replicas: ${{PULP_CONTENT_REPLICAS}}
@@ -1506,3 +1508,6 @@ parameters:
   - name: PULP_OTEL_METRICS_DISPATCH_INTERVAL_MINUTES
     description: Configure the interval to get disk usage metrics.
     value: "60"
+  - name: PULP_DATA_UPLOAD_MAX_NUMBER_FIELDS
+    description: Maximum number of fields allowed in a multipart form data upload.
+    value: "10000"


### PR DESCRIPTION
## Summary
- Adds `PULP_DATA_UPLOAD_MAX_NUMBER_FIELDS` environment variable to the pulp-api deployment in `clowdapp.yaml`
- Defaults to `10000` to support multipart form uploads with many fields

## Test plan
- [ ] Verify the env var is set in pulp-api pods after deployment
- [ ] Confirm Django picks up `DATA_UPLOAD_MAX_NUMBER_FIELDS=10000`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add configuration support for controlling the maximum number of fields accepted in multipart form uploads by pulp-api.

Build:
- Expose PULP_DATA_UPLOAD_MAX_NUMBER_FIELDS as an environment variable in the pulp-api deployment config.
- Introduce a PULP_DATA_UPLOAD_MAX_NUMBER_FIELDS ClowdApp parameter with a default of 10000 to limit multipart form field counts.