### PR TITLE
Pin cicd-tools image to 4a25c43

### DIFF
--- a/.tekton/pulp-deploy-and-test.yaml
+++ b/.tekton/pulp-deploy-and-test.yaml
@@ -29,7 +29,7 @@ spec:
     - name: BONFIRE_IMAGE
       type: string
       description: The container Bonfire image to use for the tekton tasks
-      default: quay.io/redhat-services-prod/hcm-eng-prod-tenant/cicd-tools:latest
+      default: quay.io/redhat-services-prod/hcm-eng-prod-tenant/cicd-tools:4a25c43
     - name: SNAPSHOT
       type: string
       description: |


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Update the Tekton pulp-deploy-and-test pipeline to use a fixed cicd-tools image tag instead of latest for BONFIRE_IMAGE.