### PR TITLE
When creating a pre-populated domain, we are missing a group

### DIFF
--- a/pulp_service/pulp_service/app/viewsets.py
+++ b/pulp_service/pulp_service/app/viewsets.py
@@ -1871,12 +1871,12 @@ class CreateDomainView(APIView):
                         domain_name,
                         user.username,
                     )
-            elif not user.groups.exists():
+            else:
                 group_name = f"domain-{domain_name}"
                 _logger.info(
-                    "User %s has no groups. Creating or finding group '%s' for domain creation.",
-                    user.username,
+                    "No group_name provided. Creating or finding group '%s' for domain '%s'.",
                     group_name,
+                    domain_name,
                 )
                 group, created = Group.objects.get_or_create(name=group_name)
                 if created:
@@ -1885,9 +1885,6 @@ class CreateDomainView(APIView):
                     _logger.info("Reusing existing group '%s'.", group_name)
                 user.groups.add(group)
                 _logger.info("Added user %s to group '%s'.", user.username, group_name)
-            else:
-                group = user.groups.first()
-                _logger.info("User %s already belongs to group '%s'.", user.username, group.name)
         except Exception as e:
             _logger.exception("Failed to resolve group for domain '%s'", domain_name)
             return Response(

--- a/pulp_service/pulp_service/tests/unit/test_create_domain_view.py
+++ b/pulp_service/pulp_service/tests/unit/test_create_domain_view.py
@@ -96,7 +96,7 @@ class TestCreateDomainViewValidation:
 
 
 class TestGroupNameResolution:
-    """Verify the three group-resolution paths in CreateDomainView.post()."""
+    """Verify the group-resolution paths in CreateDomainView.post()."""
 
     def _call_view(self, request):
         """Call the view with permissions and downstream deps stubbed out."""
@@ -175,16 +175,19 @@ class TestGroupNameResolution:
     # -- Path 4: no group_name, user already has a group ----------------
 
     @patch("pulp_service.app.viewsets.Group.objects")
-    def test_existing_user_group_reused(self, mock_group_objects):
+    def test_auto_group_created_even_when_user_has_groups(self, mock_group_objects):
         existing = _make_group("preexisting-group")
+        auto_group = _make_group("domain-test-domain")
+        mock_group_objects.get_or_create.return_value = (auto_group, True)
+
         user = _make_user(groups=[existing])
         request = _make_request({"name": "test-domain"}, user=user)
 
         response = self._call_view(request)
 
         assert response.status_code == 201
-        # get_or_create should NOT be called -- we reuse the user's group
-        mock_group_objects.get_or_create.assert_not_called()
+        mock_group_objects.get_or_create.assert_called_once_with(name="domain-test-domain")
+        user.groups.add.assert_called_once_with(auto_group)
 
     # -- Path 5: group resolution raises -> 400 -------------------------
 


### PR DESCRIPTION
## Summary by Sourcery

Ensure domain creation always associates the user with a dedicated auto-created group when no explicit group_name is provided, and update tests accordingly.

Bug Fixes:
- Fix domain creation so that a pre-populated domain does not skip creating a domain-specific group when the user already belongs to other groups.

Tests:
- Extend group-resolution tests to cover the case where an auto group is created even when the user already has groups, and adjust expectations to match the new behavior.