### PR TITLE
Optimize Simple API upload_time and provenance in pulp_python

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -177,6 +177,9 @@ RUN patch -p1 -d /usr/local/lib/pulp/lib/python${PYTHON_VERSION}/site-packages <
 COPY images/assets/patches/0056-repo-publication-delete.patch /tmp/
 RUN patch -p1 -d /usr/local/lib/pulp/lib/python${PYTHON_VERSION}/site-packages < /tmp/0056-repo-publication-delete.patch
 
+COPY images/assets/patches/0057-Optimize-Simple-API-upload_time-and-provenance.patch /tmp/
+RUN patch -p1 -d /usr/local/lib/pulp/lib/python${PYTHON_VERSION}/site-packages < /tmp/0057-Optimize-Simple-API-upload_time-and-provenance.patch
+
 RUN mkdir /licenses
 COPY LICENSE /licenses/LICENSE
 

--- a/images/assets/patches/0057-Optimize-Simple-API-upload_time-and-provenance.patch
+++ b/images/assets/patches/0057-Optimize-Simple-API-upload_time-and-provenance.patch
@@ -1,0 +1,78 @@
+From fcd3b3952ee471fa4acb37b7cba2748f1ccb7fc1 Mon Sep 17 00:00:00 2001
+From: Jitka Halova <jobselko@redhat.com>
+Date: Thu, 21 May 2026 16:57:41 +0200
+Subject: [PATCH] Optimize Simple API upload_time and provenance
+
+related to #1242, #1243
+Assisted By: Claude Opus 4.6
+---
+ pulp_python/app/pypi/views.py | 24 ++++++++++++------------
+ 1 file changed, 12 insertions(+), 12 deletions(-)
+
+diff --git a/pulp_python/app/pypi/views.py b/pulp_python/app/pypi/views.py
+index b8585df..e228d88 100644
+--- a/pulp_python/app/pypi/views.py
++++ b/pulp_python/app/pypi/views.py
+@@ -7,7 +7,7 @@ from urllib.parse import urljoin, urlparse, urlunsplit
+ from django.contrib.sessions.models import Session
+ from django.core.exceptions import ObjectDoesNotExist
+ from django.db import transaction
+-from django.db.models import OuterRef, Subquery
++from django.db.models import Exists, F, FilteredRelation, OuterRef, Q
+ from django.db.utils import DatabaseError
+ from django.http.response import (
+     Http404,
+@@ -26,7 +26,6 @@ from rest_framework.renderers import BrowsableAPIRenderer, JSONRenderer, Templat
+ from rest_framework.response import Response
+ from rest_framework.viewsets import ViewSet
+ 
+-from pulpcore.plugin.models import RepositoryContent
+ from pulpcore.plugin.tasking import dispatch
+ from pulpcore.plugin.util import get_domain, get_url
+ from pulpcore.plugin.viewsets import OperationPostponedResponse
+@@ -368,13 +367,16 @@ class SimpleView(PackageUploadMixin, ViewSet):
+             return redirect(urljoin(self.base_content_url, f"{path}/simple/{normalized}/"))
+         if content is not None:
+             local_packages = content.filter(name_normalized=normalized)
+-            repo_added_subquery = RepositoryContent.objects.filter(
+-                content_id=OuterRef("pk"),
+-                repository=repo_ver.repository,
+-                version_removed=None,
+-            ).values("pulp_created")[:1]
+             packages = local_packages.annotate(
+-                repo_added_time=Subquery(repo_added_subquery)
++                active_membership=FilteredRelation(
++                    "version_memberships",
++                    condition=Q(
++                        version_memberships__repository=repo_ver.repository,
++                        version_memberships__version_removed=None,
++                    ),
++                ),
++                repo_added_time=F("active_membership__pulp_created"),
++                has_provenance=Exists(PackageProvenance.objects.filter(package_id=OuterRef("pk"))),
+             ).values(
+                 "filename",
+                 "sha256",
+@@ -383,9 +385,7 @@ class SimpleView(PackageUploadMixin, ViewSet):
+                 "size",
+                 "repo_added_time",
+                 "version",
+-            )
+-            provenances = PackageProvenance.objects.filter(package__in=local_packages).values_list(
+-                "package__filename", flat=True
++                "has_provenance",
+             )
+             local_releases = {
+                 p["filename"]: {
+@@ -394,7 +394,7 @@ class SimpleView(PackageUploadMixin, ViewSet):
+                     "upload_time": p["repo_added_time"],
+                     "provenance": (
+                         self.get_provenance_url(normalized, p["version"], p["filename"])
+-                        if p["filename"] in provenances
++                        if p["has_provenance"]
+                         else None
+                     ),
+                 }
+-- 
+2.52.0
+

--- a/images/assets/patches/CLAUDE.md
+++ b/images/assets/patches/CLAUDE.md
@@ -121,3 +121,9 @@ transitive dependency pinned in pulpcore's `pyproject.toml`.
 - **Package:** pulpcore
 - **Files:** `pulpcore/app/models/repository.py`
 - **Description:** Optimizes repository deletion by materializing publication PKs before deleting published artifacts and switching to batched deletes (500 per batch) to limit WAL size in PostgreSQL.
+
+### 0057 — Optimize Simple API upload_time and provenance
+
+- **Package:** pulp_python
+- **Files:** `pulp_python/app/pypi/views.py`
+- **Description:** Replaces a correlated Subquery with a FilteredRelation JOIN when annotating `repo_added_time` and replaces a separate `PackageProvenance` query with an `Exists` annotation (`has_provenance`) in the SimpleView package detail endpoint, reducing the number of queries and improving performance for repositories with many content units.


### PR DESCRIPTION
Fixes https://github.com/pulp/pulp_python/issues/1242
Fixes https://github.com/pulp/pulp_python/issues/1243

## Summary by Sourcery

Optimize pulp_python Simple API package detail endpoint to reduce query count and improve performance for repositories with many content units.

Enhancements:
- Replace correlated subquery with a FilteredRelation-based join when annotating repository upload time in the Simple API.
- Replace a separate PackageProvenance query with an Exists-based annotation to expose provenance presence on package details.
- Register and apply a new patch in the Docker image to ship the optimized Simple API behavior.

Documentation:
- Document the new optimization patch in the CLAUDE patches registry.