### PR TITLE
fix: allow authenticated users to read PyPI views and public domains

### DIFF
--- a/pulp_service/pulp_service/app/authorization.py
+++ b/pulp_service/pulp_service/app/authorization.py
@@ -48,16 +48,17 @@ class DomainBasedPermission(BasePermission):
 
         user = request.user
 
-        # Anonymous users can make safe requests on public domains and PyPI views
-        if not user.is_authenticated:
-            if request.method in SAFE_METHODS:
-                from pulp_python.app.pypi.views import PyPIMixin
+        # Allow safe requests on PyPI views and public domains for all users
+        if request.method in SAFE_METHODS:
+            from pulp_python.app.pypi.views import PyPIMixin
 
-                if isinstance(view, PyPIMixin):
-                    return True
-                domain = getattr(request, "pulp_domain", None)
-                if domain and "public-" in domain.name:
-                    return True
+            if isinstance(view, PyPIMixin):
+                return True
+            domain = getattr(request, "pulp_domain", None)
+            if domain and "public-" in domain.name:
+                return True
+
+        if not user.is_authenticated:
             return False
 
         # Check if user is creating a domain or creating a resource within a domain
@@ -156,14 +157,3 @@ class DomainBasedPermission(BasePermission):
             query |= Q(domain_orgs__org_id=org_id)
 
         return qs.filter(query).distinct()
-
-
-class AllowUnauthPull(BasePermission):
-    """
-    A Permission Class that grants permission to make GET/HEAD/OPTIONS requests without authN/authZ
-    """
-
-    def has_permission(self, request, view):
-        if request.method in SAFE_METHODS:
-            return True
-        return None

--- a/pulp_service/pulp_service/app/authorization.py
+++ b/pulp_service/pulp_service/app/authorization.py
@@ -11,6 +11,8 @@ from rest_framework.permissions import SAFE_METHODS, BasePermission
 from pulpcore.plugin.models import Domain
 from pulpcore.plugin.util import extract_pk, get_domain_pk
 
+from pulp_python.app.pypi.views import PyPIMixin
+
 from pulp_service.app.models import DomainOrg
 
 _logger = logging.getLogger(__name__)
@@ -50,8 +52,6 @@ class DomainBasedPermission(BasePermission):
 
         # Allow safe requests on PyPI views and public domains for all users
         if request.method in SAFE_METHODS:
-            from pulp_python.app.pypi.views import PyPIMixin
-
             if isinstance(view, PyPIMixin):
                 return True
             domain = getattr(request, "pulp_domain", None)

--- a/pulp_service/pulp_service/tests/unit/test_domain_based_permission.py
+++ b/pulp_service/pulp_service/tests/unit/test_domain_based_permission.py
@@ -1,0 +1,177 @@
+"""
+Unit tests for DomainBasedPermission.has_permission().
+
+These tests mock Django ORM and Pulp internals so they can run without
+a live Pulp stack. They cover the safe-method bypass for PyPI views
+and public domains, for both anonymous and authenticated users.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from pulp_service.app.authorization import DomainBasedPermission
+
+
+def _make_request(method="GET", user=None, domain=None, view_name="pypi-metadata"):
+    """Build a mock DRF request."""
+    request = MagicMock()
+    request.method = method
+    request.user = user or _make_anonymous_user()
+    request.pulp_domain = domain
+    request.resolver_match = MagicMock()
+    request.resolver_match.view_name = view_name
+    request.META = {"REQUEST_METHOD": method, "PATH_INFO": "/api/pypi/test/main/simple/"}
+    return request
+
+
+def _make_anonymous_user():
+    user = MagicMock()
+    user.is_authenticated = False
+    user.is_superuser = False
+    return user
+
+
+def _make_authenticated_user():
+    user = MagicMock()
+    user.is_authenticated = True
+    user.is_superuser = False
+    user.groups.values_list.return_value = []
+    return user
+
+
+def _make_domain(name):
+    domain = SimpleNamespace(name=name, pk=42)
+    return domain
+
+
+def _make_pypi_view():
+    """Create a mock view that is an instance of PyPIMixin."""
+    from pulp_python.app.pypi.views import PyPIMixin
+
+    class FakePyPIView(PyPIMixin):
+        pass
+
+    view = FakePyPIView()
+    return view
+
+
+def _make_regular_view():
+    """Create a mock view that is NOT a PyPIMixin."""
+    return MagicMock()
+
+
+class TestSafeMethodBypass:
+    """Verify that safe methods on PyPI views and public domains are allowed for all users."""
+
+    def test_anonymous_get_pypi_view_allowed(self):
+        permission = DomainBasedPermission()
+        request = _make_request(method="GET", user=_make_anonymous_user())
+        view = _make_pypi_view()
+
+        assert permission.has_permission(request, view) is True
+
+    def test_authenticated_get_pypi_view_allowed(self):
+        permission = DomainBasedPermission()
+        request = _make_request(method="GET", user=_make_authenticated_user())
+        view = _make_pypi_view()
+
+        assert permission.has_permission(request, view) is True
+
+    def test_anonymous_head_pypi_view_allowed(self):
+        permission = DomainBasedPermission()
+        request = _make_request(method="HEAD", user=_make_anonymous_user())
+        view = _make_pypi_view()
+
+        assert permission.has_permission(request, view) is True
+
+    def test_authenticated_head_pypi_view_allowed(self):
+        permission = DomainBasedPermission()
+        request = _make_request(method="HEAD", user=_make_authenticated_user())
+        view = _make_pypi_view()
+
+        assert permission.has_permission(request, view) is True
+
+    def test_anonymous_get_public_domain_allowed(self):
+        permission = DomainBasedPermission()
+        domain = _make_domain("public-trusted-libraries")
+        request = _make_request(method="GET", user=_make_anonymous_user(), domain=domain)
+        view = _make_regular_view()
+
+        assert permission.has_permission(request, view) is True
+
+    def test_authenticated_get_public_domain_allowed(self):
+        permission = DomainBasedPermission()
+        domain = _make_domain("public-trusted-libraries")
+        request = _make_request(method="GET", user=_make_authenticated_user(), domain=domain)
+        view = _make_regular_view()
+
+        assert permission.has_permission(request, view) is True
+
+
+class TestSafeMethodDenied:
+    """Verify that safe methods are denied when they should be."""
+
+    def test_anonymous_get_private_domain_non_pypi_denied(self):
+        permission = DomainBasedPermission()
+        domain = _make_domain("my-private-domain")
+        request = _make_request(method="GET", user=_make_anonymous_user(), domain=domain)
+        view = _make_regular_view()
+
+        assert permission.has_permission(request, view) is False
+
+    def test_anonymous_get_no_domain_non_pypi_denied(self):
+        permission = DomainBasedPermission()
+        request = _make_request(method="GET", user=_make_anonymous_user(), domain=None)
+        view = _make_regular_view()
+
+        assert permission.has_permission(request, view) is False
+
+
+class TestUnsafeMethodsDenied:
+    """Verify that unsafe methods still require domain access."""
+
+    def test_anonymous_post_pypi_view_denied(self):
+        permission = DomainBasedPermission()
+        request = _make_request(method="POST", user=_make_anonymous_user())
+        view = _make_pypi_view()
+
+        assert permission.has_permission(request, view) is False
+
+    def test_anonymous_post_public_domain_denied(self):
+        permission = DomainBasedPermission()
+        domain = _make_domain("public-trusted-libraries")
+        request = _make_request(method="POST", user=_make_anonymous_user(), domain=domain)
+        view = _make_regular_view()
+
+        assert permission.has_permission(request, view) is False
+
+    @patch("pulp_service.app.authorization.get_domain_pk", return_value=42)
+    @patch("pulp_service.app.authorization.DomainOrg.objects")
+    def test_authenticated_post_pypi_view_checks_domain_access(
+        self, mock_domain_org, mock_get_domain_pk
+    ):
+        permission = DomainBasedPermission()
+        request = _make_request(
+            method="POST",
+            user=_make_authenticated_user(),
+            view_name="simple-detail",
+        )
+        request.META["HTTP_X_RH_IDENTITY"] = ""
+        view = _make_pypi_view()
+
+        mock_domain_org.filter.return_value.exists.return_value = False
+
+        assert permission.has_permission(request, view) is False
+
+
+class TestSuperuserBypass:
+    """Verify that superusers bypass all checks."""
+
+    def test_superuser_always_allowed(self):
+        permission = DomainBasedPermission()
+        user = MagicMock()
+        user.is_superuser = True
+        request = _make_request(method="DELETE", user=user)
+        view = _make_regular_view()
+
+        assert permission.has_permission(request, view) is True

--- a/pulp_service/pulp_service/tests/unit/test_domain_based_permission.py
+++ b/pulp_service/pulp_service/tests/unit/test_domain_based_permission.py
@@ -147,9 +147,7 @@ class TestUnsafeMethodsDenied:
 
     @patch("pulp_service.app.authorization.get_domain_pk", return_value=42)
     @patch("pulp_service.app.authorization.DomainOrg.objects")
-    def test_authenticated_post_pypi_view_checks_domain_access(
-        self, mock_domain_org, mock_get_domain_pk
-    ):
+    def test_authenticated_post_pypi_view_checks_domain_access(self, mock_domain_org, mock_get_domain_pk):
         permission = DomainBasedPermission()
         request = _make_request(
             method="POST",


### PR DESCRIPTION
## Summary

- Move PyPI (`isinstance(view, PyPIMixin)`) and public-domain (`"public-" in domain.name`) permission checks **before** the authentication gate in `DomainBasedPermission.has_permission()`, so both anonymous and authenticated users get read access on safe methods
- Remove the dead `AllowUnauthPull` class (unreferenced since patch 0038 was deleted in 5096c48)

## Problem

After PR #1220 moved the PyPI anonymous read logic from patch 0038 into `DomainBasedPermission`, the check was placed inside the `if not user.is_authenticated` branch. Authenticated users (e.g. `calunga-automatic-builds` org:15322645, `konflux-ansible-tenant` org:1979710) hitting public PyPI endpoints were routed to `_has_domain_access()`, which returned 403 because their org has no `DomainOrg` entry for the `public-trusted-libraries` domain.

**Timeline**: Last successful authenticated request was May 21 13:08 UTC (image `1222d66`). First 403 was May 22 00:41 UTC (image `278a49d`).

## Test plan

- [ ] Authenticated user can GET `/api/pypi/public-trusted-libraries/main/pypi/<package>/json/` (was 403, should be 200)
- [ ] Authenticated user can GET `/api/pypi/public-trusted-libraries/main/simple/<package>/` (was 403, should be 200)
- [ ] Anonymous user can still GET the same endpoints (unchanged, already 200)
- [ ] Authenticated user on a private domain they don't own still gets 403 for non-PyPI views
- [ ] Authenticated user on their own domain still works as before
- [ ] POST/PUT/DELETE on PyPI views still requires domain access (SAFE_METHODS guard)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Adjust domain-based permission checks so safe-method access to PyPI views and public domains is granted regardless of authentication status, and remove an unused permission class.

Bug Fixes:
- Ensure authenticated users can perform safe-method requests against PyPI views and public domains that were previously incorrectly rejected with 403 responses.

Enhancements:
- Unify the handling of safe-method access for PyPI views and public domains by moving the checks outside the anonymous-user-only branch in the permission logic.

Chores:
- Remove the unused AllowUnauthPull permission class.