### PR TITLE
fix: restore lazy PyPIMixin import to prevent circular import crash

### DIFF
--- a/pulp_service/pulp_service/app/authorization.py
+++ b/pulp_service/pulp_service/app/authorization.py
@@ -11,8 +11,6 @@ from rest_framework.permissions import SAFE_METHODS, BasePermission
 from pulpcore.plugin.models import Domain
 from pulpcore.plugin.util import extract_pk, get_domain_pk
 
-from pulp_python.app.pypi.views import PyPIMixin
-
 from pulp_service.app.models import DomainOrg
 
 _logger = logging.getLogger(__name__)
@@ -52,6 +50,8 @@ class DomainBasedPermission(BasePermission):
 
         # Allow safe requests on PyPI views and public domains for all users
         if request.method in SAFE_METHODS:
+            from pulp_python.app.pypi.views import PyPIMixin
+
             if isinstance(view, PyPIMixin):
                 return True
             domain = getattr(request, "pulp_domain", None)


### PR DESCRIPTION
## Summary

Restore the lazy import of `PyPIMixin` inside `has_permission()` that was moved to the module header in #1231.

## Problem

The top-level import causes a circular import at startup:

```
DRF settings → DomainBasedPermission → pulp_python.app.pypi.views → rest_framework.viewsets → (circular)
```

All API pods in production are in CrashLoopBackOff.

## Fix

Move `from pulp_python.app.pypi.views import PyPIMixin` back inside the `has_permission()` method body where it was originally. Python caches module imports, so after the first call it's just a dict lookup.

## Test plan

- [ ] Pods start without ImportError
- [ ] Authenticated GET on public PyPI endpoints returns 200 (not 403)
- [ ] Anonymous GET on public PyPI endpoints returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Prevent circular import crashes by moving the PyPIMixin import from module scope into the has_permission() method for PyPI views.