### PR TITLE
feat: add OOM kill trigger endpoint for alert testing

### DIFF
--- a/pulp_service/pulp_service/app/urls.py
+++ b/pulp_service/pulp_service/app/urls.py
@@ -7,6 +7,7 @@ from .viewsets import (
     DebugAuthenticationHeadersView,
     InternalServerErrorCheck,
     InternalServerErrorCheckWithException,
+    OOMKillTriggerView,
     RDSConnectionTestDispatcherView,
     RedirectCheck,
     ReleaseTaskLocksView,
@@ -37,4 +38,5 @@ urlpatterns = [
     path("api/pulp/test/random_lock_tasks/", TaskIngestionRandomResourceLockDispatcherView.as_view()),
     path("api/pulp/rds-connection-tests/", RDSConnectionTestDispatcherView.as_view()),
     path("api/pulp/create-domain/", CreateDomainView.as_view()),
+    path("api/pulp/test/trigger-oom/", OOMKillTriggerView.as_view()),
 ]

--- a/pulp_service/pulp_service/app/viewsets.py
+++ b/pulp_service/pulp_service/app/viewsets.py
@@ -110,6 +110,23 @@ class InternalServerErrorCheckWithException(APIView):
         raise APIException()
 
 
+class OOMKillTriggerView(APIView):
+    """Allocates memory until the container is OOMKilled.
+    Requires superuser authentication.
+    """
+
+    permission_classes = [IsAdminUser]
+
+    def post(self, request=None, path=None, pk=None):
+        chunk_size_mb = int(request.query_params.get("chunk_mb", 10))
+        chunks = []
+        allocated_mb = 0
+        while True:
+            chunks.append(b"x" * (chunk_size_mb * 1024 * 1024))
+            allocated_mb += chunk_size_mb
+            _logger.warning("OOM test: allocated %d MB", allocated_mb)
+
+
 class FeatureContentGuardViewSet(ContentGuardViewSet, RolesMixin):
     """
     Content guard to protect the content guarded by Subscription Features.

--- a/pulp_service/pulp_service/app/viewsets.py
+++ b/pulp_service/pulp_service/app/viewsets.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import os
 import random
 from base64 import b64decode
 from binascii import Error as Base64DecodeError
@@ -112,13 +113,23 @@ class InternalServerErrorCheckWithException(APIView):
 
 class OOMKillTriggerView(APIView):
     """Allocates memory until the container is OOMKilled.
-    Requires superuser authentication.
+    Requires superuser authentication. Only available on stage (ENV_NAME=stage).
     """
 
     permission_classes = [IsAdminUser]
 
     def post(self, request=None, path=None, pk=None):
-        chunk_size_mb = int(request.query_params.get("chunk_mb", 10))
+        if os.environ.get("ENV_NAME") != "stage":
+            return Response(
+                {"error": "OOM test endpoint is only available on stage"},
+                status=status.HTTP_403_FORBIDDEN,
+            )
+
+        try:
+            chunk_size_mb = max(1, min(100, int(request.query_params.get("chunk_mb", 10))))
+        except (ValueError, TypeError):
+            chunk_size_mb = 10
+
         chunks = []
         allocated_mb = 0
         while True:


### PR DESCRIPTION
## Summary

- Add `POST /api/pulp/test/trigger-oom/` endpoint that allocates memory in a loop until the container is OOMKilled
- Requires superuser authentication (`IsAdminUser`)
- Optional `?chunk_mb=10` query parameter to control allocation chunk size
- Used for testing PulpOOMKilled alert handling in the agent-alertmanager pipeline

## Test plan

- [ ] Deploy to stage
- [ ] `POST /api/pulp/test/trigger-oom/` as superuser → container OOMKilled
- [ ] Verify PulpOOMKilled alert fires in Alertmanager
- [ ] Verify agent-alertmanager detects and analyzes the alert
- [ ] Confirm non-superuser gets 403

Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

New Features:
- Introduce a POST /api/pulp/test/trigger-oom/ endpoint restricted to superusers to trigger an intentional OOM kill for testing alerts.