### PR TITLE
feat: add ENV_NAME env var to api, content, and worker deployments

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -440,6 +440,8 @@ objects:
             value: ${PULP_WORKER_TYPE}
           - name: PULP_DATA_UPLOAD_MAX_NUMBER_FIELDS
             value: ${PULP_DATA_UPLOAD_MAX_NUMBER_FIELDS}
+          - name: ENV_NAME
+            value: ${{ENV_NAME}}
 
     - name: content
       replicas: ${{PULP_CONTENT_REPLICAS}}
@@ -572,6 +574,8 @@ objects:
                 fieldPath: metadata.namespace
           - name: PULP_WORKER_TYPE
             value: ${PULP_WORKER_TYPE}
+          - name: ENV_NAME
+            value: ${{ENV_NAME}}
 
     - name: worker
       replicas: ${{PULP_WORKER_REPLICAS}}
@@ -682,6 +686,8 @@ objects:
             value: ${PULP_WORKER_TYPE}
           - name: ANTHROPIC_VERTEX_PROJECT_ID
             value: ${ANTHROPIC_VERTEX_PROJECT_ID}
+          - name: ENV_NAME
+            value: ${{ENV_NAME}}
       autoScaler:
         minReplicaCount: ${{PULP_WORKER_MIN_REPLICA_COUNT}}
         maxReplicaCount: ${{PULP_WORKER_MAX_REPLICA_COUNT}}


### PR DESCRIPTION
## Summary

- Add `ENV_NAME` environment variable to pulp-api, pulp-content, and pulp-worker deployment containers
- Previously only available in CronJob containers (export-access-logs)
- Enables runtime environment detection for stage-only features (e.g., OOM test endpoint from #1234)

## Context

The OOM test endpoint (#1234) checks `ENV_NAME == "stage"` to restrict access, but the env var wasn't reaching the main deployment containers — only CronJob containers had it. This adds it to all three deployments using the existing `ENV_NAME` parameter (already defined and set to `"stage"` in app-interface for stage clusters).

Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

New Features:
- Expose the ENV_NAME environment variable in pulp-api, pulp-content, and pulp-worker deployments for runtime environment detection.