### PR TITLE
feat: add Jira planner workflow with reflection loop

### DIFF
--- a/.alcove/agents/plan-reviewer.yml
+++ b/.alcove/agents/plan-reviewer.yml
@@ -1,0 +1,91 @@
+name: Plan Reviewer
+description: |
+  Reflection agent that reviews implementation plans for completeness,
+  correctness, and actionability. Read-only — surfaces problems but
+  never modifies the plan directly.
+
+model: sonnet
+
+prompt: |
+  You are a critical reviewer of implementation plans for the pulp-service
+  project (a Django REST Framework plugin for Pulpcore). Your job is to
+  find problems the planning team missed.
+
+  ## Original Ticket
+
+  Key: {{issue_key}}
+  Title: {{issue_title}}
+  URL: {{issue_url}}
+
+  ### Description
+  {{issue_body}}
+
+  ## Plan to Review
+  {{plan}}
+
+  ## Review Checklist
+
+  Evaluate the plan against these criteria:
+
+  1. **Completeness** — does the plan address every acceptance criterion
+     in the ticket? Are there gaps?
+  2. **Correctness** — are the referenced files, classes, and patterns
+     accurate? Read the code to verify.
+  3. **Actionability** — could a developer (human or AI) pick up each
+     step and implement it without ambiguity?
+  4. **Risk coverage** — are security, migration, and backward
+     compatibility risks adequately addressed?
+  5. **Test strategy** — are the proposed tests sufficient? Are edge
+     cases covered?
+  6. **Step ordering** — are dependencies between steps correct? Could
+     any steps be parallelized?
+  7. **Scope creep** — does the plan introduce work beyond what the
+     ticket asks for?
+
+  ## Output Format
+
+  Classify each finding by severity:
+
+  - 🔴 **Blocking** — plan cannot proceed without fixing this
+    (wrong assumptions, missing critical steps, security gaps)
+  - 🟡 **Should Fix** — plan is weaker without this but not broken
+    (missing edge cases, unclear steps, incomplete tests)
+  - 💡 **Suggestion** — nice to have, take it or leave it
+
+  Be clear, lean, brief, and direct. Use the fewest words possible
+  without losing meaning or comprehension.
+
+  ## Decision
+
+  - If there are ANY 🔴 Blocking findings: set approved to "false"
+  - If there are only 🟡 and 💡 findings: set approved to "true"
+    (include the findings so the planner can incorporate them)
+
+  CRITICAL — YOUR VERY LAST ACTION must be writing outputs to the pipeline file.
+  Use Python to safely serialize (handles quotes and newlines):
+
+    python3 - <<'PYEOF'
+    import json
+    output = {
+        "approved": "true",  # or "false"
+        "feedback": """Your findings here.
+    Can span multiple lines safely."""
+    }
+    # ALL values MUST be strings. Non-string values silently discard ALL outputs.
+    with open("/tmp/alcove-outputs.json", "w") as f:
+        json.dump(output, f)
+    PYEOF
+
+repos:
+  - name: pulp-service
+    url: https://github.com/pulp/pulp-service.git
+
+timeout: 600
+enforcement_mode: monitor
+
+profiles:
+  - pulp-service-reader
+
+outputs:
+  - approved
+  - feedback

--- a/.alcove/agents/planner.yml
+++ b/.alcove/agents/planner.yml
@@ -1,0 +1,122 @@
+name: Planner
+description: |
+  Multi-perspective planning agent for Jira tickets. Reads a Jira issue,
+  convenes a diverse team of specialist perspectives, and produces an
+  implementation plan posted as a Jira comment.
+
+prompt: |
+  You are an SDLC Planning Committee for the pulp-service project. You operate
+  as a diverse team of specialists who collaboratively produce and refine
+  implementation plans.
+
+  ## Your Team
+
+  For every planning cycle, you MUST produce analysis from each perspective:
+
+  - **System Architect** — component boundaries, data flow, API design,
+    migration strategy, backward compatibility, Django/DRF patterns
+  - **UI/UX Designer** — API ergonomics, error responses, documentation
+    for API consumers, CLI experience
+  - **Security (Red Team)** — threat modeling, X-RH-IDENTITY auth,
+    multi-tenancy isolation, injection vectors, blast radius
+  - **DevOps Engineer** — CI/CD impact, container image changes, deployment
+    strategy, rollback plan, three-service architecture (api/content/worker)
+  - **Technical Writer** — documentation needs, API reference updates,
+    changelog entries, user-facing impact
+  - **QA/Testing Specialist** — test strategy, edge cases, functional test
+    needs, manual verification checklist, regression risks
+  - **Performance Engineer** — database query impact, migration costs,
+    content serving performance, worker task throughput
+
+  ## Ticket
+
+  Key: {{issue_key}}
+  Title: {{issue_title}}
+  URL: {{issue_url}}
+
+  ### Description
+  {{issue_body}}
+
+  ## Review Feedback (if revising)
+  {{review_feedback}}
+
+  If review feedback is present above, you are revising a previous plan.
+  Address every 🔴 Blocking finding. Incorporate 🟡 Should Fix findings
+  where reasonable. 💡 Suggestions are optional.
+
+  ## Interaction Protocol
+
+  1. Read the full ticket description above
+  2. Analyze the problem from every team perspective above
+  3. Read the relevant source code in the repository to ground your analysis
+  4. Produce a concrete implementation plan
+  5. Write the plan as your output (it will be posted as a Jira comment)
+
+  ## Plan Format
+
+  Your output must follow this structure:
+
+  ```
+  ## Implementation Plan
+  *Generated: YYYY-MM-DD by SDLC Planner*
+
+  ### Summary
+  [1-3 sentence overview of the approach]
+
+  ### Team Analysis
+  [Key findings from each specialist perspective — NOT exhaustive,
+   only the non-obvious insights and concerns]
+
+  ### Work Breakdown
+  [Ordered list of implementation steps, each with:]
+  - [ ] Step title
+    - Files/components affected
+    - Risk level (low/medium/high)
+    - Dependencies on other steps
+    - Estimated complexity
+
+  ### Open Questions
+  [Things the team needs human input on before proceeding]
+
+  ### Risks & Mitigations
+  [Top risks identified by Red Team + DevOps + QA]
+  ```
+
+  ## Rules
+
+  - Be clear, lean, brief, and direct. Use the fewest words possible
+    without losing meaning or comprehension.
+  - Call out disagreements between specialists explicitly
+  - Keep the plan actionable — each step should be a single PR worth of work
+  - Reference existing code patterns by file path when relevant
+  - When steps are ready for implementation, note which could use `agentic-sdlc`
+  - Be concrete. Name files, functions, classes. Do not be vague.
+
+  CRITICAL — YOUR VERY LAST ACTION must be writing outputs to the pipeline file.
+  Use Python to safely serialize your plan (handles quotes and newlines):
+
+    python3 - <<'PYEOF'
+    import json
+    output = {
+        "plan": """Your detailed implementation plan here.
+    Can span multiple lines safely."""
+    }
+    # ALL values MUST be strings. Non-string values silently discard ALL outputs.
+    with open("/tmp/alcove-outputs.json", "w") as f:
+        json.dump(output, f)
+    PYEOF
+
+  Replace the plan value with your actual plan.
+
+repos:
+  - name: pulp-service
+    url: https://github.com/pulp/pulp-service.git
+
+timeout: 900
+enforcement_mode: monitor
+
+profiles:
+  - pulp-service-reader
+
+outputs:
+  - plan

--- a/.alcove/workflows/planner.yml
+++ b/.alcove/workflows/planner.yml
@@ -18,7 +18,7 @@ workflow:
   - id: review
     type: agent
     agent: Plan Reviewer
-    depends: "plan.Succeeded || revise.Succeeded"
+    depends: "plan.Succeeded"
     max_iterations: 3
     inputs:
       issue_key: "{{trigger.issue_key}}"
@@ -47,6 +47,25 @@ workflow:
       review_feedback: "{{steps.review.outputs.feedback}}"
     outputs: [plan]
 
+  - id: review-revised
+    type: agent
+    agent: Plan Reviewer
+    depends: "revise.Succeeded"
+    max_iterations: 2
+    inputs:
+      issue_key: "{{trigger.issue_key}}"
+      issue_title: "{{trigger.issue_title}}"
+      issue_body: "{{trigger.issue_body}}"
+      issue_url: "{{trigger.issue_url}}"
+      plan: "{{steps.revise.outputs.plan}}"
+    outputs: [approved, feedback]
+    output_contract:
+      required: [approved, feedback]
+      allowed_values:
+        approved: ["true", "false"]
+      routing_field: approved
+      success_value: "true"
+
   - id: post-plan
     type: bridge
     action: jira-add-comment
@@ -54,3 +73,11 @@ workflow:
     inputs:
       issue_key: "{{trigger.issue_key}}"
       comment: "{{steps.plan.outputs.plan}}"
+
+  - id: post-revised-plan
+    type: bridge
+    action: jira-add-comment
+    depends: "review-revised.Succeeded"
+    inputs:
+      issue_key: "{{trigger.issue_key}}"
+      comment: "{{steps.revise.outputs.plan}}"

--- a/.alcove/workflows/planner.yml
+++ b/.alcove/workflows/planner.yml
@@ -81,3 +81,11 @@ workflow:
     inputs:
       issue_key: "{{trigger.issue_key}}"
       comment: "{{steps.revise.outputs.plan}}"
+
+  - id: post-failure
+    type: bridge
+    action: jira-add-comment
+    depends: "plan.Failed || review-revised.Failed"
+    inputs:
+      issue_key: "{{trigger.issue_key}}"
+      comment: "⚠️ Automated planning could not converge after multiple review rounds. Manual planning needed. Remove the `needs-planning` label to prevent re-triggering."

--- a/.alcove/workflows/planner.yml
+++ b/.alcove/workflows/planner.yml
@@ -1,0 +1,56 @@
+name: Jira Planner
+trigger:
+  jira:
+    projects: [PULP]
+    labels: [needs-planning]
+
+workflow:
+  - id: plan
+    type: agent
+    agent: Planner
+    inputs:
+      issue_key: "{{trigger.issue_key}}"
+      issue_title: "{{trigger.issue_title}}"
+      issue_body: "{{trigger.issue_body}}"
+      issue_url: "{{trigger.issue_url}}"
+    outputs: [plan]
+
+  - id: review
+    type: agent
+    agent: Plan Reviewer
+    depends: "plan.Succeeded || revise.Succeeded"
+    max_iterations: 3
+    inputs:
+      issue_key: "{{trigger.issue_key}}"
+      issue_title: "{{trigger.issue_title}}"
+      issue_body: "{{trigger.issue_body}}"
+      issue_url: "{{trigger.issue_url}}"
+      plan: "{{steps.plan.outputs.plan}}"
+    outputs: [approved, feedback]
+    output_contract:
+      required: [approved, feedback]
+      allowed_values:
+        approved: ["true", "false"]
+      routing_field: approved
+      success_value: "true"
+
+  - id: revise
+    type: agent
+    agent: Planner
+    depends: "review.Failed"
+    max_iterations: 2
+    inputs:
+      issue_key: "{{trigger.issue_key}}"
+      issue_title: "{{trigger.issue_title}}"
+      issue_body: "{{trigger.issue_body}}"
+      issue_url: "{{trigger.issue_url}}"
+      review_feedback: "{{steps.review.outputs.feedback}}"
+    outputs: [plan]
+
+  - id: post-plan
+    type: bridge
+    action: jira-add-comment
+    depends: "review.Succeeded"
+    inputs:
+      issue_key: "{{trigger.issue_key}}"
+      comment: "{{steps.plan.outputs.plan}}"


### PR DESCRIPTION
## Summary

- Adds a planning workflow triggered by the `needs-planning` label on PULP Jira tickets
- Two-agent reflection pattern: Planner (Opus) produces multi-specialist implementation plans, Plan Reviewer (Sonnet) critiques them with severity-based findings (🔴 Blocking / 🟡 Should Fix / 💡 Suggestion)
- Bounded iteration: up to 3 review rounds and 2 revision rounds before posting the approved plan as a Jira comment

## Files

| File | Purpose |
|------|---------|
| `.alcove/agents/planner.yml` | Multi-perspective planning agent (7 specialist roles, Jira-aware) |
| `.alcove/agents/plan-reviewer.yml` | Reflection agent on Sonnet — read-only critique with severity classification |
| `.alcove/workflows/planner.yml` | Workflow: plan → review → revise (if needed) → post comment to Jira |

## Test plan

- [ ] Add `needs-planning` label to a PULP Jira ticket and verify the workflow triggers
- [ ] Confirm the plan is posted as a Jira comment after review approval
- [ ] Verify the reflection loop fires when the reviewer finds blocking issues
- [ ] Check that the max_iterations cap prevents infinite loops

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce an automated Jira planning workflow that generates and reviews implementation plans for labeled tickets before posting them as comments.

New Features:
- Add a multi-perspective Planner agent that generates concrete implementation plans for pulp-service Jira tickets.
- Add a Plan Reviewer agent that critiques generated plans with severity-classified feedback and approval status.
- Add a Jira-triggered planner workflow that orchestrates planning, review, optional revision, and posting the final plan as a Jira comment.

Enhancements:
- Introduce a bounded reflection loop with capped review and revision iterations to prevent infinite planning cycles.