### PR TITLE
Remove pulp_gem and any possible relation to it.

### DIFF
--- a/.alcove/agents/upgrade-deps/AGENT.md
+++ b/.alcove/agents/upgrade-deps/AGENT.md
@@ -73,7 +73,7 @@ When the workflow finishes, `/workspace/pulp-service` has all changes applied in
 
 ```bash
 export PATH="$HOME/.swamp/bin:$PATH"
-for pkg in pulpcore pulp-container pulp-python pulp-rpm pulp-maven pulp-file pulp-npm pulp-gem oras django-storages; do
+for pkg in pulpcore pulp-container pulp-python pulp-rpm pulp-maven pulp-file pulp-npm oras django-storages; do
   swamp data get --workflow "pulp-upgrade-check" "result-${pkg}" 2>/dev/null | grep -E '"status":\s*"(conflicts|regen_verify_failed|failed)"' && echo "^^^ $pkg has unresolved patches"
 done
 ```
@@ -94,7 +94,7 @@ First, uninstall all packages that have patches applied to them:
 curl -s -X POST http://$DEV_CONTAINER_HOST/exec \
   -H "Authorization: Bearer $DEV_TOKEN" \
   -H "Content-Type: application/json" \
-  -d '{"cmd": "pip uninstall -y pulpcore pulp-python pulp-container pulp-rpm pulp-maven pulp-file pulp-npm pulp-gem django-storages oras", "timeout": 120}'
+  -d '{"cmd": "pip uninstall -y pulpcore pulp-python pulp-container pulp-rpm pulp-maven pulp-file pulp-npm django-storages oras", "timeout": 120}'
 ```
 
 IMPORTANT: `pip uninstall` only removes files that pip installed. Files CREATED by patches (new files, not modifications) survive the uninstall. You MUST delete these manually before reinstalling.

--- a/.alcove/repo-groups/pulp-stack.yml
+++ b/.alcove/repo-groups/pulp-stack.yml
@@ -13,8 +13,6 @@ repos:
     name: pulp_python
   - url: https://github.com/pulp/pulp_container
     name: pulp_container
-  - url: https://github.com/pulp/pulp_gem
-    name: pulp_gem
   - url: https://github.com/pulp/pulp_npm
     name: pulp_npm
   - url: https://github.com/pulp/pulp_maven

--- a/.tekton/pulp-deploy-and-test.yaml
+++ b/.tekton/pulp-deploy-and-test.yaml
@@ -90,7 +90,7 @@ spec:
     - name: PULP_BINDINGS_COMPONENTS
       type: string
       description: space-separated list of Pulp components to generate the bindings
-      default: "pulpcore pulp_python pulp_npm pulp_gem pulp_rpm pulp_maven pulp_file pulp_service"
+      default: "pulpcore pulp_python pulp_npm pulp_rpm pulp_maven pulp_file pulp_service"
     - name: BINDINGS_TEMPLATES
       type: string
       description: space-separated list of openapi-generator mustache template files

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,7 +69,7 @@ WSGI middleware (`images/assets/log_middleware.py`) → Django middleware stack 
 - **Storage backends**: `AIPCCStorageBackend` (S3) and `OCIStorageBackend` (OCI/ORAS) in `app/storage.py`
 - **Tasks**: Background work in `app/tasks/` (package scanning, domain metrics, RDS testing)
 
-**Upstream plugins this extends**: pulpcore, pulp-python, pulp-container, pulp-rpm, pulp-gem, pulp-npm, pulp-maven, pulp-hugging-face.
+**Upstream plugins this extends**: pulpcore, pulp-python, pulp-container, pulp-rpm, pulp-npm, pulp-maven, pulp-hugging-face.
 
 ## Changelog Process
 

--- a/dev-container/scripts/pulp-test
+++ b/dev-container/scripts/pulp-test
@@ -3,7 +3,7 @@ set -e
 
 PULP_SERVICE_DIR="${PULP_SERVICE_DIR:-/workspace/pulp-service}"
 BINDINGS_DIR="/tmp/bindings"
-COMPONENTS="pulpcore pulp_python pulp_npm pulp_gem pulp_rpm pulp_maven pulp_file pulp_service"
+COMPONENTS="pulpcore pulp_python pulp_npm pulp_rpm pulp_maven pulp_file pulp_service"
 API_HOST="${API_HOST:-localhost}"
 API_PORT="${API_PORT:-24817}"
 API_PROTOCOL="${API_PROTOCOL:-http}"

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -739,10 +739,6 @@ This service is a Django plugin built on top of Pulp (Python-based repository ma
 
 ### Additional Pulp Plugins
 
-**Pulp Gem** (0.7.5, see requirements.txt):
-- RubyGems repository support
-- Documentation: https://docs.pulpproject.org/pulp_gem/
-
 **Pulp NPM** (0.5.0, see requirements.txt):
 - NPM registry support
 - Documentation: https://docs.pulpproject.org/pulp_npm/

--- a/pulp_service/pulp_service/tests/functional/constants.py
+++ b/pulp_service/pulp_service/tests/functional/constants.py
@@ -63,12 +63,6 @@ PYTHON_VULNERABILITY_IDS = [
     "PYSEC-2025-1",
 ]
 
-# GEM
-GEM_REMOTE_REGISTRY = "https://index.rubygems.org/"
-GEM_REMOTE_INCLUDE = {"rails": "= 7.0.1"}
-GEM_VULNERABILITY_PACKAGE = "rails-7.0.1"
-GEM_VULNERABILITY_IDS = ["GHSA-9822-6m93-xqf4"]
-
 # RPM
 RPM_SAMPLE_PACKAGE_URL = "https://vault.centos.org/7.0.1406/os/x86_64/Packages/kernel-3.10.0-123.el7.x86_64.rpm"
 RPM_SAMPLE_RH_CPE = '["cpe:/o:redhat:enterprise_linux:7::workstation"]'

--- a/pulp_service/pulp_service/tests/functional/test_vulnerability_report.py
+++ b/pulp_service/pulp_service/tests/functional/test_vulnerability_report.py
@@ -8,10 +8,6 @@ from pulpcore.client.pulp_rpm import ContentPackagesApi
 
 from pulp_service.app.constants import OSV_RH_ECOSYSTEM_CPES_LABEL, OSV_RH_ECOSYSTEM_LABEL
 from pulp_service.tests.functional.constants import (
-    GEM_REMOTE_INCLUDE,
-    GEM_REMOTE_REGISTRY,
-    GEM_VULNERABILITY_IDS,
-    GEM_VULNERABILITY_PACKAGE,
     NPM_PACKAGE_LOCK_FILE,
     NPM_REMOTE_REGISTRY,
     NPM_SAMPLE_PACKAGE,
@@ -115,17 +111,6 @@ def test_npm_package_lock(run_vuln_report, vuln_report_checks):
             None,
             NPM_VULNERABILITY_PACKAGE,
             NPM_VULNERABILITY_IDS,
-        ),
-        (
-            "gem_bindings",
-            "RepositoriesGemApi",
-            "gem_gem_repository_href",
-            "gem_repository_factory",
-            "gem_remote_factory",
-            GEM_REMOTE_REGISTRY,
-            GEM_REMOTE_INCLUDE,
-            GEM_VULNERABILITY_PACKAGE,
-            GEM_VULNERABILITY_IDS,
         ),
     ],
 )

--- a/pulp_service/pyproject.toml
+++ b/pulp_service/pyproject.toml
@@ -129,7 +129,7 @@ section-order = [
 
 [tool.ruff.lint.isort.sections]
 "pulpcore" = ["pulpcore"]
-"content-plugins" = ["pulp_rpm", "pulp_npm", "pulp_python", "pulp_container", "pulp_gem", "pulp_maven", "pulp_hugging_face"]
+"content-plugins" = ["pulp_rpm", "pulp_npm", "pulp_python", "pulp_container", "pulp_maven", "pulp_hugging_face"]
 
 [tool.ruff.lint.mccabe]
 max-complexity = 10

--- a/pulp_service/requirements.txt
+++ b/pulp_service/requirements.txt
@@ -1,14 +1,12 @@
 pulpcore==3.112.0
 pulp-rpm==3.35.2
 solv>=0.7.21,<0.7.38
-pulp-gem==0.7.5
 pulp-python==3.30.2
 pulp-npm==0.8.0
 pulp-container==2.27.9
 pulp-maven==0.12.0
 pulp-hugging-face==0.3.0
 pulp-cli
-pulp-cli-gem
 sentry-sdk
 app-common-python
 oras==0.2.38

--- a/tools/pulp_domain_removal/delete_domain.py
+++ b/tools/pulp_domain_removal/delete_domain.py
@@ -3,7 +3,7 @@
 Pulp Domain Deletion Script
 
 You need to install the client bindings:
-pip3 install crc-{pulpcore,pulp-python,pulp-npm,pulp-gem,pulp-rpm,pulp-maven,pulp-file,pulp-service}-client
+pip3 install crc-{pulpcore,pulp-python,pulp-npm,pulp-rpm,pulp-maven,pulp-file,pulp-service}-client
 
 This script cleans up all resources in a Pulp domain and then deletes the domain itself.
 It uses the Pulp client bindings to:


### PR DESCRIPTION
## Summary by Sourcery

Remove support and references for the Pulp Gem plugin from the service, tests, documentation, and tooling.

Build:
- Remove pulp-gem and pulp-cli-gem from runtime dependencies and related tooling configuration.

Documentation:
- Remove Pulp Gem plugin references from architecture and contributor documentation.

Tests:
- Remove Gem-related vulnerability reporting test cases and constants.

Chores:
- Update developer tooling, scripts, and config to no longer mention or require the Pulp Gem plugin.