### PR TITLE
Upgrade pulp-container 2.27.9 → 2.28.0

### DIFF
--- a/images/assets/patches/0018-Re-root-the-registry-API-at-api-pulp-v2.patch
+++ b/images/assets/patches/0018-Re-root-the-registry-API-at-api-pulp-v2.patch
@@ -7,19 +7,13 @@ Moves all container registry URL routes from /v2/ to /api/pulp/v2/ and
 the content app prefix from /pulp/container/ to /api/pulp-container/.
 Replaces RegistryPermission with DomainBasedPermission.
 
-When TOKEN_AUTH_DISABLED is true, includes both RegistryAuthentication
-and all DEFAULT_AUTHENTICATION_CLASSES instead of a single auth class,
-allowing custom authentication backends (e.g. remote header-based auth)
-to work alongside standard Basic auth for container registry operations.
-
 Co-Authored-By: Andre "decko" de Brito <decko@redhat.com>
 ---
  pulp_container/app/content.py            |  2 +-
  pulp_container/app/redirects.py          |  4 ++--
- pulp_container/app/registry_api.py       |  8 +++++++-
  pulp_container/app/token_verification.py | 16 +---------------
  pulp_container/app/urls.py               | 14 +++++++-------
- 5 files changed, 18 insertions(+), 28 deletions(-)
+ 4 files changed, 12 insertions(+), 26 deletions(-)
 
 diff --git a/pulp_container/app/content.py b/pulp_container/app/content.py
 index dbe6418d..006e8afb 100644
@@ -47,25 +41,6 @@ index 0c7a5898..fa4808cb 100644
              if settings.DOMAIN_ENABLED
              else "pulp/container"
          )
-diff --git a/pulp_container/app/registry_api.py b/pulp_container/app/registry_api.py
---- a/pulp_container/app/registry_api.py
-+++ b/pulp_container/app/registry_api.py
-@@ -232,9 +232,14 @@ class ContainerRegistryApiMixin:
-     def authentication_classes(self):
-         """
-         List of authentication classes to check for this view.
-+
-+        When token auth is disabled, includes both RegistryAuthentication (Basic auth)
-+        and any authentication classes configured in DEFAULT_AUTHENTICATION_CLASSES.
-+        This allows deployments to use custom authentication backends (e.g. remote
-+        header-based auth) alongside standard Basic auth for container registry operations.
-         """
-         if settings.get("TOKEN_AUTH_DISABLED", False):
--            return [RegistryAuthentication]
-+            return [RegistryAuthentication, *api_settings.DEFAULT_AUTHENTICATION_CLASSES]
-         return [TokenAuthentication]
- 
-     @property
 diff --git a/pulp_container/app/token_verification.py b/pulp_container/app/token_verification.py
 index d78738a4..faf05cd6 100644
 --- a/pulp_container/app/token_verification.py

--- a/images/assets/patches/CLAUDE.md
+++ b/images/assets/patches/CLAUDE.md
@@ -9,7 +9,7 @@ Each patch modifies files installed into site-packages via the Dockerfile.
 | ---------------- | ---------------------------------------------------------- | ---------------- | ------------------- |
 | `pulpcore/`      | [pulp/pulpcore](https://github.com/pulp/pulpcore)          | pulpcore         | 3.112.0             |
 | `pulp_file/`     | [pulp/pulpcore](https://github.com/pulp/pulpcore)          | (bundled)        | 3.112.0             |
-| `pulp_container/`| [pulp/pulp_container](https://github.com/pulp/pulp_container) | pulp-container | 2.27.9              |
+| `pulp_container/`| [pulp/pulp_container](https://github.com/pulp/pulp_container) | pulp-container | 2.28.0              |
 | `pulp_python/`   | [pulp/pulp_python](https://github.com/pulp/pulp_python)    | pulp-python      | 3.30.2              |
 | `pulp_maven/`    | [pulp/pulp_maven](https://github.com/pulp/pulp_maven)      | pulp-maven       | 0.12.0              |
 | `oras/`          | [oras-project/oras-py](https://github.com/oras-project/oras-py) | oras        | 0.2.38              |
@@ -41,8 +41,8 @@ transitive dependency pinned in pulpcore's `pyproject.toml`.
 ### 0018 — Re-root the registry API at /api/pulp/v2/
 
 - **Package:** pulp_container
-- **Files:** `pulp_container/app/content.py`, `pulp_container/app/redirects.py`, `pulp_container/app/registry_api.py`, `pulp_container/app/token_verification.py`, `pulp_container/app/urls.py`
-- **Description:** Moves all container registry URL routes from `/v2/` to `/api/pulp/v2/` and the content app prefix from `/pulp/container/` to `/api/pulp-container/`. Replaces `RegistryPermission` with `DomainBasedPermission`. When `TOKEN_AUTH_DISABLED` is true, includes both `RegistryAuthentication` and all `DEFAULT_AUTHENTICATION_CLASSES` instead of a single auth class, allowing custom authentication backends (e.g. remote header-based auth) alongside standard Basic auth.
+- **Files:** `pulp_container/app/content.py`, `pulp_container/app/redirects.py`, `pulp_container/app/token_verification.py`, `pulp_container/app/urls.py`
+- **Description:** Moves all container registry URL routes from `/v2/` to `/api/pulp/v2/` and the content app prefix from `/pulp/container/` to `/api/pulp-container/`. Replaces `RegistryPermission` with `DomainBasedPermission`.
 
 ### 0022 — Adds authentication to the mvn deploy api
 

--- a/pulp_service/requirements.txt
+++ b/pulp_service/requirements.txt
@@ -3,7 +3,7 @@ pulp-rpm==3.35.2
 solv>=0.7.21,<0.7.38
 pulp-python==3.30.2
 pulp-npm==0.8.0
-pulp-container==2.27.9
+pulp-container==2.28.0
 pulp-maven==0.12.0
 pulp-hugging-face==0.3.0
 pulp-cli


### PR DESCRIPTION
## Summary
- Upgrade pulp-container from 2.27.9 to 2.28.0
- Remove the `DEFAULT_AUTHENTICATION_CLASSES` change from patch 0018 — upstreamed in pulp_container#2363 (included in 2.28.0)
- Patch 0018 now only handles URL re-rooting and `RegistryPermission` → `DomainBasedPermission` replacement

## Test plan
- [x] Local `podman build` succeeds — all patches apply cleanly
- [ ] Konflux CI build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bump the pulp-container dependency to 2.28.0 and align local patch metadata with upstream changes.

Enhancements:
- Update the pulp-container package requirement from 2.27.9 to 2.28.0 in the service dependencies.
- Adjust patch 0018 to only cover registry URL re-rooting and DomainBasedPermission usage, matching upstream behavior.

Documentation:
- Refresh CLAUDE patch documentation to reflect the new pulp-container version and the narrowed scope of patch 0018.