### PR TITLE
Set glibc malloc tuning for API pods to reduce memory fragmentation

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -337,6 +337,10 @@ objects:
             cpu: ${{PULP_API_CPU_LIMIT}}
             memory: ${{PULP_API_MEMORY_LIMIT}}
         env:
+          - name: MALLOC_MMAP_THRESHOLD_
+            value: "65536"
+          - name: MALLOC_TRIM_THRESHOLD_
+            value: "65536"
           - name: GUNICORN_CMD_ARGS
             value: "--config /usr/bin/log_middleware.py"
           - name: PULP_OTEL_ENABLED


### PR DESCRIPTION
## Summary

- Set `MALLOC_MMAP_THRESHOLD_=65536` and `MALLOC_TRIM_THRESHOLD_=65536` env vars on the pulp-api container in `deploy/clowdapp.yaml`

## Background

API pods in production oscillate between 1.0-2.5 GB due to gunicorn worker recycling (`--max-requests 1000`). Even after workers are recycled, freed Python memory isn't always returned to the OS because glibc's default `malloc` uses `brk()` for small-to-medium allocations, which can only release memory from the top of the heap.

These two settings change the behavior:
- **`MALLOC_MMAP_THRESHOLD_=65536`**: Allocations >=64KB use `mmap()` instead of `brk()`. When freed, `mmap`'d regions are returned to the OS immediately.
- **`MALLOC_TRIM_THRESHOLD_=65536`**: Triggers `malloc_trim()` when >=64KB of free space accumulates at the top of the heap.

This should lower the post-recycle memory floor and reduce the overall oscillation range.

## Test plan

- [ ] Deploy to staging and verify API pods start successfully
- [ ] Monitor memory over several worker recycle cycles
- [ ] Compare post-recycle memory floor with and without the setting

## Summary by Sourcery

Deployment:
- Set MALLOC_MMAP_THRESHOLD_ and MALLOC_TRIM_THRESHOLD_ environment variables on the pulp-api container to tune glibc malloc behavior in production API pods.