### PR TITLE
fix: simplify Alcove workflow to single agent step

### DIFF
--- a/.alcove/workflows/alertmanager-analysis-pipeline.yml
+++ b/.alcove/workflows/alertmanager-analysis-pipeline.yml
@@ -1,11 +1,7 @@
 name: AlertManager Analysis Pipeline
 
 workflow:
-  - id: check-alerts
-    type: bridge
-    command: agent-alertmanager --check-only
   - id: analyze-alerts
     type: agent
     agent: AlertManager Analyzer
-    when: check-alerts.alerts_found == true
     outputs: [issues_found, issues_created, alert_summary]


### PR DESCRIPTION
## Summary

- Remove the `bridge` step from the alertmanager analysis pipeline workflow
- The bridge step caused a validation error: `workflow step 'check-alerts' of type 'bridge' missing required field: action`
- The agent already handles the no-alerts case internally (pre-flight dedup exits early with no LLM cost)
- Match the splunk-analysis-pipeline pattern (single agent step)

Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Simplify the AlertManager analysis pipeline workflow by using a single agent step for alert analysis and removing the redundant pre-check step.

Bug Fixes:
- Resolve a workflow validation error caused by a bridge step missing a required action field.

Enhancements:
- Align the AlertManager analysis pipeline with the single-agent pattern used by similar workflows by inlining the alert check into the analyzer agent step.