### PR TITLE
fix: wire ALERTMANAGER_CLUSTERS and ANTHROPIC_VERTEX_PROJECT_ID credentials

### DIFF
--- a/.alcove/agents/alertmanager-analyzer.yml
+++ b/.alcove/agents/alertmanager-analyzer.yml
@@ -13,7 +13,8 @@ enforcement_mode: monitor
 direct_outbound: true
 
 credentials:
-  ALERTMANAGER_TOKEN: alertmanager
+  ALERTMANAGER_CLUSTERS: ALERTMANAGER_CLUSTERS
+  ANTHROPIC_VERTEX_PROJECT_ID: ANTHROPIC_VERTEX_PROJECT_ID
   JIRA_TOKEN: jira
   VERTEX_SA_JSON: google-vertex
 


### PR DESCRIPTION
## Summary

- Replace `ALERTMANAGER_TOKEN` with `ALERTMANAGER_CLUSTERS` (multi-cluster JSON config stored as a secret)
- Add `ANTHROPIC_VERTEX_PROJECT_ID` for Vertex AI access

The agent binary reads `ALERTMANAGER_CLUSTERS` for multi-cluster config and `ANTHROPIC_VERTEX_PROJECT_ID` for LLM access. Both need to be wired as credentials so Alcove injects them as env vars.

Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Wire new credentials for alertmanager analyzer agent to support multi-cluster Alertmanager config and Vertex/Anthropic integration.

New Features:
- Introduce ALERTMANAGER_CLUSTERS credential for providing multi-cluster Alertmanager configuration to the agent.
- Expose ANTHROPIC_VERTEX_PROJECT_ID as a credential for Vertex-based Anthropic LLM access.

Bug Fixes:
- Replace deprecated ALERTMANAGER_TOKEN credential with the new ALERTMANAGER_CLUSTERS configuration secret in the alertmanager analyzer agent.