### PR TITLE
feat(exporter): add content-app download log exporter

### DIFF
--- a/management_tools/pulp-access-logs-exporter/pyproject.toml
+++ b/management_tools/pulp-access-logs-exporter/pyproject.toml
@@ -23,3 +23,4 @@ test = [
 [project.scripts]
 export-access-logs = "pulp_access_logs_exporter.cli:main"
 upload-parquet = "pulp_access_logs_exporter.cli:upload_main"
+export-content-logs = "pulp_access_logs_exporter.cli:content_main"

--- a/management_tools/pulp-access-logs-exporter/src/pulp_access_logs_exporter/cli.py
+++ b/management_tools/pulp-access-logs-exporter/src/pulp_access_logs_exporter/cli.py
@@ -3,7 +3,7 @@
 import argparse
 import sys
 import re
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 
@@ -95,7 +95,7 @@ def parse_time(time_str: str) -> datetime:
     """
     # Handle "now"
     if time_str.lower() == "now":
-        return datetime.utcnow()
+        return datetime.now(timezone.utc)
 
     # Handle relative times like "1 hour ago", "15 minutes ago"
     relative_match = re.match(r'(\d+)\s+(minute|hour|day)s?\s+ago', time_str.lower())
@@ -110,7 +110,7 @@ def parse_time(time_str: str) -> datetime:
         elif unit == 'day':
             delta = timedelta(days=value)
 
-        return datetime.utcnow() - delta
+        return datetime.now(timezone.utc) - delta
 
     # Try to parse as ISO format
     try:
@@ -198,6 +198,109 @@ def main():
     write_parquet(table, args.output_path, s3_credentials=s3_credentials)
 
     # 6. Print statistics
+    elapsed = time_module.time() - start_time
+    print("\n" + "=" * 60)
+    print("Export completed successfully!")
+    print("=" * 60)
+    print(f"  Records exported: {len(table)}")
+    print(f"  Time elapsed: {elapsed:.2f} seconds")
+    print("=" * 60)
+
+    return 0
+
+
+def parse_content_args(args=None):
+    """Parse command-line arguments for content logs exporter."""
+    parser = argparse.ArgumentParser(
+        description="Export Pulp content download logs from CloudWatch to Parquet format"
+    )
+
+    parser.add_argument("--cloudwatch-group", required=True, help="CloudWatch log group name")
+    parser.add_argument("--start-time", required=True, help='Start timestamp - ISO format or relative ("1 hour ago")')
+    parser.add_argument("--end-time", required=True, help='End timestamp - ISO format or relative ("now")')
+    parser.add_argument("--output-path", required=True, help="Local file path or S3 URI (s3://bucket/key)")
+    parser.add_argument("--content-type", required=True, choices=["python", "rpm"], help="Content type to export")
+    parser.add_argument("--aws-region", default="us-east-1", help="AWS region (default: us-east-1)")
+    parser.add_argument("--s3-access-key-id", help="AWS access key ID for S3")
+    parser.add_argument("--s3-secret-access-key", help="AWS secret access key for S3")
+    parser.add_argument("--s3-session-token", help="AWS session token for S3")
+    parser.add_argument("--s3-endpoint-url", help="Custom S3 endpoint URL")
+    parser.add_argument("--s3-region", help="AWS region for S3 (if different from --aws-region)")
+
+    return parser.parse_args(args)
+
+
+def content_main():
+    """Main entry point for content logs exporter CLI."""
+    import time as time_module
+    from pulp_access_logs_exporter.cloudwatch import fetch_cloudwatch_logs
+    from pulp_access_logs_exporter.content_cloudwatch import (
+        build_content_query,
+        convert_content_to_arrow_table,
+    )
+    from pulp_access_logs_exporter.writer import write_parquet
+
+    start_time = time_module.time()
+    args = parse_content_args()
+
+    print("=" * 60)
+    print(f"Pulp Content Logs Exporter ({args.content_type})")
+    print("=" * 60)
+
+    print("\nParsing time range...")
+    start_dt = parse_time(args.start_time)
+    end_dt = parse_time(args.end_time)
+
+    print(f"  Start: {start_dt.isoformat()}")
+    print(f"  End:   {end_dt.isoformat()}")
+    print(f"  Duration: {end_dt - start_dt}")
+
+    print("\nBuilding CloudWatch Logs Insights query...")
+    query = build_content_query()
+
+    print(f"\nQuerying CloudWatch Logs...")
+    print(f"  Log group: {args.cloudwatch_group}")
+    print(f"  Region: {args.aws_region}")
+    print(f"  Content type: {args.content_type}")
+
+    results = fetch_cloudwatch_logs(
+        log_group=args.cloudwatch_group,
+        query=query,
+        start_time=int(start_dt.timestamp()),
+        end_time=int(end_dt.timestamp()),
+        region=args.aws_region,
+    )
+
+    if not results:
+        print("\nNo logs found in the specified time range.")
+        return 0
+
+    print("\nConverting to PyArrow Table...")
+    table = convert_content_to_arrow_table(results, args.content_type)
+    print(f"  Schema: {table.schema}")
+
+    if len(table) == 0:
+        print(f"\nNo {args.content_type} downloads found in the logs.")
+        return 0
+
+    print("\nWriting Parquet file...")
+    print(f"  Output: {args.output_path}")
+
+    s3_credentials = None
+    if args.s3_access_key_id and args.s3_secret_access_key:
+        s3_credentials = {
+            'access_key': args.s3_access_key_id,
+            'secret_key': args.s3_secret_access_key,
+        }
+        if args.s3_session_token:
+            s3_credentials['session_token'] = args.s3_session_token
+        if args.s3_endpoint_url:
+            s3_credentials['endpoint_url'] = args.s3_endpoint_url
+        if args.s3_region:
+            s3_credentials['region'] = args.s3_region
+
+    write_parquet(table, args.output_path, s3_credentials=s3_credentials)
+
     elapsed = time_module.time() - start_time
     print("\n" + "=" * 60)
     print("Export completed successfully!")

--- a/management_tools/pulp-access-logs-exporter/src/pulp_access_logs_exporter/cloudwatch.py
+++ b/management_tools/pulp-access-logs-exporter/src/pulp_access_logs_exporter/cloudwatch.py
@@ -102,7 +102,7 @@ def fetch_cloudwatch_logs(
 
         # Start async query
         response = logs_client.start_query(
-            logGroupName=log_group,
+            logGroupNames=[log_group],
             startTime=int(current.timestamp()),
             endTime=int(chunk_end.timestamp()),
             queryString=query,

--- a/management_tools/pulp-access-logs-exporter/src/pulp_access_logs_exporter/content_cloudwatch.py
+++ b/management_tools/pulp-access-logs-exporter/src/pulp_access_logs_exporter/content_cloudwatch.py
@@ -48,9 +48,14 @@ def _parse_org_id(org_value):
 
 
 def _parse_timestamp(timestamp_str):
-    if timestamp_str.endswith("Z"):
-        timestamp_str = timestamp_str[:-1]
-    return datetime.fromisoformat(timestamp_str)
+    if not timestamp_str:
+        return None
+    try:
+        if timestamp_str.endswith("Z"):
+            timestamp_str = timestamp_str[:-1]
+        return datetime.fromisoformat(timestamp_str)
+    except ValueError:
+        return None
 
 
 FILENAME_PARSERS = {
@@ -63,7 +68,11 @@ def convert_content_to_arrow_table(results, content_type):
     schema = SCHEMAS[content_type]
     filename_parser = FILENAME_PARSERS[content_type]
     records = []
-    skipped_count = 0
+    skipped_log_parse = 0
+    skipped_path_parse = 0
+    skipped_extension = 0
+    skipped_filename = 0
+    skipped_timestamp = 0
 
     for result in results:
         message = result.get("message", result.get("@message", ""))
@@ -71,14 +80,17 @@ def convert_content_to_arrow_table(results, content_type):
 
         parsed_line = parse_content_log_line(message)
         if parsed_line is None:
+            skipped_log_parse += 1
             continue
 
         parsed_path = parse_content_path(parsed_line["path"])
         if parsed_path is None:
+            skipped_path_parse += 1
             continue
 
         filename = parsed_path["filename"]
         if not matches_content_type(filename, content_type):
+            skipped_extension += 1
             continue
 
         parsed_filename = filename_parser(filename)
@@ -87,11 +99,16 @@ def convert_content_to_arrow_table(results, content_type):
                 f"WARNING: Skipping malformed filename: {filename}",
                 file=sys.stderr,
             )
-            skipped_count += 1
+            skipped_filename += 1
+            continue
+
+        timestamp = _parse_timestamp(timestamp_str)
+        if timestamp is None:
+            skipped_timestamp += 1
             continue
 
         record = {
-            "timestamp": _parse_timestamp(timestamp_str),
+            "timestamp": timestamp,
             "domain": parsed_path["domain"],
             "distribution": parsed_path["distribution"],
             "artifact_path": parsed_path["artifact_path"],
@@ -105,9 +122,13 @@ def convert_content_to_arrow_table(results, content_type):
         record.update(parsed_filename)
         records.append(record)
 
-    if skipped_count > 0:
+    total_skipped = skipped_log_parse + skipped_path_parse + skipped_extension + skipped_filename + skipped_timestamp
+    if total_skipped > 0:
         print(
-            f"Records skipped (malformed filename): {skipped_count}",
+            f"Records filtered: {total_skipped} "
+            f"(log parse: {skipped_log_parse}, path parse: {skipped_path_parse}, "
+            f"extension: {skipped_extension}, malformed filename: {skipped_filename}, "
+            f"bad timestamp: {skipped_timestamp})",
             file=sys.stderr,
         )
 

--- a/management_tools/pulp-access-logs-exporter/src/pulp_access_logs_exporter/content_cloudwatch.py
+++ b/management_tools/pulp-access-logs-exporter/src/pulp_access_logs_exporter/content_cloudwatch.py
@@ -1,0 +1,114 @@
+import sys
+from datetime import datetime
+
+import pyarrow as pa
+
+from pulp_access_logs_exporter.content_parser import (
+    matches_content_type,
+    parse_content_log_line,
+    parse_content_path,
+    parse_rpm_filename,
+    parse_wheel_filename,
+)
+from pulp_access_logs_exporter.content_schemas import SCHEMAS
+
+
+def build_content_query():
+    return "\n".join(
+        [
+            "filter @message like /pulp-content/",
+            "| filter @message not like /livez/",
+            "| filter @message not like /status\\/$/",
+            "| fields @timestamp, message",
+        ]
+    )
+
+
+def _parse_cache_hit(cache_value):
+    if cache_value == "HIT":
+        return True
+    if cache_value == "MISS":
+        return False
+    return None
+
+
+def _parse_artifact_size(size_value):
+    if not size_value or size_value == "-":
+        return None
+    try:
+        return int(size_value)
+    except ValueError:
+        return None
+
+
+def _parse_org_id(org_value):
+    if not org_value or org_value == "-":
+        return None
+    return org_value
+
+
+def _parse_timestamp(timestamp_str):
+    if timestamp_str.endswith("Z"):
+        timestamp_str = timestamp_str[:-1]
+    return datetime.fromisoformat(timestamp_str)
+
+
+FILENAME_PARSERS = {
+    "python": parse_wheel_filename,
+    "rpm": parse_rpm_filename,
+}
+
+
+def convert_content_to_arrow_table(results, content_type):
+    schema = SCHEMAS[content_type]
+    filename_parser = FILENAME_PARSERS[content_type]
+    records = []
+    skipped_count = 0
+
+    for result in results:
+        message = result.get("message", result.get("@message", ""))
+        timestamp_str = result.get("@timestamp", "")
+
+        parsed_line = parse_content_log_line(message)
+        if parsed_line is None:
+            continue
+
+        parsed_path = parse_content_path(parsed_line["path"])
+        if parsed_path is None:
+            continue
+
+        filename = parsed_path["filename"]
+        if not matches_content_type(filename, content_type):
+            continue
+
+        parsed_filename = filename_parser(filename)
+        if parsed_filename is None:
+            print(
+                f"WARNING: Skipping malformed filename: {filename}",
+                file=sys.stderr,
+            )
+            skipped_count += 1
+            continue
+
+        record = {
+            "timestamp": _parse_timestamp(timestamp_str),
+            "domain": parsed_path["domain"],
+            "distribution": parsed_path["distribution"],
+            "artifact_path": parsed_path["artifact_path"],
+            "artifact_size": _parse_artifact_size(parsed_line["artifact_size"]),
+            "status_code": int(parsed_line["status"]),
+            "cache_hit": _parse_cache_hit(parsed_line["cache"]),
+            "user_agent": parsed_line["user_agent"],
+            "org_id": _parse_org_id(parsed_line["rh_org_id"]),
+            "x_forwarded_for": parsed_line["x_forwarded_for"],
+        }
+        record.update(parsed_filename)
+        records.append(record)
+
+    if skipped_count > 0:
+        print(
+            f"Records skipped (malformed filename): {skipped_count}",
+            file=sys.stderr,
+        )
+
+    return pa.Table.from_pylist(records, schema=schema)

--- a/management_tools/pulp-access-logs-exporter/src/pulp_access_logs_exporter/content_parser.py
+++ b/management_tools/pulp-access-logs-exporter/src/pulp_access_logs_exporter/content_parser.py
@@ -1,0 +1,126 @@
+import re
+
+CONTENT_LOG_REGEX = re.compile(
+    r"(?P<src_ip>\S+)\s+"
+    r"\[(?P<timestamp>[^\]]+)\]\s+"
+    r'"(?P<method>\S+)\s+(?P<path>\S+)\s+HTTP/\d\.\d"\s+'
+    r"(?P<status>\d+)\s+"
+    r"(?P<bytes>\S+)\s+"
+    r'"(?P<referer>[^"]*)"\s+'
+    r'"(?P<user_agent>[^"]*)"\s+'
+    r'cache:"(?P<cache>[^"]*)"\s+'
+    r'artifact_size:"(?P<artifact_size>[^"]*)"\s+'
+    r'rh_org_id:"(?P<rh_org_id>[^"]*)"\s+'
+    r'x_forwarded_for:"(?P<x_forwarded_for>[^"]*)"'
+)
+
+# From pulp_python/app/utils.py:80-85 (regex sourced from pip)
+WHEEL_REGEX = re.compile(
+    r"""^(?P<name>.+?)-(?P<version>.*?)
+    ((-(?P<build>\d[^-]*?))?-(?P<pyver>.+?)-(?P<abi>.+?)-(?P<plat>.+?)
+    \.whl|\.dist-info)$""",
+    re.VERBOSE,
+)
+
+CONTENT_TYPE_EXTENSIONS = {
+    "python": (".whl", ".whl.metadata"),
+    "rpm": (".rpm",),
+}
+
+CONTENT_PATH_PREFIX = "/api/pulp-content/"
+
+
+def parse_content_log_line(message):
+    match = CONTENT_LOG_REGEX.search(message)
+    if match is None:
+        return None
+    return match.groupdict()
+
+
+def parse_content_path(path):
+    if not path.startswith(CONTENT_PATH_PREFIX):
+        return None
+    remainder = path[len(CONTENT_PATH_PREFIX):]
+    segments = remainder.split("/")
+    if len(segments) < 2:
+        return None
+    domain = segments[0]
+    filename = segments[-1]
+    distribution = "/".join(segments[1:-1])
+    return {
+        "domain": domain,
+        "distribution": distribution,
+        "artifact_path": path,
+        "filename": filename,
+    }
+
+
+def matches_content_type(filename, content_type):
+    extensions = CONTENT_TYPE_EXTENSIONS.get(content_type, ())
+    return any(filename.endswith(ext) for ext in extensions)
+
+
+def parse_wheel_filename(filename):
+    base_filename = filename
+    if filename.endswith(".whl.metadata"):
+        base_filename = filename[:-len(".metadata")]
+
+    match = WHEEL_REGEX.match(base_filename)
+    if match is None:
+        return None
+    groups = match.groupdict()
+    return {
+        "package_name": groups["name"],
+        "package_version": groups["version"],
+        "build_tag": groups.get("build"),
+        "pyver": groups.get("pyver"),
+        "abi": groups.get("abi"),
+        "architecture": groups.get("plat"),
+    }
+
+
+# From pulp_rpm/app/depsolving.py:69-99
+def _parse_nevr(name):
+    if name.count("-") < 2:
+        raise ValueError("failed to parse nevr '%s' not a valid nevr" % name)
+    release_dash_pos = name.rfind("-")
+    release = name[release_dash_pos + 1:]
+    name_epoch_version = name[:release_dash_pos]
+    name_dash_pos = name_epoch_version.rfind("-")
+    package_name = name_epoch_version[:name_dash_pos]
+    epoch_version = name_epoch_version[name_dash_pos + 1:].split(":")
+    if len(epoch_version) == 1:
+        epoch = 0
+        version = epoch_version[0]
+    elif len(epoch_version) == 2:
+        epoch = int(epoch_version[0])
+        version = epoch_version[1]
+    else:
+        raise ValueError("failed to parse nevr '%s' not a valid nevr" % name)
+    return package_name, epoch, version, release
+
+
+# From pulp_rpm/app/depsolving.py:50-66
+def _parse_nevra(name):
+    if name.count(".") < 1:
+        raise ValueError("failed to parse nevra '%s' not a valid nevra" % name)
+    arch_dot_pos = name.rfind(".")
+    arch = name[arch_dot_pos + 1:]
+    return _parse_nevr(name[:arch_dot_pos]) + (arch,)
+
+
+def parse_rpm_filename(filename):
+    if not filename.endswith(".rpm"):
+        return None
+    nevra_string = filename[:-len(".rpm")]
+    try:
+        package_name, epoch, version, release, arch = _parse_nevra(nevra_string)
+    except ValueError:
+        return None
+    return {
+        "package_name": package_name,
+        "package_version": version,
+        "architecture": arch,
+        "epoch": epoch,
+        "release": release,
+    }

--- a/management_tools/pulp-access-logs-exporter/src/pulp_access_logs_exporter/content_schemas.py
+++ b/management_tools/pulp-access-logs-exporter/src/pulp_access_logs_exporter/content_schemas.py
@@ -1,0 +1,39 @@
+import pyarrow as pa
+
+COMMON_FIELDS = [
+    ("timestamp", pa.timestamp("ns")),
+    ("domain", pa.string()),
+    ("distribution", pa.string()),
+    ("package_name", pa.string()),
+    ("package_version", pa.string()),
+    ("architecture", pa.string()),
+    ("artifact_path", pa.string()),
+    ("artifact_size", pa.int64()),
+    ("status_code", pa.int16()),
+    ("cache_hit", pa.bool_()),
+    ("user_agent", pa.string()),
+    ("org_id", pa.string()),
+    ("x_forwarded_for", pa.string()),
+]
+
+PYTHON_SCHEMA = pa.schema(
+    COMMON_FIELDS
+    + [
+        ("build_tag", pa.string()),
+        ("pyver", pa.string()),
+        ("abi", pa.string()),
+    ]
+)
+
+RPM_SCHEMA = pa.schema(
+    COMMON_FIELDS
+    + [
+        ("epoch", pa.int32()),
+        ("release", pa.string()),
+    ]
+)
+
+SCHEMAS = {
+    "python": PYTHON_SCHEMA,
+    "rpm": RPM_SCHEMA,
+}

--- a/management_tools/pulp-access-logs-exporter/tests/conftest.py
+++ b/management_tools/pulp-access-logs-exporter/tests/conftest.py
@@ -38,3 +38,36 @@ def sample_cloudwatch_results():
 def sample_parquet_path(tmp_path):
     """Temporary path for Parquet file testing."""
     return str(tmp_path / "test_logs.parquet")
+
+
+@pytest.fixture
+def sample_content_cloudwatch_results():
+    """Sample CloudWatch results wrapping content-app log lines."""
+    return [
+        {
+            '@timestamp': '2026-06-09 14:30:00.000',
+            'message': '10.128.4.123 [09/Jun/2026:14:30:00 +0000] "GET /api/pulp-content/public-rhai/rhoai/3.5-EA2/cpu-ubi9/requests-2.34.2-2-py3-none-any.whl HTTP/1.1" 200 19456789 "-" "pip/24.0" cache:"HIT" artifact_size:"19456789" rh_org_id:"123456" x_forwarded_for:"23.48.249.160,10.0.0.1"',
+        },
+        {
+            '@timestamp': '2026-06-09 14:30:01.000',
+            'message': '10.128.4.124 [09/Jun/2026:14:30:01 +0000] "GET /api/pulp-content/public-rhai/rhoai/3.5-EA2/cpu-ubi9/numpy-1.26.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata HTTP/1.1" 200 1234 "-" "uv/0.9.26" cache:"MISS" artifact_size:"1234" rh_org_id:"789012" x_forwarded_for:"10.20.30.40"',
+        },
+        {
+            '@timestamp': '2026-06-09 14:30:02.000',
+            'message': '10.128.4.125 [09/Jun/2026:14:30:02 +0000] "GET /api/pulp-content/public-copr/packit/teemtee-tmt-4901/fedora-43-x86_64/Packages/b/bash-5.2.26-4.fc43.x86_64.rpm HTTP/1.1" 200 5678901 "-" "dnf/4.18.0" cache:"MISS" artifact_size:"5678901" rh_org_id:"-" x_forwarded_for:"192.168.1.1"',
+        },
+        {
+            '@timestamp': '2026-06-09 14:30:03.000',
+            'message': '10.128.4.126 [09/Jun/2026:14:30:03 +0000] "GET /api/pulp-content/public-copr/packit/teemtee-tmt-4901/fedora-43-x86_64/repodata/repomd.xml HTTP/1.1" 200 3456 "-" "dnf/4.18.0" cache:"HIT" artifact_size:"3456" rh_org_id:"-" x_forwarded_for:"192.168.1.2"',
+        },
+        {
+            '@timestamp': '2026-06-09 14:30:04.000',
+            'message': '10.128.4.127 [09/Jun/2026:14:30:04 +0000] "GET /api/pulp-content/ccac33ac/templates/kernel-core-6.8.0-300.fc40.x86_64.rpm HTTP/1.1" 200 99887766 "-" "yum/4.0" cache:"HIT" artifact_size:"99887766" rh_org_id:"555666" x_forwarded_for:"172.16.0.1"',
+        },
+    ]
+
+
+@pytest.fixture
+def sample_content_parquet_path(tmp_path):
+    """Temporary path for content Parquet file testing."""
+    return str(tmp_path / "test_content_logs.parquet")

--- a/management_tools/pulp-access-logs-exporter/tests/test_content_export.py
+++ b/management_tools/pulp-access-logs-exporter/tests/test_content_export.py
@@ -1,0 +1,260 @@
+"""Tests for content-app log exporter."""
+
+import pyarrow.parquet as pq
+
+from pulp_access_logs_exporter.content_parser import (
+    matches_content_type,
+    parse_content_log_line,
+    parse_content_path,
+    parse_rpm_filename,
+    parse_wheel_filename,
+)
+from pulp_access_logs_exporter.content_cloudwatch import (
+    build_content_query,
+    convert_content_to_arrow_table,
+)
+from pulp_access_logs_exporter.content_schemas import PYTHON_SCHEMA, RPM_SCHEMA
+from pulp_access_logs_exporter.writer import write_parquet
+
+
+class TestParseContentLogLine:
+    def test_parses_all_fields(self):
+        line = '10.128.4.123 [09/Jun/2026:14:30:00 +0000] "GET /api/pulp-content/default/dist/pkg-1.0-py3-none-any.whl HTTP/1.1" 200 19456789 "-" "pip/24.0" cache:"HIT" artifact_size:"19456789" rh_org_id:"123456" x_forwarded_for:"23.48.249.160,10.0.0.1"'
+        result = parse_content_log_line(line)
+        assert result is not None
+        assert result["src_ip"] == "10.128.4.123"
+        assert result["method"] == "GET"
+        assert result["path"] == "/api/pulp-content/default/dist/pkg-1.0-py3-none-any.whl"
+        assert result["status"] == "200"
+        assert result["user_agent"] == "pip/24.0"
+        assert result["cache"] == "HIT"
+        assert result["artifact_size"] == "19456789"
+        assert result["rh_org_id"] == "123456"
+        assert result["x_forwarded_for"] == "23.48.249.160,10.0.0.1"
+
+    def test_parses_cache_miss(self):
+        line = '10.0.0.1 [09/Jun/2026:14:30:00 +0000] "GET /api/pulp-content/d/r/file.rpm HTTP/1.1" 200 100 "-" "dnf/4.0" cache:"MISS" artifact_size:"100" rh_org_id:"-" x_forwarded_for:"1.2.3.4"'
+        result = parse_content_log_line(line)
+        assert result is not None
+        assert result["cache"] == "MISS"
+        assert result["rh_org_id"] == "-"
+
+    def test_returns_none_for_non_matching(self):
+        result = parse_content_log_line("not a valid log line")
+        assert result is None
+
+    def test_parses_empty_org_id(self):
+        line = '10.0.0.1 [09/Jun/2026:14:30:00 +0000] "GET /api/pulp-content/d/r/file.whl HTTP/1.1" 200 100 "-" "pip/24.0" cache:"HIT" artifact_size:"100" rh_org_id:"-" x_forwarded_for:"1.2.3.4"'
+        result = parse_content_log_line(line)
+        assert result["rh_org_id"] == "-"
+
+
+class TestParseWheelFilename:
+    def test_standard_wheel(self):
+        result = parse_wheel_filename("requests-2.31.0-py3-none-any.whl")
+        assert result is not None
+        assert result["package_name"] == "requests"
+        assert result["package_version"] == "2.31.0"
+        assert result["build_tag"] is None
+        assert result["pyver"] == "py3"
+        assert result["abi"] == "none"
+        assert result["architecture"] == "any"
+
+    def test_platform_specific_wheel(self):
+        result = parse_wheel_filename(
+            "numpy-1.26.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        )
+        assert result is not None
+        assert result["package_name"] == "numpy"
+        assert result["package_version"] == "1.26.4"
+        assert result["pyver"] == "cp312"
+        assert result["abi"] == "cp312"
+        assert result["architecture"] == "manylinux_2_17_x86_64.manylinux2014_x86_64"
+
+    def test_wheel_with_build_tag(self):
+        result = parse_wheel_filename("requests-2.34.2-2-py3-none-any.whl")
+        assert result is not None
+        assert result["package_name"] == "requests"
+        assert result["package_version"] == "2.34.2"
+        assert result["build_tag"] == "2"
+        assert result["pyver"] == "py3"
+
+    def test_wheel_metadata(self):
+        result = parse_wheel_filename(
+            "numpy-1.26.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata"
+        )
+        assert result is not None
+        assert result["package_name"] == "numpy"
+        assert result["package_version"] == "1.26.4"
+
+    def test_malformed_wheel_returns_none(self):
+        result = parse_wheel_filename("not-a-wheel.txt")
+        assert result is None
+
+
+class TestParseRpmFilename:
+    def test_standard_rpm(self):
+        result = parse_rpm_filename("bash-5.2.26-4.fc43.x86_64.rpm")
+        assert result is not None
+        assert result["package_name"] == "bash"
+        assert result["package_version"] == "5.2.26"
+        assert result["release"] == "4.fc43"
+        assert result["architecture"] == "x86_64"
+        assert result["epoch"] == 0
+
+    def test_rpm_with_epoch(self):
+        result = parse_rpm_filename("jay-3:3.10-4.fc3.x86_64.rpm")
+        assert result is not None
+        assert result["package_name"] == "jay"
+        assert result["epoch"] == 3
+        assert result["package_version"] == "3.10"
+        assert result["release"] == "4.fc3"
+
+    def test_noarch_rpm(self):
+        result = parse_rpm_filename("nodejs26-npm-11.13.0-1.26.1.0.5.fc45.noarch.rpm")
+        assert result is not None
+        assert result["package_name"] == "nodejs26-npm"
+        assert result["package_version"] == "11.13.0"
+        assert result["release"] == "1.26.1.0.5.fc45"
+        assert result["architecture"] == "noarch"
+
+    def test_complex_name_rpm(self):
+        result = parse_rpm_filename("kernel-core-6.8.0-300.fc40.x86_64.rpm")
+        assert result is not None
+        assert result["package_name"] == "kernel-core"
+        assert result["package_version"] == "6.8.0"
+        assert result["release"] == "300.fc40"
+
+    def test_malformed_rpm_returns_none(self):
+        result = parse_rpm_filename("notavalidrpm.rpm")
+        assert result is None
+
+    def test_non_rpm_returns_none(self):
+        result = parse_rpm_filename("somefile.txt")
+        assert result is None
+
+
+class TestContentTypeFiltering:
+    def test_python_whl_matches(self):
+        assert matches_content_type("pkg-1.0-py3-none-any.whl", "python") is True
+
+    def test_python_metadata_matches(self):
+        assert matches_content_type("pkg-1.0-py3-none-any.whl.metadata", "python") is True
+
+    def test_rpm_matches(self):
+        assert matches_content_type("bash-5.2-1.fc43.x86_64.rpm", "rpm") is True
+
+    def test_python_rejects_rpm(self):
+        assert matches_content_type("bash-5.2-1.fc43.x86_64.rpm", "python") is False
+
+    def test_rpm_rejects_whl(self):
+        assert matches_content_type("pkg-1.0-py3-none-any.whl", "rpm") is False
+
+    def test_rejects_repodata(self):
+        assert matches_content_type("repomd.xml", "python") is False
+        assert matches_content_type("repomd.xml", "rpm") is False
+
+
+class TestParseContentPath:
+    def test_python_path(self):
+        result = parse_content_path(
+            "/api/pulp-content/public-rhai/rhoai/3.5-EA2/cpu-ubi9/requests-2.34.2-2-py3-none-any.whl"
+        )
+        assert result is not None
+        assert result["domain"] == "public-rhai"
+        assert result["distribution"] == "rhoai/3.5-EA2/cpu-ubi9"
+        assert result["filename"] == "requests-2.34.2-2-py3-none-any.whl"
+
+    def test_rpm_path(self):
+        result = parse_content_path(
+            "/api/pulp-content/public-copr/packit/tmt/fedora-43-x86_64/Packages/b/bash-5.2.26-4.fc43.x86_64.rpm"
+        )
+        assert result is not None
+        assert result["domain"] == "public-copr"
+        assert result["distribution"] == "packit/tmt/fedora-43-x86_64/Packages/b"
+        assert result["filename"] == "bash-5.2.26-4.fc43.x86_64.rpm"
+
+    def test_non_content_path_returns_none(self):
+        result = parse_content_path("/api/pypi/default/dist/simple/pkg/")
+        assert result is None
+
+    def test_too_short_path_returns_none(self):
+        result = parse_content_path("/api/pulp-content/domain")
+        assert result is None
+
+
+class TestContentToParquetPython:
+    def test_converts_python_downloads(self, sample_content_cloudwatch_results, sample_content_parquet_path):
+        table = convert_content_to_arrow_table(
+            sample_content_cloudwatch_results, "python"
+        )
+        assert table.num_rows == 2
+        assert table.schema == PYTHON_SCHEMA
+
+        write_parquet(table, sample_content_parquet_path)
+        read_table = pq.read_table(sample_content_parquet_path)
+        assert read_table.num_rows == 2
+
+        rows = read_table.to_pydict()
+        assert rows["package_name"][0] == "requests"
+        assert rows["package_version"][0] == "2.34.2"
+        assert rows["build_tag"][0] == "2"
+        assert rows["cache_hit"][0] is True
+        assert rows["artifact_size"][0] == 19456789
+        assert rows["org_id"][0] == "123456"
+
+        assert rows["package_name"][1] == "numpy"
+        assert rows["package_version"][1] == "1.26.4"
+        assert rows["cache_hit"][1] is False
+
+
+class TestContentToParquetRpm:
+    def test_converts_rpm_downloads(self, sample_content_cloudwatch_results, sample_content_parquet_path):
+        table = convert_content_to_arrow_table(
+            sample_content_cloudwatch_results, "rpm"
+        )
+        assert table.num_rows == 2
+        assert table.schema == RPM_SCHEMA
+
+        write_parquet(table, sample_content_parquet_path)
+        read_table = pq.read_table(sample_content_parquet_path)
+        assert read_table.num_rows == 2
+
+        rows = read_table.to_pydict()
+        assert rows["package_name"][0] == "bash"
+        assert rows["package_version"][0] == "5.2.26"
+        assert rows["release"][0] == "4.fc43"
+        assert rows["architecture"][0] == "x86_64"
+        assert rows["epoch"][0] == 0
+        assert rows["org_id"][0] is None
+        assert rows["cache_hit"][0] is False
+
+        assert rows["package_name"][1] == "kernel-core"
+        assert rows["package_version"][1] == "6.8.0"
+        assert rows["cache_hit"][1] is True
+        assert rows["org_id"][1] == "555666"
+
+
+class TestEmptyContentResults:
+    def test_empty_results_python(self):
+        table = convert_content_to_arrow_table([], "python")
+        assert table.num_rows == 0
+        assert table.schema == PYTHON_SCHEMA
+
+    def test_empty_results_rpm(self):
+        table = convert_content_to_arrow_table([], "rpm")
+        assert table.num_rows == 0
+        assert table.schema == RPM_SCHEMA
+
+
+class TestContentQueryBuilding:
+    def test_query_contains_content_path_filter(self):
+        query = build_content_query()
+        assert "pulp-content" in query
+        assert "livez" in query
+        assert "status" in query
+
+    def test_query_fetches_timestamp_and_message(self):
+        query = build_content_query()
+        assert "@timestamp" in query
+        assert "message" in query

--- a/management_tools/pulp-access-logs-exporter/tests/test_content_export.py
+++ b/management_tools/pulp-access-logs-exporter/tests/test_content_export.py
@@ -208,6 +208,41 @@ class TestContentToParquetPython:
         assert rows["cache_hit"][1] is False
 
 
+    def test_skips_invalid_and_non_matching_records(self, sample_content_cloudwatch_results):
+        extra_records = [
+            {"message": "not a valid log line"},
+            {
+                "@timestamp": "2026-06-09 14:30:05.000",
+                "message": '10.0.0.1 [09/Jun/2026:14:30:05 +0000] "GET /api/pypi/default/simple/pkg/ HTTP/1.1" 200 100 "-" "pip/24.0" cache:"HIT" artifact_size:"100" rh_org_id:"-" x_forwarded_for:"1.2.3.4"',
+            },
+        ]
+        mixed_results = sample_content_cloudwatch_results + extra_records
+        table = convert_content_to_arrow_table(mixed_results, "python")
+        assert table.num_rows == 2
+
+    def test_skips_malformed_filename_and_warns(self, capsys):
+        results = [
+            {
+                "@timestamp": "2026-06-09 14:30:00.000",
+                "message": '10.0.0.1 [09/Jun/2026:14:30:00 +0000] "GET /api/pulp-content/default/dist/badfile.whl HTTP/1.1" 200 100 "-" "pip/24.0" cache:"HIT" artifact_size:"100" rh_org_id:"-" x_forwarded_for:"1.2.3.4"',
+            },
+        ]
+        table = convert_content_to_arrow_table(results, "python")
+        assert table.num_rows == 0
+        captured = capsys.readouterr()
+        assert "malformed" in captured.err.lower()
+
+    def test_skips_bad_timestamp(self):
+        results = [
+            {
+                "@timestamp": "",
+                "message": '10.0.0.1 [09/Jun/2026:14:30:00 +0000] "GET /api/pulp-content/public-rhai/rhoai/3.5/requests-2.31.0-py3-none-any.whl HTTP/1.1" 200 100 "-" "pip/24.0" cache:"HIT" artifact_size:"100" rh_org_id:"-" x_forwarded_for:"1.2.3.4"',
+            },
+        ]
+        table = convert_content_to_arrow_table(results, "python")
+        assert table.num_rows == 0
+
+
 class TestContentToParquetRpm:
     def test_converts_rpm_downloads(self, sample_content_cloudwatch_results, sample_content_parquet_path):
         table = convert_content_to_arrow_table(


### PR DESCRIPTION
## Summary

- New `export-content-logs` CLI command that exports Python (.whl/.whl.metadata) and RPM (.rpm) download logs from content-app (pulp-content) CloudWatch streams to Parquet
- Parses package metadata from filenames: wheel regex (from pip/pulp_python) for Python, NEVRA parser (from pulp_rpm) for RPM
- Type-specific Parquet schemas with common fields (timestamp, domain, distribution, package_name, package_version, architecture, artifact_size, cache_hit, org_id) plus Python-specific (build_tag, pyver, abi) or RPM-specific (epoch, release)
- Fixes timezone bug in existing `parse_time()` (utcnow → timezone-aware) and switches to `logGroupNames` (plural) for JSON-structured log support

## Test plan

- [x] 36 unit tests passing (31 new + 5 existing, no regressions)
- [x] Live-tested against prod CloudWatch: 4,138 Python downloads and 3,742 RPM downloads exported in 10 min window
- [ ] Deploy CronJob config (follow-up: PULP-1831)

Jira: [PULP-1811](https://redhat.atlassian.net/browse/PULP-1811)
Epic: [PULP-1809](https://redhat.atlassian.net/browse/PULP-1809)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[PULP-1811]: https://redhat.atlassian.net/browse/PULP-1811?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PULP-1809]: https://redhat.atlassian.net/browse/PULP-1809?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Add a new CLI command for exporting pulp-content download logs from CloudWatch to Parquet, with typed schemas for Python wheels and RPMs, and improve time handling and CloudWatch querying.

New Features:
- Introduce an export-content-logs CLI entrypoint to export pulp-content download logs for Python wheels and RPMs to Parquet with S3 support.
- Add parsing of content-app access log lines and content paths to extract package metadata and request details for Python and RPM artifacts.
- Define dedicated PyArrow schemas and conversion logic for Python and RPM download records.

Bug Fixes:
- Make parse_time return timezone-aware UTC datetimes instead of naive utcnow values.
- Switch CloudWatch Logs querying to use logGroupNames to support structured log groups.

Tests:
- Add unit tests covering content log parsing, filename parsing for wheels and RPMs, content-type filtering, schema-based Parquet conversion, and CloudWatch query building.
- Extend test fixtures with sample content CloudWatch results and Parquet paths for the new exporter.