### PR TITLE
fix: remove content-sources iqePlugin dep from bonfire tests

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -264,8 +264,6 @@ objects:
     name: pulp
   spec:
     envName: "${ENV_NAME}"
-    testing:
-      iqePlugin: content-sources
     deployments:
     - name: api
       replicas: ${{PULP_API_REPLICAS}}


### PR DESCRIPTION
## Summary

- Remove `testing.iqePlugin: content-sources` from the ClowdApp spec
- This field causes bonfire to deploy `content-sources-backend` as a dependency in ephemeral environments
- We don't run IQE tests — our bonfire pipeline runs pytest functional tests directly
- content-sources-backend frequently fails due to ephemeral cluster resource exhaustion (`FailedScheduling: 0/48 nodes available: 43 Insufficient cpu`), causing flaky bonfire-tekton CI

## Evidence

From PR #1258 bonfire logs (`pulp-bonfire-tekton-ntcv4`):
```
deployment/content-sources-backend-service not ready: Progressing: False (ReplicaSet has timed out progressing)
deployment/content-sources-backend-task-worker not ready: Init container db-migrate-init CrashLoopBackOff
FailedScheduling: 0/48 nodes are available: 43 Insufficient cpu
```

Same failure pattern on unrelated PR #1256.

## Test plan

- [ ] Bonfire pipeline should no longer deploy content-sources-backend
- [ ] Functional tests should still pass (they don't depend on content-sources)
- [ ] Reduced ephemeral resource footprint should lower flake rate

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Stop unnecessary deployment of the content-sources-backend service in bonfire tests by removing the IQE plugin configuration from the ClowdApp spec.