### PR TITLE
fix: use correct input name for jira-add-comment in planner workflow

### DIFF
--- a/.alcove/workflows/planner.yml
+++ b/.alcove/workflows/planner.yml
@@ -72,7 +72,7 @@ workflow:
     depends: "review.Succeeded"
     inputs:
       issue_key: "{{trigger.issue_key}}"
-      comment: "{{steps.plan.outputs.plan}}"
+      body: "{{steps.plan.outputs.plan}}"
 
   - id: post-revised-plan
     type: bridge
@@ -80,7 +80,7 @@ workflow:
     depends: "review-revised.Succeeded"
     inputs:
       issue_key: "{{trigger.issue_key}}"
-      comment: "{{steps.revise.outputs.plan}}"
+      body: "{{steps.revise.outputs.plan}}"
 
   - id: post-failure
     type: bridge
@@ -88,4 +88,4 @@ workflow:
     depends: "plan.Failed || review-revised.Failed"
     inputs:
       issue_key: "{{trigger.issue_key}}"
-      comment: "⚠️ Automated planning could not converge after multiple review rounds. Manual planning needed. Remove the `needs-planning` label to prevent re-triggering."
+      body: "⚠️ Automated planning could not converge after multiple review rounds. Manual planning needed. Remove the `needs-planning` label to prevent re-triggering."


### PR DESCRIPTION
## Summary

- The `jira-add-comment` bridge action expects `body` as the input field, not `comment`
- All three comment steps in the Jira Planner workflow (`post-plan`, `post-revised-plan`, `post-failure`) were silently failing with "missing required inputs: issue_key, body"

## Root cause

The workflow was written with `comment:` as the input name, but `bridgeActionJiraAddComment` reads `getStringInput(inputs, "body")`.

## Test plan

- [ ] Trigger the Jira Planner workflow on a PULP ticket with `needs-planning` label
- [ ] Verify the plan or failure comment is posted to the Jira ticket

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce an automated Jira planning workflow that generates, reviews, and posts implementation plans as Jira comments for PULP tickets labeled needs-planning.

New Features:
- Add a Planner agent that produces structured implementation plans for pulp-service Jira tickets.
- Add a Plan Reviewer agent that validates plans for completeness, correctness, and actionability before approval.
- Add a Jira Planner workflow that orchestrates planning, review, revision cycles, and posts plan or failure comments back to the Jira issue.