### PR TITLE
fix: use oc instead of kubectl for route creation in ephemeral

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -191,7 +191,7 @@ objects:
       EOF
       
       kubectl create secret generic pulp-settings --from-file /tmp/settings.py
-      kubectl apply -f-<<EOF
+      oc apply -f-<<EOF
       ---
       apiVersion: route.openshift.io/v1
       kind: Route


### PR DESCRIPTION
## Summary

- The `create-settings-and-ingress` ClowdJobInvocation uses `kubectl apply` to create the `pulp-api` and `pulp-content` routes in ephemeral namespaces
- Recent ephemeral cluster upgrades introduced a `stolostron/cluster-lifecycle-api` CRD that causes `kubectl` client-side schema validation to fail: `SchemaError(github.com/stolostron/cluster-lifecycle-api/clusterview/v1alpha1.UserPermission.status)`
- The script uses `set -ex` but the heredoc pipe masks the exit code, so the job exits 0 without creating routes
- Since `oc` is already downloaded and extracted by the same script (line 96-99), switching to `oc apply` avoids the schema validation issue

This has been causing **all bonfire-tekton CI runs to fail** at the `build-bindings` step with `routes.route.openshift.io "pulp-api" not found`. Without the manually-created routes, `CONTENT_ORIGIN` in `settings.py` also points to a host that no route serves.

## Evidence

S3 pod logs from `pulp-bonfire-tekton-xhm54` (`pulp-create-settings-and-ingress-y6ghqxz`) show:
```
+ kubectl apply -f-<<EOF
error: SchemaError(github.com/stolostron/cluster-lifecycle-api/clusterview/v1alpha1.UserPermission.status): unknown model in reference
```

The `oc_get_all.yaml` artifact confirms only Clowder-generated routes exist (`pulp-api-sl6jm` with random suffix), not the expected `pulp-api` exact-name route.

## Test plan

- [ ] Merge and verify next bonfire-tekton run passes the `build-bindings` step
- [ ] Confirm `pulp-api` and `pulp-content` routes exist in ephemeral namespace after deploy

## Summary by Sourcery

Bug Fixes:
- Switch route creation in the ephemeral settings-and-ingress job from kubectl apply to oc apply to prevent client-side schema validation errors that were skipping route creation.