### PR TITLE
feat(agent-alertmanager): add diagnostic tool credentials to Alcove workflow

### DIFF
--- a/.alcove/agents/alertmanager-analyzer.yml
+++ b/.alcove/agents/alertmanager-analyzer.yml
@@ -1,11 +1,14 @@
 name: AlertManager Analyzer
 description: |
-  Analyzes Prometheus Alertmanager alerts for Pulp services and drafts Jira issues.
-  Runs as a pre-compiled agent binary from GitHub Releases.
+  Analyzes Prometheus Alertmanager alerts for Pulp services, gathers diagnostic
+  context from K8s, Prometheus, GlitchTip, and CloudWatch, and creates/updates
+  Jira issues. Runs as a pre-compiled agent binary from GitHub Releases.
 
 executable:
   url: https://github.com/pulp/pulp-service/releases/download/agent-alertmanager-20260604-fc65a31/agent-alertmanager
   args: ["--model", "claude-sonnet-4-6"]
+  env:
+    JIRA_URL: "https://redhat.atlassian.net/"
 
 timeout: 1800
 enforcement_mode: monitor
@@ -15,7 +18,10 @@ direct_outbound: true
 credentials:
   ALERTMANAGER_CLUSTERS: ALERTMANAGER_CLUSTERS
   ANTHROPIC_VERTEX_PROJECT_ID: ANTHROPIC_VERTEX_PROJECT_ID
-  JIRA_TOKEN: jira
+  JIRA_API_TOKEN: Jira-pulp-sre-agent
+  GLITCHTIP_TOKEN: glitchtip-decko-sa-token
+  AWS_ACCESS_KEY_ID: aws-access-key-id-log-readonly
+  AWS_SECRET_ACCESS_KEY: aws-secret-access-key-log-readonly
   VERTEX_SA_JSON: google-vertex
 
 schedule:


### PR DESCRIPTION
## Summary

Wire credentials for the 4 new diagnostic data sources into the Alcove workflow so agent-alertmanager can query K8s, Prometheus, GlitchTip, and CloudWatch when running on schedule.

## Changes

- **JIRA_URL** (hardcoded env var) + **JIRA_API_TOKEN** (from `jira` secret) — replaces `JIRA_TOKEN` (MCP server no longer used, native REST client instead)
- **GLITCHTIP_TOKEN** from `glitchtip` secret — GlitchTip error tracking
- **AWS_ACCESS_KEY_ID** + **AWS_SECRET_ACCESS_KEY** from `aws` secret — CloudWatch Log Insights
- Updated description to reflect diagnostic capabilities
- **ALERTMANAGER_CLUSTERS** secret needs to be updated separately with `api_server_url`, `prometheus_url`, `namespace` per cluster entry

Release URL intentionally unchanged — will be updated after validating credential injection works on Alcove.

## Jira

Closes: PULP-1797

---
Labels: ai-assisted
Assisted-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

## Summary by Sourcery

Configure the AlertManager Analyzer Alcove agent to use new diagnostic data source credentials and updated Jira integration for automated alert analysis.

New Features:
- Enable the AlertManager Analyzer agent to access Jira via JIRA_URL and JIRA_API_TOKEN environment configuration.
- Provide the agent with GlitchTip access through a dedicated GLITCHTIP_TOKEN credential for error diagnostics.
- Allow the agent to query AWS CloudWatch using AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY credentials for log insights.

Enhancements:
- Update the AlertManager Analyzer agent description to reflect its expanded diagnostic capabilities across K8s, Prometheus, GlitchTip, and CloudWatch.