### PR TITLE
fix: auto-subdivide CloudWatch chunks that exceed 10k record limit

### DIFF
--- a/management_tools/pulp-access-logs-exporter/src/pulp_access_logs_exporter/cloudwatch.py
+++ b/management_tools/pulp-access-logs-exporter/src/pulp_access_logs_exporter/cloudwatch.py
@@ -8,7 +8,9 @@ import pyarrow as pa
 from pulp_access_logs_exporter.writer import SCHEMA
 
 
-def build_query(filter_paths: str = "/api/pypi/", exclude_paths: str = "/livez,/status") -> str:
+def build_query(
+    filter_paths: str = "/api/pypi/", exclude_paths: str = "/livez,/status"
+) -> str:
     """
     Build CloudWatch Logs Insights query with parsing and filtering.
 
@@ -24,16 +26,16 @@ def build_query(filter_paths: str = "/api/pypi/", exclude_paths: str = "/livez,/
     """
     # Build filter for include paths (currently only supports single path)
     # Escape forward slashes for CloudWatch Logs Insights regex
-    filter_pattern = filter_paths.replace('/', '\\/')
+    filter_pattern = filter_paths.replace("/", "\\/")
 
     # Build exclude filters
     exclude_filters = []
     if exclude_paths:
-        for path in exclude_paths.split(','):
+        for path in exclude_paths.split(","):
             path = path.strip()
             if path:
                 # Escape forward slashes
-                escaped_path = path.replace('/', '\\/')
+                escaped_path = path.replace("/", "\\/")
                 exclude_filters.append(f"| filter @message not like /{escaped_path}/")
 
     # Always exclude django warnings
@@ -45,20 +47,122 @@ def build_query(filter_paths: str = "/api/pypi/", exclude_paths: str = "/livez,/
         f"| filter @message like /{filter_pattern}/",
     ]
     query_parts.extend(exclude_filters)
-    query_parts.extend([
-        "| parse @message \"user:* org_id\" as parsed_user",
-        "| parse @message \"org_id:* \" as parsed_org_id",
-        "| parse @message '/api/pypi/*/*/simple/' as parsed_domain, parsed_distribution",
-        "| parse @message '/simple/*/ ' as parsed_package",
-        "| filter ispresent(parsed_package)",
-        "| parse message ' HTTP/1.1\" * ' as parsed_status_code",
-        "| parse message '\"-\" \"*\" ' as parsed_user_agent",
-        "| parse message ' x_forwarded_for:\"*\"' as xff",
-        "| parse xff '*,*' as client_ip, xff_rest",
-        "| fields @timestamp, @message, parsed_user as user, parsed_org_id as org_id, parsed_domain as domain, parsed_distribution as distribution, parsed_package as package, parsed_status_code as status_code, parsed_user_agent as user_agent, coalesce(client_ip, xff) as x_forwarded_for",
-    ])
+    query_parts.extend(
+        [
+            '| parse @message "user:* org_id" as parsed_user',
+            '| parse @message "org_id:* " as parsed_org_id',
+            "| parse @message '/api/pypi/*/*/simple/' as parsed_domain, parsed_distribution",
+            "| parse @message '/simple/*/ ' as parsed_package",
+            "| filter ispresent(parsed_package)",
+            "| parse message ' HTTP/1.1\" * ' as parsed_status_code",
+            '| parse message \'"-" "*" \' as parsed_user_agent',
+            "| parse message ' x_forwarded_for:\"*\"' as xff",
+            "| parse xff '*,*' as client_ip, xff_rest",
+            "| fields @timestamp, @message, parsed_user as user, parsed_org_id as org_id, parsed_domain as domain, parsed_distribution as distribution, parsed_package as package, parsed_status_code as status_code, parsed_user_agent as user_agent, coalesce(client_ip, xff) as x_forwarded_for",
+        ]
+    )
 
     return "\n    ".join(query_parts)
+
+
+CLOUDWATCH_RESULT_LIMIT = 10000
+MAX_SUBDIVISION_DEPTH = 5
+
+
+def _execute_query(
+    logs_client, log_group: str, query: str, start_epoch: int, end_epoch: int
+) -> dict:
+    """Start a CloudWatch Logs Insights query and poll until complete."""
+    response = logs_client.start_query(
+        logGroupNames=[log_group],
+        startTime=start_epoch,
+        endTime=end_epoch,
+        queryString=query,
+        limit=CLOUDWATCH_RESULT_LIMIT,
+    )
+
+    query_id = response["queryId"]
+    max_wait_seconds = 300
+    poll_interval = 2
+    max_poll_interval = 30
+    start_poll_time = time.time()
+
+    while True:
+        if time.time() - start_poll_time > max_wait_seconds:
+            raise TimeoutError(
+                f"Timed out after {max_wait_seconds} seconds waiting for query {query_id} to complete"
+            )
+
+        result = logs_client.get_query_results(queryId=query_id)
+        status = result["status"]
+
+        if status == "Complete":
+            return result
+        elif status in ["Failed", "Cancelled"]:
+            raise RuntimeError(f"Query {query_id} failed with status: {status}")
+
+        time.sleep(poll_interval)
+        poll_interval = min(poll_interval * 2, max_poll_interval)
+
+
+def _fetch_chunk(
+    logs_client,
+    log_group: str,
+    query: str,
+    chunk_start: datetime,
+    chunk_end: datetime,
+    depth: int = 0,
+) -> List[Dict[str, Any]]:
+    """
+    Fetch a single time-window chunk, subdividing on truncation.
+
+    When a chunk returns exactly CLOUDWATCH_RESULT_LIMIT records, it is
+    likely truncated. The chunk is bisected and each half is queried
+    separately. Recursion stops at MAX_SUBDIVISION_DEPTH.
+    """
+    print(
+        f"{'  ' * depth}Querying logs from {chunk_start.isoformat()} to {chunk_end.isoformat()}..."
+    )
+
+    result = _execute_query(
+        logs_client,
+        log_group,
+        query,
+        int(chunk_start.timestamp()),
+        int(chunk_end.timestamp()),
+    )
+
+    chunk_results = result["results"]
+    print(f"{'  ' * depth}  Retrieved {len(chunk_results)} records")
+
+    if len(chunk_results) >= CLOUDWATCH_RESULT_LIMIT:
+        if depth >= MAX_SUBDIVISION_DEPTH:
+            stats = result.get("statistics", {})
+            records_matched = stats.get("recordsMatched", 0)
+            print(
+                f"{'  ' * depth}  WARNING: Truncated at max subdivision depth {depth} "
+                f"({chunk_start.isoformat()} to {chunk_end.isoformat()}, "
+                f"matched: {records_matched}). Some records may be lost."
+            )
+        else:
+            midpoint = chunk_start + (chunk_end - chunk_start) / 2
+            print(
+                f"{'  ' * depth}  Truncated at {CLOUDWATCH_RESULT_LIMIT} records, "
+                f"subdividing at {midpoint.isoformat()}..."
+            )
+            first_half = _fetch_chunk(
+                logs_client, log_group, query, chunk_start, midpoint, depth + 1
+            )
+            second_half = _fetch_chunk(
+                logs_client, log_group, query, midpoint, chunk_end, depth + 1
+            )
+            return first_half + second_half
+
+    records = []
+    for record in chunk_results:
+        parsed = {item["field"]: item["value"] for item in record}
+        records.append(parsed)
+    return records
 
 
 def fetch_cloudwatch_logs(
@@ -75,6 +179,10 @@ def fetch_cloudwatch_logs(
     logs.get_query_results() until Complete. Handles time-based chunking
     for queries that may return >10K results.
 
+    When a 5-minute chunk returns the maximum 10K records, it is
+    automatically bisected into smaller windows until no truncation
+    occurs (up to MAX_SUBDIVISION_DEPTH levels).
+
     Args:
         log_group: CloudWatch log group name
         query: CloudWatch Logs Insights query string
@@ -85,9 +193,8 @@ def fetch_cloudwatch_logs(
     Returns:
         List of structured records (already parsed by Logs Insights)
     """
-    logs_client = boto3.client('logs', region_name=region)
+    logs_client = boto3.client("logs", region_name=region)
 
-    # Split time range into 5-minute chunks to handle >10K results
     chunk_duration = timedelta(minutes=5)
     start_dt = datetime.fromtimestamp(start_time)
     end_dt = datetime.fromtimestamp(end_time)
@@ -97,60 +204,8 @@ def fetch_cloudwatch_logs(
 
     while current < end_dt:
         chunk_end = min(current + chunk_duration, end_dt)
-
-        print(f"Querying logs from {current.isoformat()} to {chunk_end.isoformat()}...")
-
-        # Start async query
-        response = logs_client.start_query(
-            logGroupNames=[log_group],
-            startTime=int(current.timestamp()),
-            endTime=int(chunk_end.timestamp()),
-            queryString=query,
-            limit=10000,  # CloudWatch max limit
-        )
-
-        query_id = response['queryId']
-
-        # Poll until complete with timeout and exponential backoff
-        max_wait_seconds = 300  # Maximum total wait time (5 minutes)
-        poll_interval = 2       # Initial poll interval in seconds
-        max_poll_interval = 30  # Maximum poll interval in seconds
-        start_poll_time = time.time()
-
-        while True:
-            if time.time() - start_poll_time > max_wait_seconds:
-                raise TimeoutError(
-                    f"Timed out after {max_wait_seconds} seconds waiting for query {query_id} to complete"
-                )
-
-            result = logs_client.get_query_results(queryId=query_id)
-            status = result['status']
-
-            if status == 'Complete':
-                break
-            elif status in ['Failed', 'Cancelled']:
-                raise RuntimeError(f"Query {query_id} failed with status: {status}")
-
-            time.sleep(poll_interval)
-            poll_interval = min(poll_interval * 2, max_poll_interval)
-
-        # Process results
-        chunk_results = result['results']
-        print(f"  Retrieved {len(chunk_results)} records")
-
-        # Check if results were truncated
-        stats = result.get('statistics', {})
-        records_matched = stats.get('recordsMatched', 0)
-        records_scanned = stats.get('recordsScanned', 0)
-
-        if len(chunk_results) >= 10000:
-            print(f"  WARNING: Result set may be truncated (matched: {records_matched}, scanned: {records_scanned})")
-
-        # Convert from CloudWatch format to dict
-        for record in chunk_results:
-            parsed = {item['field']: item['value'] for item in record}
-            all_results.append(parsed)
-
+        chunk_records = _fetch_chunk(logs_client, log_group, query, current, chunk_end)
+        all_results.extend(chunk_records)
         current = chunk_end
 
     print(f"Total records retrieved: {len(all_results)}")
@@ -178,33 +233,35 @@ def convert_to_arrow_table(results: List[Dict[str, Any]]) -> pa.Table:
     records = []
     for result in results:
         # Convert "-" to None for proper null handling
-        user = result.get('user')
-        if user == '-':
+        user = result.get("user")
+        if user == "-":
             user = None
 
-        org_id = result.get('org_id')
-        if org_id == '-':
+        org_id = result.get("org_id")
+        if org_id == "-":
             org_id = None
 
         # Parse timestamp from ISO format as timezone-naive UTC
         # PyArrow schema uses pa.timestamp('ns') which is timezone-naive
-        timestamp_str = result.get('@timestamp', '')
-        timestamp = datetime.fromisoformat(timestamp_str.replace('Z', '+00:00')).replace(tzinfo=None)
+        timestamp_str = result.get("@timestamp", "")
+        timestamp = datetime.fromisoformat(
+            timestamp_str.replace("Z", "+00:00")
+        ).replace(tzinfo=None)
 
         # Convert status_code to int
-        status_code = int(result.get('status_code', 0))
+        status_code = int(result.get("status_code", 0))
 
         record = {
-            'timestamp': timestamp,
-            'message': result.get('@message', ''),
-            'user': user,
-            'org_id': org_id,
-            'domain': result.get('domain', ''),
-            'distribution': result.get('distribution', ''),
-            'package': result.get('package', ''),
-            'status_code': status_code,
-            'user_agent': result.get('user_agent', ''),
-            'x_forwarded_for': result.get('x_forwarded_for', ''),
+            "timestamp": timestamp,
+            "message": result.get("@message", ""),
+            "user": user,
+            "org_id": org_id,
+            "domain": result.get("domain", ""),
+            "distribution": result.get("distribution", ""),
+            "package": result.get("package", ""),
+            "status_code": status_code,
+            "user_agent": result.get("user_agent", ""),
+            "x_forwarded_for": result.get("x_forwarded_for", ""),
         }
         records.append(record)
 

--- a/management_tools/pulp-access-logs-exporter/tests/test_cloudwatch_truncation.py
+++ b/management_tools/pulp-access-logs-exporter/tests/test_cloudwatch_truncation.py
@@ -1,0 +1,165 @@
+"""Tests for CloudWatch query truncation handling and automatic subdivision."""
+
+from datetime import datetime
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from pulp_access_logs_exporter.cloudwatch import (
+    CLOUDWATCH_RESULT_LIMIT,
+    MAX_SUBDIVISION_DEPTH,
+    _fetch_chunk,
+    fetch_cloudwatch_logs,
+)
+
+
+def _make_cloudwatch_record(index):
+    """Build a single CloudWatch Logs Insights result row."""
+    return [
+        {"field": "@timestamp", "value": f"2026-06-01T00:00:{index:02d}.000Z"},
+        {"field": "@message", "value": f"log line {index}"},
+    ]
+
+
+def _make_query_result(count, records_matched=None):
+    """Build a get_query_results response with `count` records."""
+    return {
+        "status": "Complete",
+        "results": [_make_cloudwatch_record(idx % 60) for idx in range(count)],
+        "statistics": {
+            "recordsMatched": records_matched or count,
+            "recordsScanned": count * 2,
+        },
+    }
+
+
+@pytest.fixture
+def mock_logs_client():
+    client = MagicMock()
+    client.start_query.return_value = {"queryId": "test-query-id"}
+    return client
+
+
+@pytest.mark.unit
+class TestFetchChunkSubdivision:
+    def test_no_subdivision_when_under_limit(self, mock_logs_client):
+        mock_logs_client.get_query_results.return_value = _make_query_result(500)
+        start = datetime(2026, 6, 1, 0, 0, 0)
+        end = datetime(2026, 6, 1, 0, 5, 0)
+
+        results = _fetch_chunk(mock_logs_client, "/log-group", "query", start, end)
+
+        assert len(results) == 500
+        assert mock_logs_client.start_query.call_count == 1
+
+    def test_subdivides_on_truncation(self, mock_logs_client):
+        truncated = _make_query_result(CLOUDWATCH_RESULT_LIMIT, records_matched=11882)
+        not_truncated = _make_query_result(6000)
+
+        mock_logs_client.get_query_results.side_effect = [
+            truncated,
+            not_truncated,
+            not_truncated,
+        ]
+
+        start = datetime(2026, 6, 1, 0, 0, 0)
+        end = datetime(2026, 6, 1, 0, 5, 0)
+
+        results = _fetch_chunk(mock_logs_client, "/log-group", "query", start, end)
+
+        assert len(results) == 12000
+        assert mock_logs_client.start_query.call_count == 3
+
+    def test_recursive_subdivision(self, mock_logs_client):
+        truncated = _make_query_result(CLOUDWATCH_RESULT_LIMIT)
+        ok_result = _make_query_result(3000)
+
+        mock_logs_client.get_query_results.side_effect = [
+            truncated,
+            truncated,
+            ok_result,
+            ok_result,
+            ok_result,
+        ]
+
+        start = datetime(2026, 6, 1, 0, 0, 0)
+        end = datetime(2026, 6, 1, 0, 5, 0)
+
+        results = _fetch_chunk(mock_logs_client, "/log-group", "query", start, end)
+
+        assert len(results) == 3000 * 3
+        assert mock_logs_client.start_query.call_count == 5
+
+    def test_stops_at_max_depth(self, mock_logs_client):
+        truncated = _make_query_result(CLOUDWATCH_RESULT_LIMIT, records_matched=15000)
+        mock_logs_client.get_query_results.return_value = truncated
+
+        start = datetime(2026, 6, 1, 0, 0, 0)
+        end = datetime(2026, 6, 1, 0, 5, 0)
+
+        results = _fetch_chunk(
+            mock_logs_client,
+            "/log-group",
+            "query",
+            start,
+            end,
+            depth=MAX_SUBDIVISION_DEPTH,
+        )
+
+        assert len(results) == CLOUDWATCH_RESULT_LIMIT
+        assert mock_logs_client.start_query.call_count == 1
+
+    def test_midpoint_splits_time_evenly(self, mock_logs_client):
+        truncated = _make_query_result(CLOUDWATCH_RESULT_LIMIT)
+        ok_result = _make_query_result(5000)
+
+        mock_logs_client.get_query_results.side_effect = [
+            truncated,
+            ok_result,
+            ok_result,
+        ]
+
+        start = datetime(2026, 6, 1, 0, 0, 0)
+        end = datetime(2026, 6, 1, 0, 10, 0)
+
+        _fetch_chunk(mock_logs_client, "/log-group", "query", start, end)
+
+        calls = mock_logs_client.start_query.call_args_list
+        first_half_end = calls[1][1]["endTime"]
+        second_half_start = calls[2][1]["startTime"]
+        assert first_half_end == second_half_start
+
+        midpoint = start + (end - start) / 2
+        assert first_half_end == int(midpoint.timestamp())
+
+
+@pytest.mark.unit
+class TestFetchCloudwatchLogsIntegration:
+    @patch("pulp_access_logs_exporter.cloudwatch.boto3")
+    def test_multiple_chunks_with_subdivision(self, mock_boto3):
+        mock_client = MagicMock()
+        mock_boto3.client.return_value = mock_client
+        mock_client.start_query.return_value = {"queryId": "q1"}
+
+        truncated = _make_query_result(CLOUDWATCH_RESULT_LIMIT)
+        ok_small = _make_query_result(100)
+
+        mock_client.get_query_results.side_effect = [
+            ok_small,
+            truncated,
+            ok_small,
+            ok_small,
+        ]
+
+        start = datetime(2026, 6, 1, 0, 0, 0)
+        end = datetime(2026, 6, 1, 0, 10, 0)
+
+        results = fetch_cloudwatch_logs(
+            log_group="/log-group",
+            query="fields @timestamp",
+            start_time=int(start.timestamp()),
+            end_time=int(end.timestamp()),
+        )
+
+        assert len(results) == 100 + 100 + 100
+        assert mock_client.start_query.call_count == 4


### PR DESCRIPTION
## Summary

When a 5-minute CloudWatch Logs Insights query chunk returns exactly 10,000 records (the API maximum), the exporter now automatically bisects the time window and retries each half. This prevents silent data loss during high-traffic periods.

## Changes

- Extracted `_execute_query()` helper for the start-query/poll loop
- Added `_fetch_chunk()` with recursive bisection on truncation detection
- Depth limit of 5 prevents infinite loops (~9s minimum window)
- `fetch_cloudwatch_logs()` signature unchanged — callers unaffected
- 6 new unit tests covering subdivision, recursion, depth limit, and midpoint math

## Testing

- 45/45 tests pass (6 new + 39 existing)
- Validated against prod CloudWatch data: 4 truncation events in a 3-hour window, all resolved
- ~18k records recovered that would have been silently dropped
- Two-level subdivision observed and working correctly

## Jira

Closes: PULP-1887

---
Assisted-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

## Summary by Sourcery

Handle CloudWatch Logs Insights result truncation by subdividing large time windows while preserving the existing public API.

Bug Fixes:
- Prevent silent data loss when a 5-minute CloudWatch Logs Insights chunk hits the 10K record limit by automatically subdividing the time window and re-querying.

Enhancements:
- Extract a reusable helper for executing and polling CloudWatch Logs Insights queries.
- Introduce a recursive chunk-fetching helper that bisects time ranges on truncation with a configurable maximum subdivision depth.
- Refine CloudWatch log query construction and result conversion code style for consistency.

Tests:
- Add unit tests covering chunk subdivision behavior, recursive truncation handling, maximum subdivision depth, midpoint calculation, and multi-chunk integration with the public fetch function.