### PR TITLE
fix(exporter): separate distribution from repo file structure

### DIFF
--- a/management_tools/pulp-access-logs-exporter/src/pulp_access_logs_exporter/content_parser.py
+++ b/management_tools/pulp-access-logs-exporter/src/pulp_access_logs_exporter/content_parser.py
@@ -29,6 +29,8 @@ CONTENT_TYPE_EXTENSIONS = {
 
 CONTENT_PATH_PREFIX = "/api/pulp-content/"
 
+RPM_PACKAGES_DIR_RE = re.compile(r"^[a-zA-Z0-9]$")
+
 
 def parse_content_log_line(message):
     match = CONTENT_LOG_REGEX.search(message)
@@ -37,16 +39,31 @@ def parse_content_log_line(message):
     return match.groupdict()
 
 
+def _strip_repo_structure(segments):
+    if (
+        len(segments) >= 2
+        and segments[-2] == "Packages"
+        and RPM_PACKAGES_DIR_RE.match(segments[-1])
+    ):
+        return segments[:-2]
+    if segments and segments[-1] == "repodata":
+        return segments[:-1]
+    return segments
+
+
 def parse_content_path(path):
     if not path.startswith(CONTENT_PATH_PREFIX):
         return None
-    remainder = path[len(CONTENT_PATH_PREFIX):]
+    remainder = path[len(CONTENT_PATH_PREFIX) :]
     segments = remainder.split("/")
     if len(segments) < 2:
         return None
     domain = segments[0]
     filename = segments[-1]
-    distribution = "/".join(segments[1:-1])
+    dist_segments = _strip_repo_structure(segments[1:-1])
+    if not dist_segments:
+        return None
+    distribution = "/".join(dist_segments)
     return {
         "domain": domain,
         "distribution": distribution,
@@ -63,7 +80,7 @@ def matches_content_type(filename, content_type):
 def parse_wheel_filename(filename):
     base_filename = filename
     if filename.endswith(".whl.metadata"):
-        base_filename = filename[:-len(".metadata")]
+        base_filename = filename[: -len(".metadata")]
 
     match = WHEEL_REGEX.match(base_filename)
     if match is None:
@@ -84,11 +101,11 @@ def _parse_nevr(name):
     if name.count("-") < 2:
         raise ValueError("failed to parse nevr '%s' not a valid nevr" % name)
     release_dash_pos = name.rfind("-")
-    release = name[release_dash_pos + 1:]
+    release = name[release_dash_pos + 1 :]
     name_epoch_version = name[:release_dash_pos]
     name_dash_pos = name_epoch_version.rfind("-")
     package_name = name_epoch_version[:name_dash_pos]
-    epoch_version = name_epoch_version[name_dash_pos + 1:].split(":")
+    epoch_version = name_epoch_version[name_dash_pos + 1 :].split(":")
     if len(epoch_version) == 1:
         epoch = 0
         version = epoch_version[0]
@@ -105,14 +122,14 @@ def _parse_nevra(name):
     if name.count(".") < 1:
         raise ValueError("failed to parse nevra '%s' not a valid nevra" % name)
     arch_dot_pos = name.rfind(".")
-    arch = name[arch_dot_pos + 1:]
+    arch = name[arch_dot_pos + 1 :]
     return _parse_nevr(name[:arch_dot_pos]) + (arch,)
 
 
 def parse_rpm_filename(filename):
     if not filename.endswith(".rpm"):
         return None
-    nevra_string = filename[:-len(".rpm")]
+    nevra_string = filename[: -len(".rpm")]
     try:
         package_name, epoch, version, release, arch = _parse_nevra(nevra_string)
     except ValueError:

--- a/management_tools/pulp-access-logs-exporter/tests/test_content_export.py
+++ b/management_tools/pulp-access-logs-exporter/tests/test_content_export.py
@@ -24,7 +24,9 @@ class TestParseContentLogLine:
         assert result is not None
         assert result["src_ip"] == "10.128.4.123"
         assert result["method"] == "GET"
-        assert result["path"] == "/api/pulp-content/default/dist/pkg-1.0-py3-none-any.whl"
+        assert (
+            result["path"] == "/api/pulp-content/default/dist/pkg-1.0-py3-none-any.whl"
+        )
         assert result["status"] == "200"
         assert result["user_agent"] == "pip/24.0"
         assert result["cache"] == "HIT"
@@ -139,7 +141,9 @@ class TestContentTypeFiltering:
         assert matches_content_type("pkg-1.0-py3-none-any.whl", "python") is True
 
     def test_python_metadata_matches(self):
-        assert matches_content_type("pkg-1.0-py3-none-any.whl.metadata", "python") is True
+        assert (
+            matches_content_type("pkg-1.0-py3-none-any.whl.metadata", "python") is True
+        )
 
     def test_rpm_matches(self):
         assert matches_content_type("bash-5.2-1.fc43.x86_64.rpm", "rpm") is True
@@ -165,14 +169,35 @@ class TestParseContentPath:
         assert result["distribution"] == "rhoai/3.5-EA2/cpu-ubi9"
         assert result["filename"] == "requests-2.34.2-2-py3-none-any.whl"
 
-    def test_rpm_path(self):
+    def test_rpm_path_strips_packages_dir(self):
         result = parse_content_path(
             "/api/pulp-content/public-copr/packit/tmt/fedora-43-x86_64/Packages/b/bash-5.2.26-4.fc43.x86_64.rpm"
         )
         assert result is not None
         assert result["domain"] == "public-copr"
-        assert result["distribution"] == "packit/tmt/fedora-43-x86_64/Packages/b"
+        assert result["distribution"] == "packit/tmt/fedora-43-x86_64"
         assert result["filename"] == "bash-5.2.26-4.fc43.x86_64.rpm"
+
+    def test_rpm_path_strips_repodata(self):
+        result = parse_content_path(
+            "/api/pulp-content/public-copr/packit/tmt/fedora-43-x86_64/repodata/repomd.xml"
+        )
+        assert result is not None
+        assert result["distribution"] == "packit/tmt/fedora-43-x86_64"
+        assert result["filename"] == "repomd.xml"
+
+    def test_rpm_path_without_packages_dir(self):
+        result = parse_content_path(
+            "/api/pulp-content/ccac33ac/templates/kernel-core-6.8.0-300.fc40.x86_64.rpm"
+        )
+        assert result is not None
+        assert result["domain"] == "ccac33ac"
+        assert result["distribution"] == "templates"
+        assert result["filename"] == "kernel-core-6.8.0-300.fc40.x86_64.rpm"
+
+    def test_empty_distribution_after_stripping_returns_none(self):
+        result = parse_content_path("/api/pulp-content/domain/repodata/repomd.xml")
+        assert result is None
 
     def test_non_content_path_returns_none(self):
         result = parse_content_path("/api/pypi/default/dist/simple/pkg/")
@@ -184,7 +209,9 @@ class TestParseContentPath:
 
 
 class TestContentToParquetPython:
-    def test_converts_python_downloads(self, sample_content_cloudwatch_results, sample_content_parquet_path):
+    def test_converts_python_downloads(
+        self, sample_content_cloudwatch_results, sample_content_parquet_path
+    ):
         table = convert_content_to_arrow_table(
             sample_content_cloudwatch_results, "python"
         )
@@ -202,13 +229,16 @@ class TestContentToParquetPython:
         assert rows["cache_hit"][0] is True
         assert rows["artifact_size"][0] == 19456789
         assert rows["org_id"][0] == "123456"
+        assert rows["distribution"][0] == "rhoai/3.5-EA2/cpu-ubi9"
 
         assert rows["package_name"][1] == "numpy"
         assert rows["package_version"][1] == "1.26.4"
         assert rows["cache_hit"][1] is False
+        assert rows["distribution"][1] == "rhoai/3.5-EA2/cpu-ubi9"
 
-
-    def test_skips_invalid_and_non_matching_records(self, sample_content_cloudwatch_results):
+    def test_skips_invalid_and_non_matching_records(
+        self, sample_content_cloudwatch_results
+    ):
         extra_records = [
             {"message": "not a valid log line"},
             {
@@ -244,10 +274,10 @@ class TestContentToParquetPython:
 
 
 class TestContentToParquetRpm:
-    def test_converts_rpm_downloads(self, sample_content_cloudwatch_results, sample_content_parquet_path):
-        table = convert_content_to_arrow_table(
-            sample_content_cloudwatch_results, "rpm"
-        )
+    def test_converts_rpm_downloads(
+        self, sample_content_cloudwatch_results, sample_content_parquet_path
+    ):
+        table = convert_content_to_arrow_table(sample_content_cloudwatch_results, "rpm")
         assert table.num_rows == 2
         assert table.schema == RPM_SCHEMA
 
@@ -263,11 +293,13 @@ class TestContentToParquetRpm:
         assert rows["epoch"][0] == 0
         assert rows["org_id"][0] is None
         assert rows["cache_hit"][0] is False
+        assert rows["distribution"][0] == "packit/teemtee-tmt-4901/fedora-43-x86_64"
 
         assert rows["package_name"][1] == "kernel-core"
         assert rows["package_version"][1] == "6.8.0"
         assert rows["cache_hit"][1] is True
         assert rows["org_id"][1] == "555666"
+        assert rows["distribution"][1] == "templates"
 
 
 class TestEmptyContentResults:

--- a/management_tools/pulp-access-logs-exporter/tests/test_content_export.py
+++ b/management_tools/pulp-access-logs-exporter/tests/test_content_export.py
@@ -250,6 +250,16 @@ class TestContentToParquetPython:
         table = convert_content_to_arrow_table(mixed_results, "python")
         assert table.num_rows == 2
 
+    def test_skips_empty_distribution_after_stripping(self):
+        results = [
+            {
+                "@timestamp": "2026-06-09 14:30:00.000",
+                "message": '10.0.0.1 [09/Jun/2026:14:30:00 +0000] "GET /api/pulp-content/domain/repodata/repomd.xml HTTP/1.1" 200 3456 "-" "dnf/4.18.0" cache:"HIT" artifact_size:"3456" rh_org_id:"-" x_forwarded_for:"1.2.3.4"',
+            },
+        ]
+        table = convert_content_to_arrow_table(results, "rpm")
+        assert table.num_rows == 0
+
     def test_skips_malformed_filename_and_warns(self, capsys):
         results = [
             {


### PR DESCRIPTION
## Summary
- `parse_content_path()` was including RPM repo-internal paths (`Packages/<letter>/`, `repodata/`) in the distribution name
- Added `_strip_repo_structure()` to detect and strip these suffixes before building the distribution string
- Returns `None` when stripping leaves an empty distribution (defensive against malformed paths)
- Added end-to-end distribution assertions to integration tests

**Example (from PULP-1889):**
- Path: `/api/pulp-content/public-copr/pbrezina/s4u/fedora-44-x86_64/Packages/p/python3-libipa_hbac-2.14.0-1.fc44.x86_64.rpm`
- Before: distribution = `pbrezina/s4u/fedora-44-x86_64/Packages/p`
- After: distribution = `pbrezina/s4u/fedora-44-x86_64`

Closes PULP-1889

## Test plan
- [x] All 37 tests pass
- [x] RPM `Packages/<letter>/` stripping verified
- [x] RPM `repodata/` stripping verified
- [x] RPM paths without repo structure unchanged
- [x] Empty distribution after stripping returns `None`
- [x] Integration tests assert distribution field end-to-end (Python + RPM)
- [x] Ruff format clean

Assisted-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

## Summary by Sourcery

Adjust content path parsing to exclude RPM repository-internal directories from distributions and strengthen tests around parsed distribution values.

Bug Fixes:
- Stop including RPM repo-internal paths like Packages/<letter> and repodata in the parsed distribution field.
- Return None when stripping repository structure would result in an empty distribution, avoiding malformed parsed records.

Enhancements:
- Refine content path parsing helpers to separate repository structure from logical distribution segments.
- Improve code style and slicing semantics in content parsing utilities for better readability.

Tests:
- Extend unit and integration tests to cover RPM Packages directory stripping, repodata stripping, unchanged RPM paths without repo structure, empty distributions, and distribution propagation into parquet output for both Python and RPM.