### PR TITLE
feat(exporter): add Maven content type support for download logs

### DIFF
--- a/management_tools/pulp-access-logs-exporter/README.md
+++ b/management_tools/pulp-access-logs-exporter/README.md
@@ -131,6 +131,24 @@ Key features:
 - **PyArrow native**: No pandas dependency for core export (only for test validation)
 - **Efficient storage**: Snappy compression, columnar format
 
+## Adding a New Content Type
+
+Content type registrations are currently spread across multiple modules:
+
+| What | Module |
+|------|--------|
+| File extensions | `CONTENT_TYPE_EXTENSIONS` in `content_parser.py` |
+| Parquet schema | `SCHEMAS` in `content_schemas.py` |
+| Filename parser | `FILENAME_PARSERS` in `content_cloudwatch.py` |
+| Distribution parser | `DISTRIBUTION_PARSERS` in `content_cloudwatch.py` |
+| CLI choices | Derived from `CONTENT_TYPE_EXTENSIONS` in `cli.py` |
+
+When adding a new content type, all applicable registries must be updated. A missing
+entry in `SCHEMAS` or both parser dicts will raise a `ValueError` at runtime.
+
+Consider centralizing these into a single content type registry if the number of
+content types grows beyond the current three (Python, RPM, Maven).
+
 ## License
 
 See repository root for license information.

--- a/management_tools/pulp-access-logs-exporter/src/pulp_access_logs_exporter/cli.py
+++ b/management_tools/pulp-access-logs-exporter/src/pulp_access_logs_exporter/cli.py
@@ -6,6 +6,8 @@ import re
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
+from pulp_access_logs_exporter.content_parser import CONTENT_TYPE_EXTENSIONS
+
 
 def parse_args(args=None):
     """Parse command-line arguments."""
@@ -219,7 +221,7 @@ def parse_content_args(args=None):
     parser.add_argument("--start-time", required=True, help='Start timestamp - ISO format or relative ("1 hour ago")')
     parser.add_argument("--end-time", required=True, help='End timestamp - ISO format or relative ("now")')
     parser.add_argument("--output-path", required=True, help="Local file path or S3 URI (s3://bucket/key)")
-    parser.add_argument("--content-type", required=True, choices=["python", "rpm"], help="Content type to export")
+    parser.add_argument("--content-type", required=True, choices=sorted(CONTENT_TYPE_EXTENSIONS), help="Content type to export")
     parser.add_argument("--aws-region", default="us-east-1", help="AWS region (default: us-east-1)")
     parser.add_argument("--s3-access-key-id", help="AWS access key ID for S3")
     parser.add_argument("--s3-secret-access-key", help="AWS secret access key for S3")

--- a/management_tools/pulp-access-logs-exporter/src/pulp_access_logs_exporter/content_cloudwatch.py
+++ b/management_tools/pulp-access-logs-exporter/src/pulp_access_logs_exporter/content_cloudwatch.py
@@ -8,6 +8,7 @@ from pulp_access_logs_exporter.content_parser import (
     matches_content_type,
     parse_content_log_line,
     parse_content_path,
+    parse_maven_distribution,
     parse_rpm_filename,
     parse_wheel_filename,
 )
@@ -71,10 +72,15 @@ FILENAME_PARSERS = {
     "rpm": parse_rpm_filename,
 }
 
+DISTRIBUTION_PARSERS = {
+    "maven": parse_maven_distribution,
+}
+
 
 def convert_content_to_arrow_table(results, content_type):
     schema = SCHEMAS[content_type]
-    filename_parser = FILENAME_PARSERS[content_type]
+    filename_parser = FILENAME_PARSERS.get(content_type)
+    distribution_parser = DISTRIBUTION_PARSERS.get(content_type)
     records = []
     skipped_log_parse = 0
     skipped_path_parse = 0
@@ -101,7 +107,10 @@ def convert_content_to_arrow_table(results, content_type):
             skipped_extension += 1
             continue
 
-        parsed_filename = filename_parser(filename)
+        if distribution_parser:
+            parsed_filename = distribution_parser(parsed_path["distribution"], filename)
+        else:
+            parsed_filename = filename_parser(filename)
         if parsed_filename is None:
             print(
                 f"WARNING: Skipping malformed filename: {filename}",
@@ -115,10 +124,14 @@ def convert_content_to_arrow_table(results, content_type):
             skipped_timestamp += 1
             continue
 
+        # Maven's distribution_parser returns its own "distribution" (repo name only),
+        # overriding the full coordinate path from parse_content_path.
+        distribution = parsed_filename.pop("distribution", parsed_path["distribution"])
+
         record = {
             "timestamp": timestamp,
             "domain": parsed_path["domain"],
-            "distribution": parsed_path["distribution"],
+            "distribution": distribution,
             "artifact_path": parsed_path["artifact_path"],
             "artifact_size": _parse_artifact_size(parsed_line["artifact_size"]),
             "status_code": int(parsed_line["status"]),

--- a/management_tools/pulp-access-logs-exporter/src/pulp_access_logs_exporter/content_cloudwatch.py
+++ b/management_tools/pulp-access-logs-exporter/src/pulp_access_logs_exporter/content_cloudwatch.py
@@ -88,6 +88,9 @@ def convert_content_to_arrow_table(results, content_type):
     skipped_filename = 0
     skipped_timestamp = 0
 
+    if not filename_parser and not distribution_parser:
+        raise ValueError(f"No parser registered for content type: {content_type!r}")
+
     for result in results:
         message = result.get("message", result.get("@message", ""))
         timestamp_str = result.get("@timestamp", "")

--- a/management_tools/pulp-access-logs-exporter/src/pulp_access_logs_exporter/content_parser.py
+++ b/management_tools/pulp-access-logs-exporter/src/pulp_access_logs_exporter/content_parser.py
@@ -23,6 +23,7 @@ WHEEL_REGEX = re.compile(
 )
 
 CONTENT_TYPE_EXTENSIONS = {
+    "maven": (".jar", ".pom"),
     "python": (".whl", ".whl.metadata"),
     "rpm": (".rpm",),
 }
@@ -140,4 +141,61 @@ def parse_rpm_filename(filename):
         "architecture": arch,
         "epoch": epoch,
         "release": release,
+    }
+
+
+def parse_maven_distribution(distribution, filename):
+    """Extract Maven coordinates from the distribution path and filename.
+
+    parse_content_path returns the full Maven coordinate path as distribution:
+    maven-releases/org/springframework/cloud/spring-cloud-config-server/4.3.0-redhat-1
+
+    This function splits that into the actual distribution (repo name), group_id,
+    artifact_id (package_name), version, and parses classifier/packaging from
+    the filename using the known artifact_id and version.
+
+    Reference: https://maven.apache.org/repository/layout.html
+    """
+    segments = distribution.split("/")
+    if len(segments) < 4:
+        return None
+
+    repo_name = segments[0]
+    group_segments = segments[1:-2]
+    artifact_id = segments[-2]
+    version = segments[-1]
+
+    if not group_segments:
+        return None
+
+    group_id = ".".join(group_segments)
+
+    prefix = f"{artifact_id}-{version}"
+    if not filename.startswith(prefix):
+        return None
+
+    rest = filename[len(prefix) :]
+    classifier = None
+    packaging = None
+
+    if rest.startswith("-"):
+        rest = rest[1:]
+        dot_pos = rest.find(".")
+        if dot_pos == -1:
+            return None
+        classifier = rest[:dot_pos]
+        packaging = rest[dot_pos + 1 :]
+    elif rest.startswith("."):
+        packaging = rest[1:]
+    else:
+        return None
+
+    return {
+        "distribution": repo_name,
+        "group_id": group_id,
+        "package_name": artifact_id,
+        "package_version": version,
+        "architecture": None,
+        "classifier": classifier,
+        "packaging": packaging,
     }

--- a/management_tools/pulp-access-logs-exporter/src/pulp_access_logs_exporter/content_parser.py
+++ b/management_tools/pulp-access-logs-exporter/src/pulp_access_logs_exporter/content_parser.py
@@ -180,7 +180,7 @@ def parse_maven_distribution(distribution, filename):
 
     if rest.startswith("-"):
         rest = rest[1:]
-        dot_pos = rest.find(".")
+        dot_pos = rest.rfind(".")
         if dot_pos == -1:
             return None
         classifier = rest[:dot_pos]

--- a/management_tools/pulp-access-logs-exporter/src/pulp_access_logs_exporter/content_schemas.py
+++ b/management_tools/pulp-access-logs-exporter/src/pulp_access_logs_exporter/content_schemas.py
@@ -33,7 +33,17 @@ RPM_SCHEMA = pa.schema(
     ]
 )
 
+MAVEN_SCHEMA = pa.schema(
+    COMMON_FIELDS
+    + [
+        ("group_id", pa.string()),
+        ("classifier", pa.string()),
+        ("packaging", pa.string()),
+    ]
+)
+
 SCHEMAS = {
+    "maven": MAVEN_SCHEMA,
     "python": PYTHON_SCHEMA,
     "rpm": RPM_SCHEMA,
 }

--- a/management_tools/pulp-access-logs-exporter/tests/conftest.py
+++ b/management_tools/pulp-access-logs-exporter/tests/conftest.py
@@ -68,6 +68,25 @@ def sample_content_cloudwatch_results():
 
 
 @pytest.fixture
+def sample_maven_cloudwatch_results():
+    """Sample CloudWatch results wrapping Maven content-app log lines."""
+    return [
+        {
+            "@timestamp": "2026-06-20 13:47:49.000",
+            "message": '10.131.32.14 [20/Jun/2026:13:47:49 +0000] "GET /api/pulp-content/balor-stage/maven-releases/org/springframework/cloud/spring-cloud-config-server/4.3.0-redhat-1/spring-cloud-config-server-4.3.0-redhat-1.jar HTTP/1.1" 302 727 "-" "curl/8.15.0" cache:"MISS" artifact_size:"18432000" rh_org_id:"5894300" x_forwarded_for:"66.187.232.140, 66.187.232.140, 23.220.105.201"',
+        },
+        {
+            "@timestamp": "2026-06-20 13:47:50.000",
+            "message": '10.128.2.5 [20/Jun/2026:13:47:50 +0000] "GET /api/pulp-content/balor-stage/maven-releases/org/springframework/spring-expression/5.3.18-redhat-1/spring-expression-5.3.18-redhat-1.pom HTTP/1.1" 302 729 "-" "Apache-Maven/3.9.11 (Java 25.0.3; Linux 7.0.12-201.fc44.x86_64)" cache:"MISS" artifact_size:"2048" rh_org_id:"5894300" x_forwarded_for:"66.187.232.140"',
+        },
+        {
+            "@timestamp": "2026-06-20 13:47:51.000",
+            "message": '10.129.8.16 [20/Jun/2026:13:47:51 +0000] "GET /api/pulp-content/balor-stage/maven-releases/net/minidev/json-smart/2.5.0/json-smart-2.5.0-sources.jar HTTP/1.1" 302 733 "-" "curl/8.15.0" cache:"HIT" artifact_size:"45056" rh_org_id:"5894300" x_forwarded_for:"66.187.232.140"',
+        },
+    ]
+
+
+@pytest.fixture
 def sample_content_parquet_path(tmp_path):
     """Temporary path for content Parquet file testing."""
     return str(tmp_path / "test_content_logs.parquet")

--- a/management_tools/pulp-access-logs-exporter/tests/test_content_export.py
+++ b/management_tools/pulp-access-logs-exporter/tests/test_content_export.py
@@ -6,6 +6,7 @@ from pulp_access_logs_exporter.content_parser import (
     matches_content_type,
     parse_content_log_line,
     parse_content_path,
+    parse_maven_distribution,
     parse_rpm_filename,
     parse_wheel_filename,
 )
@@ -13,7 +14,7 @@ from pulp_access_logs_exporter.content_cloudwatch import (
     build_content_query,
     convert_content_to_arrow_table,
 )
-from pulp_access_logs_exporter.content_schemas import PYTHON_SCHEMA, RPM_SCHEMA
+from pulp_access_logs_exporter.content_schemas import MAVEN_SCHEMA, PYTHON_SCHEMA, RPM_SCHEMA
 from pulp_access_logs_exporter.writer import write_parquet
 
 
@@ -136,6 +137,128 @@ class TestParseRpmFilename:
         assert result is None
 
 
+class TestParseMavenDistribution:
+    def test_standard_jar(self):
+        result = parse_maven_distribution(
+            "maven-releases/org/springframework/cloud/spring-cloud-config-server/4.3.0-redhat-1",
+            "spring-cloud-config-server-4.3.0-redhat-1.jar",
+        )
+        assert result is not None
+        assert result["distribution"] == "maven-releases"
+        assert result["group_id"] == "org.springframework.cloud"
+        assert result["package_name"] == "spring-cloud-config-server"
+        assert result["package_version"] == "4.3.0-redhat-1"
+        assert result["classifier"] is None
+        assert result["packaging"] == "jar"
+        assert result["architecture"] is None
+
+    def test_pom_file(self):
+        result = parse_maven_distribution(
+            "maven-releases/org/springframework/spring-expression/5.3.18-redhat-1",
+            "spring-expression-5.3.18-redhat-1.pom",
+        )
+        assert result is not None
+        assert result["group_id"] == "org.springframework"
+        assert result["package_name"] == "spring-expression"
+        assert result["packaging"] == "pom"
+        assert result["classifier"] is None
+
+    def test_with_classifier(self):
+        result = parse_maven_distribution(
+            "maven-releases/net/minidev/json-smart/2.5.0",
+            "json-smart-2.5.0-sources.jar",
+        )
+        assert result is not None
+        assert result["group_id"] == "net.minidev"
+        assert result["package_name"] == "json-smart"
+        assert result["package_version"] == "2.5.0"
+        assert result["classifier"] == "sources"
+        assert result["packaging"] == "jar"
+
+    def test_javadoc_classifier(self):
+        result = parse_maven_distribution(
+            "maven-releases/com/google/guava/guava/33.0.0-jre",
+            "guava-33.0.0-jre-javadoc.jar",
+        )
+        assert result is not None
+        assert result["group_id"] == "com.google.guava"
+        assert result["package_name"] == "guava"
+        assert result["package_version"] == "33.0.0-jre"
+        assert result["classifier"] == "javadoc"
+        assert result["packaging"] == "jar"
+
+    def test_single_segment_group_id(self):
+        result = parse_maven_distribution(
+            "maven-releases/junit/junit/4.13.2",
+            "junit-4.13.2.jar",
+        )
+        assert result is not None
+        assert result["group_id"] == "junit"
+        assert result["package_name"] == "junit"
+        assert result["package_version"] == "4.13.2"
+
+    def test_snapshot_distribution(self):
+        result = parse_maven_distribution(
+            "maven-snapshots/com/mycompany/app/my-app/1.0-SNAPSHOT",
+            "my-app-1.0-SNAPSHOT.jar",
+        )
+        assert result is not None
+        assert result["distribution"] == "maven-snapshots"
+        assert result["group_id"] == "com.mycompany.app"
+        assert result["package_name"] == "my-app"
+        assert result["package_version"] == "1.0-SNAPSHOT"
+        assert result["packaging"] == "jar"
+
+    def test_deeply_nested_group_id(self):
+        result = parse_maven_distribution(
+            "maven-releases/io/opentelemetry/instrumentation/opentelemetry-instrumentation-api/2.10.0",
+            "opentelemetry-instrumentation-api-2.10.0.jar",
+        )
+        assert result is not None
+        assert result["group_id"] == "io.opentelemetry.instrumentation"
+        assert result["package_name"] == "opentelemetry-instrumentation-api"
+        assert result["package_version"] == "2.10.0"
+
+    def test_multi_hyphen_version(self):
+        result = parse_maven_distribution(
+            "maven-releases/org/jboss/resteasy/resteasy-core/6.2.0-alpha-1",
+            "resteasy-core-6.2.0-alpha-1.jar",
+        )
+        assert result is not None
+        assert result["group_id"] == "org.jboss.resteasy"
+        assert result["package_name"] == "resteasy-core"
+        assert result["package_version"] == "6.2.0-alpha-1"
+        assert result["classifier"] is None
+        assert result["packaging"] == "jar"
+
+    def test_redhat_milestone_version(self):
+        result = parse_maven_distribution(
+            "maven-releases/org/springframework/boot/spring-boot/3.0.0-M1-redhat-00001",
+            "spring-boot-3.0.0-M1-redhat-00001.jar",
+        )
+        assert result is not None
+        assert result["package_name"] == "spring-boot"
+        assert result["package_version"] == "3.0.0-M1-redhat-00001"
+
+    def test_too_few_segments_returns_none(self):
+        result = parse_maven_distribution("maven-releases/junit/4.13.2", "junit-4.13.2.jar")
+        assert result is None
+
+    def test_filename_mismatch_returns_none(self):
+        result = parse_maven_distribution(
+            "maven-releases/org/example/my-lib/1.0.0",
+            "wrong-name-1.0.0.jar",
+        )
+        assert result is None
+
+    def test_no_extension_returns_none(self):
+        result = parse_maven_distribution(
+            "maven-releases/org/example/my-lib/1.0.0",
+            "my-lib-1.0.0",
+        )
+        assert result is None
+
+
 class TestContentTypeFiltering:
     def test_python_whl_matches(self):
         assert matches_content_type("pkg-1.0-py3-none-any.whl", "python") is True
@@ -153,6 +276,18 @@ class TestContentTypeFiltering:
 
     def test_rpm_rejects_whl(self):
         assert matches_content_type("pkg-1.0-py3-none-any.whl", "rpm") is False
+
+    def test_maven_jar_matches(self):
+        assert matches_content_type("spring-core-6.2.0.jar", "maven") is True
+
+    def test_maven_pom_matches(self):
+        assert matches_content_type("spring-core-6.2.0.pom", "maven") is True
+
+    def test_maven_rejects_checksum(self):
+        assert matches_content_type("spring-core-6.2.0.jar.sha1", "maven") is False
+
+    def test_maven_rejects_rpm(self):
+        assert matches_content_type("bash-5.2-1.fc43.x86_64.rpm", "maven") is False
 
     def test_rejects_repodata(self):
         assert matches_content_type("repomd.xml", "python") is False
@@ -312,6 +447,63 @@ class TestContentToParquetRpm:
         assert rows["distribution"][1] == "templates"
 
 
+class TestContentToParquetMaven:
+    def test_converts_maven_downloads(
+        self, sample_maven_cloudwatch_results, sample_content_parquet_path
+    ):
+        table = convert_content_to_arrow_table(
+            sample_maven_cloudwatch_results, "maven"
+        )
+        assert table.num_rows == 3
+        assert table.schema == MAVEN_SCHEMA
+
+        write_parquet(table, sample_content_parquet_path)
+        read_table = pq.read_table(sample_content_parquet_path)
+        assert read_table.num_rows == 3
+
+        rows = read_table.to_pydict()
+        assert rows["domain"][0] == "balor-stage"
+        assert rows["distribution"][0] == "maven-releases"
+        assert rows["group_id"][0] == "org.springframework.cloud"
+        assert rows["package_name"][0] == "spring-cloud-config-server"
+        assert rows["package_version"][0] == "4.3.0-redhat-1"
+        assert rows["classifier"][0] is None
+        assert rows["packaging"][0] == "jar"
+        assert rows["org_id"][0] == "5894300"
+        assert rows["cache_hit"][0] is False
+        assert rows["artifact_size"][0] == 18432000
+
+        assert rows["group_id"][1] == "org.springframework"
+        assert rows["package_name"][1] == "spring-expression"
+        assert rows["packaging"][1] == "pom"
+
+        assert rows["group_id"][2] == "net.minidev"
+        assert rows["package_name"][2] == "json-smart"
+        assert rows["classifier"][2] == "sources"
+        assert rows["packaging"][2] == "jar"
+        assert rows["cache_hit"][2] is True
+
+    def test_skips_checksum_files(self):
+        results = [
+            {
+                "@timestamp": "2026-06-20 13:47:49.000",
+                "message": '10.131.32.14 [20/Jun/2026:13:47:49 +0000] "GET /api/pulp-content/balor-stage/maven-releases/org/springframework/cloud/spring-cloud-config-server/4.3.0-redhat-1/spring-cloud-config-server-4.3.0-redhat-1-provenance.json.md5 HTTP/1.1" 302 727 "-" "curl/8.15.0" cache:"MISS" artifact_size:"32" rh_org_id:"5894300" x_forwarded_for:"66.187.232.140"',
+            },
+        ]
+        table = convert_content_to_arrow_table(results, "maven")
+        assert table.num_rows == 0
+
+    def test_skips_metadata_xml(self):
+        results = [
+            {
+                "@timestamp": "2026-06-20 13:47:49.000",
+                "message": '10.131.32.14 [20/Jun/2026:13:47:49 +0000] "GET /api/pulp-content/balor-stage/maven-releases/org/springframework/cloud/spring-cloud-config-server/maven-metadata.xml HTTP/1.1" 200 500 "-" "curl/8.15.0" cache:"HIT" artifact_size:"500" rh_org_id:"5894300" x_forwarded_for:"66.187.232.140"',
+            },
+        ]
+        table = convert_content_to_arrow_table(results, "maven")
+        assert table.num_rows == 0
+
+
 class TestEmptyContentResults:
     def test_empty_results_python(self):
         table = convert_content_to_arrow_table([], "python")
@@ -322,6 +514,11 @@ class TestEmptyContentResults:
         table = convert_content_to_arrow_table([], "rpm")
         assert table.num_rows == 0
         assert table.schema == RPM_SCHEMA
+
+    def test_empty_results_maven(self):
+        table = convert_content_to_arrow_table([], "maven")
+        assert table.num_rows == 0
+        assert table.schema == MAVEN_SCHEMA
 
 
 class TestContentQueryBuilding:
@@ -346,6 +543,13 @@ class TestContentQueryBuilding:
         query = build_content_query("rpm")
         assert '.rpm"' in query
         assert ".whl" not in query
+
+    def test_maven_query_filters_by_jar_and_pom_extensions(self):
+        query = build_content_query("maven")
+        assert '.jar"' in query
+        assert '.pom"' in query
+        assert ".whl" not in query
+        assert ".rpm" not in query
 
     def test_unknown_content_type_raises(self):
         import pytest

--- a/management_tools/pulp-access-logs-exporter/tests/test_content_export.py
+++ b/management_tools/pulp-access-logs-exporter/tests/test_content_export.py
@@ -283,8 +283,11 @@ class TestContentTypeFiltering:
     def test_maven_pom_matches(self):
         assert matches_content_type("spring-core-6.2.0.pom", "maven") is True
 
-    def test_maven_rejects_checksum(self):
+    def test_maven_rejects_jar_checksum(self):
         assert matches_content_type("spring-core-6.2.0.jar.sha1", "maven") is False
+
+    def test_maven_rejects_pom_checksum(self):
+        assert matches_content_type("spring-core-6.2.0.pom.sha1", "maven") is False
 
     def test_maven_rejects_rpm(self):
         assert matches_content_type("bash-5.2-1.fc43.x86_64.rpm", "maven") is False


### PR DESCRIPTION
## Summary

Add Maven artifact parsing to the content-app logs exporter, enabling `--content-type maven` for the CloudWatch-to-Parquet pipeline. Maven paths use a coordinate-based layout (`groupId/artifactId/version/filename`) that requires distribution-level parsing rather than filename-only parsing.

## Changes

- **content_schemas.py**: Added `MAVEN_SCHEMA` (COMMON_FIELDS + `group_id`, `classifier`, `packaging`)
- **content_parser.py**: Added `parse_maven_distribution()` function and registered `.jar`/`.pom` in `CONTENT_TYPE_EXTENSIONS`
- **content_cloudwatch.py**: Introduced `DISTRIBUTION_PARSERS` dispatch alongside `FILENAME_PARSERS` for content types that need path-level coordinate extraction
- **cli.py**: Derived `--content-type` choices from `CONTENT_TYPE_EXTENSIONS` keys (auto-registers new content types)
- **tests**: 18 new tests covering Maven distribution parsing, content type filtering, Parquet roundtrip, and edge cases (deep groupIds, multi-hyphen versions, SNAPSHOT, classifiers)

## Testing

- 62 tests pass (18 new Maven + 44 existing RPM/Python — no regressions)
- Manually tested against prod CloudWatch logs: exported 9 Maven records from `balor-stage` and `default` domains to Parquet, verified all fields parse correctly
- Validated that checksum files (`.md5`, `.sha1`) and `maven-metadata.xml` are correctly filtered out

## Jira

Closes: PULP-1815

---
Assisted-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

## Summary by Sourcery

Add Maven content type support to the pulp access logs exporter so Maven downloads can be parsed and exported to Parquet alongside existing Python and RPM artifacts.

New Features:
- Support exporting Maven content downloads via a new maven content type with dedicated schema fields for group ID, classifier, and packaging.

Enhancements:
- Introduce distribution-based parsing for content types like Maven that require path-level coordinate extraction, while preserving filename-based parsing for existing types.
- Derive CLI --content-type choices from registered content type extensions to automatically surface newly supported types.

Tests:
- Add comprehensive tests covering Maven distribution parsing, content-type filtering, query generation, Parquet roundtrip, and edge cases such as deep group IDs, classifiers, and SNAPSHOT versions.