### PR TITLE
fix: pass missing mirror argument to pulp_python sync task

### DIFF
--- a/pulp_service/pulp_service/app/tasks/lightwell_period_sync.py
+++ b/pulp_service/pulp_service/app/tasks/lightwell_period_sync.py
@@ -24,5 +24,6 @@ def python_repository_sync():
         kwargs={
             "remote_pk": str(remote_pk),
             "repository_pk": str(repository.pk),
+            "mirror": False,
         },
     )


### PR DESCRIPTION
The pulp_python sync function requires a `mirror` parameter, but the lightwell scheduled sync dispatch was not passing it, causing the task to fail with "sync() missing 1 required positional argument: 'mirror'".

## Summary by Sourcery

Bug Fixes:
- Pass the missing mirror flag to the scheduled pulp_python repository sync task to prevent sync failures due to a missing required argument.