### PR TITLE
Add patch for duplicate Maven artifact upload handling

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -160,6 +160,9 @@ RUN patch -p1 -d /usr/local/lib/pulp/lib/python${PYTHON_VERSION}/site-packages <
 COPY images/assets/patches/0058-fix-migrate.patch /tmp/
 RUN patch -p1 -d /usr/local/lib/pulp/lib/python${PYTHON_VERSION}/site-packages < /tmp/0058-fix-migrate.patch
 
+COPY images/assets/patches/0059-Handle-duplicate-Maven-artifact-uploads.patch /tmp/
+RUN patch -p1 -d /usr/local/lib/pulp/lib/python${PYTHON_VERSION}/site-packages < /tmp/0059-Handle-duplicate-Maven-artifact-uploads.patch
+
 
 RUN mkdir /licenses
 COPY LICENSE /licenses/LICENSE

--- a/images/assets/patches/0059-Handle-duplicate-Maven-artifact-uploads.patch
+++ b/images/assets/patches/0059-Handle-duplicate-Maven-artifact-uploads.patch
@@ -1,0 +1,75 @@
+From 762a89d9737ac16d890fe9e9a62f9e07d9fc5380 Mon Sep 17 00:00:00 2001
+From: Dennis Kliban <dkliban@redhat.com>
+Date: Sat, 27 Jun 2026 09:12:27 -0400
+Subject: [PATCH] Handle duplicate Maven artifact uploads by returning existing
+ content
+
+Implement retrieve() to look up existing content by group_id, artifact_id,
+version, filename, and pulp_domain. This matches the pulp_rpm pattern and
+prevents 500 errors when uploading an artifact with the same relative_path.
+
+Fixes #361
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+---
+ pulp_maven/app/serializers.py                 |  9 +++++++
+ .../functional/api/test_create_content.py     | 26 +++++++++++++++++++
+ 2 files changed, 35 insertions(+)
+
+diff --git a/pulp_maven/app/serializers.py b/pulp_maven/app/serializers.py
+index 86287f7..b269614 100644
+--- a/pulp_maven/app/serializers.py
++++ b/pulp_maven/app/serializers.py
+@@ -37,6 +37,15 @@ class MavenArtifactSerializer(platform.SingleArtifactContentUploadSerializer):
+     )
+     filename = serializers.CharField(help_text=_("Filename of the artifact."), read_only=True)
+ 
++    def retrieve(self, validated_data):
++        return models.MavenArtifact.objects.filter(
++            group_id=validated_data["group_id"],
++            artifact_id=validated_data["artifact_id"],
++            version=validated_data["version"],
++            filename=validated_data["filename"],
++            pulp_domain=get_domain_pk(),
++        ).first()
++
+     def create(self, validated_data):
+         group_id, artifact_id, version, filename = (
+             models.MavenArtifact.group_artifact_version_filename(validated_data["relative_path"])
+diff --git a/pulp_maven/tests/functional/api/test_create_content.py b/pulp_maven/tests/functional/api/test_create_content.py
+index be4f8b4..dd0cbed 100644
+--- a/pulp_maven/tests/functional/api/test_create_content.py
++++ b/pulp_maven/tests/functional/api/test_create_content.py
+@@ -244,3 +244,29 @@ def test_async_create_maven_artifact(
+     downloaded = download_file(unit_url)
+     assert downloaded.response_obj.status == 200
+     assert hashlib.sha256(downloaded.body).hexdigest() == artifact.sha256
++
++
++@pytest.mark.parallel
++def test_upload_duplicate_maven_artifact(
++    maven_artifact_api_client,
++    random_artifact_factory,
++):
++    """Test that uploading a duplicate Maven artifact returns the existing content unit."""
++    artifact = random_artifact_factory(size=64)
++    filename = "duplicate-test-1.0.0.jar"
++    relative_path = f"com/example/duplicate-test/1.0.0/{filename}"
++
++    first = maven_artifact_api_client.upload(
++        artifact=artifact.pulp_href,
++        relative_path=relative_path,
++    )
++    assert first.pulp_href is not None
++
++    # Upload again with same relative_path but different artifact content
++    artifact2 = random_artifact_factory(size=64)
++    second = maven_artifact_api_client.upload(
++        artifact=artifact2.pulp_href,
++        relative_path=relative_path,
++    )
++
++    assert second.pulp_href == first.pulp_href
+-- 
+2.54.0
+


### PR DESCRIPTION
## Summary
- Adds patch `0059-Handle-duplicate-Maven-artifact-uploads.patch` to handle duplicate Maven artifact uploads
- Implements `retrieve()` on `MavenArtifactSerializer` to return existing content instead of 500
- Matches the pulp_rpm `PackageSerializer.retrieve()` pattern

## Test plan
- [x] Tested locally in dev container — duplicate upload returns existing content unit
- [x] Upstream PR with functional test: https://github.com/pulp/pulp_maven/pull/362

Related Jira: https://redhat.atlassian.net/browse/PULP-1936

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Apply a new patch to the Pulp Maven installation in the container image to gracefully handle duplicate Maven artifact uploads by reusing existing content units instead of failing.

Bug Fixes:
- Ensure duplicate Maven artifact uploads return the existing content unit rather than causing a server error in the Maven artifact serializer.

Build:
- Include and apply the 0059-Handle-duplicate-Maven-artifact-uploads.patch file during container image build.