### PR TITLE
Upgrade pulp-maven to 0.18.0

### DIFF
--- a/pulp_service/requirements.txt
+++ b/pulp_service/requirements.txt
@@ -4,7 +4,7 @@ solv>=0.7.21,<0.7.38
 pulp-python==3.30.3
 pulp-npm==0.8.0
 pulp-container==2.28.0
-pulp-maven==0.17.0
+pulp-maven==0.18.0
 pulp-hugging-face==0.3.0
 pulp-cli
 sentry-sdk


### PR DESCRIPTION
## Summary
- Upgrade pulp-maven from 0.17.0 to 0.18.0

pulp-maven 0.18.0 includes:
- MavenMetadata GAV parsing from XML content instead of ambiguous path (fixes #367)
- Version-level SNAPSHOT metadata support
- `defusedxml` dependency for safe XML parsing

🤖 Generated with [Claude Code](https://claude.com/claude-code)