### PR TITLE
Upgrade pulp-maven to 0.19.0

### DIFF
--- a/pulp_service/requirements.txt
+++ b/pulp_service/requirements.txt
@@ -4,7 +4,7 @@ solv>=0.7.21,<0.7.38
 pulp-python==3.30.3
 pulp-npm==0.8.0
 pulp-container==2.28.0
-pulp-maven==0.18.0
+pulp-maven==0.19.0
 pulp-hugging-face==0.3.0
 pulp-cli
 sentry-sdk


### PR DESCRIPTION
## Summary
- Bumps `pulp-maven` from 0.18.0 to 0.19.0
- Key change: invalid XML uploads to maven-metadata.xml now return 400 instead of 500

## Test plan
- [ ] CI passes
- [ ] Patch 0022 (mvn deploy auth) still applies cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)