### PR TITLE
docs: distribute code gotchas into CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,11 +84,22 @@ Uses **towncrier**. For any non-trivial change, create a file in `CHANGES/` name
 
 ## Code Gotchas
 
-- **jq `// empty` raises `StopIteration`** — never use `// empty` in jq filters passed to `.first()`. An empty stream raises `StopIteration`, not `None`. Use direct null comparisons: `if .foo == "bar" then ... else null end`.
-- **jq string interpolation produces `"null"` not null** — `"\(.foo)"` where `.foo` is null produces the string `"null"`. The parent `JSONHeaderRemoteAuthentication` accepts any non-null string as valid. Always add explicit null checks before interpolation.
+### jq filters
+
+- **`// empty` raises `StopIteration`** — never use `// empty` in jq filters passed to `.first()`. An empty stream raises `StopIteration`, not `None`. Use direct null comparisons: `if .foo == "bar" then ... else null end`.
+- **String interpolation produces `"null"` not null** — `"\(.foo)"` where `.foo` is null produces the string `"null"`. The parent `JSONHeaderRemoteAuthentication` accepts any non-null string as valid. Always add explicit null checks before interpolation.
+
+### Auth configuration
+
 - **`@merge` appends, doesn't prepend** — Pulp's `@merge` directive for `REST_FRAMEWORK__DEFAULT_AUTHENTICATION_CLASSES` appends custom classes after pulpcore's defaults. Use an explicit full list when auth class order matters.
+
+### API behavior
+
 - **`pulp_label_select` negation causes 500s** — the `!label` and `label!=value` operators can cause server errors. Fall back to client-side filtering when excluding by labels.
 - **CloudWatch domain listing needs `fields` parameter** — domain objects include large `storage_settings` blobs. Use `?fields=name,pulp_href,pulp_labels&limit=50` to avoid 500 errors from oversized responses.
+
+### Python dependencies
+
 - **PyArrow `S3FileSystem` region issues** — passing `region=None` overrides auto-detection (different from omitting the parameter). Use `**kwargs` and only include `region` when explicitly set. `copy_files()` uses multipart upload which fails with PermanentRedirect; use `open_output_stream()` or boto3 instead.
 - **`UV_INDEX` vs `UV_DEFAULT_INDEX`** — `UV_DEFAULT_INDEX` replaces PyPI entirely (dependencies won't resolve). Use `UV_INDEX` to add a private repo alongside PyPI.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,6 +82,16 @@ Uses **towncrier**. For any non-trivial change, create a file in `CHANGES/` name
 - Complexity thresholds: max-complexity=10, max-branches=10, max-args=6, max-statements=40
 - Per-file exceptions: viewsets.py and rds_connection_tests.py (complexity rules), storage.py (hardcoded temp paths), tests (argument count, print, unused args, security), migrations (excluded entirely)
 
+## Code Gotchas
+
+- **jq `// empty` raises `StopIteration`** — never use `// empty` in jq filters passed to `.first()`. An empty stream raises `StopIteration`, not `None`. Use direct null comparisons: `if .foo == "bar" then ... else null end`.
+- **jq string interpolation produces `"null"` not null** — `"\(.foo)"` where `.foo` is null produces the string `"null"`. The parent `JSONHeaderRemoteAuthentication` accepts any non-null string as valid. Always add explicit null checks before interpolation.
+- **`@merge` appends, doesn't prepend** — Pulp's `@merge` directive for `REST_FRAMEWORK__DEFAULT_AUTHENTICATION_CLASSES` appends custom classes after pulpcore's defaults. Use an explicit full list when auth class order matters.
+- **`pulp_label_select` negation causes 500s** — the `!label` and `label!=value` operators can cause server errors. Fall back to client-side filtering when excluding by labels.
+- **CloudWatch domain listing needs `fields` parameter** — domain objects include large `storage_settings` blobs. Use `?fields=name,pulp_href,pulp_labels&limit=50` to avoid 500 errors from oversized responses.
+- **PyArrow `S3FileSystem` region issues** — passing `region=None` overrides auto-detection (different from omitting the parameter). Use `**kwargs` and only include `region` when explicitly set. `copy_files()` uses multipart upload which fails with PermanentRedirect; use `open_output_stream()` or boto3 instead.
+- **`UV_INDEX` vs `UV_DEFAULT_INDEX`** — `UV_DEFAULT_INDEX` replaces PyPI entirely (dependencies won't resolve). Use `UV_INDEX` to add a private repo alongside PyPI.
+
 ## Dev Container: hosted-pulp-dev-env
 
 A self-contained development container with PostgreSQL, Redis, and all Pulp services running locally. Built automatically on every push to any branch.


### PR DESCRIPTION
## Summary

- Move 7 code-level gotchas from the centralized gotchas reference into `CLAUDE.md`
- Covers jq filter pitfalls, auth implementation traps, API behavior, PyArrow S3, and UV index config
- Agents now load these automatically when working in pulp-service

Part of a broader effort to distribute gotchas into domain-specific files where they're loaded on-demand.

## Test plan

- [ ] Verify CLAUDE.md renders correctly
- [ ] Confirm no duplicate gotchas with other project docs

Assisted-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

## Summary by Sourcery

Documentation:
- Add a Code Gotchas section to CLAUDE.md capturing common jq, authentication, API, PyArrow S3, and UV index configuration pitfalls for pulp-service.