### PR TITLE
fix: inject org_id on raised HTTPException responses in content middleware

### DIFF
--- a/CHANGES/1959.bugfix
+++ b/CHANGES/1959.bugfix
@@ -1,0 +1,1 @@
+Fixed org_id not being logged for content app responses that raise HTTPException (404, 301, 302 on cache miss). The middleware now injects X-RH-ORG-ID on both normal returns and raised exceptions.

--- a/pulp_service/pulp_service/app/content.py
+++ b/pulp_service/pulp_service/app/content.py
@@ -99,24 +99,28 @@ async def add_true_client_ip_to_forwarded_for(request, handler):
     return await handler(request)
 
 
+def _set_org_id_header(request, response):
+    """Extract org_id from x-rh-identity and set it on the response header."""
+    rh_identity_header = request.headers.get("x-rh-identity")
+    if not rh_identity_header:
+        return
+
+    identity = json.loads(b64decode(rh_identity_header))
+
+    # non-entitlement certs (x509, SAML) have a different structure without identity.org_id
+    if "identity" in identity and "org_id" in identity["identity"]:
+        response.headers["X-RH-ORG-ID"] = identity["identity"]["org_id"]
+
+
 @web.middleware
 async def add_rh_org_id_resp_header(request, handler):
     try:
         response = await handler(request)
     except web.HTTPException as exc:
+        _set_org_id_header(request, exc)
         return exc
 
-    if not request.headers.get("x-rh-identity"):
-        return response
-
-    rh_identity_header = request.headers["x-rh-identity"]
-    rh_identity_header_decoded = b64decode(rh_identity_header)
-    rh_identity_header_json = json.loads(rh_identity_header_decoded)
-
-    # we need to check if the entire path exists because non-entitlement certs have a diff structure
-    if "identity" in rh_identity_header_json and "org_id" in rh_identity_header_json["identity"]:
-        response.headers["X-RH-ORG-ID"] = rh_identity_header_json["identity"]["org_id"]
-
+    _set_org_id_header(request, response)
     return response
 
 

--- a/pulp_service/pulp_service/app/content.py
+++ b/pulp_service/pulp_service/app/content.py
@@ -105,7 +105,10 @@ def _set_org_id_header(request, response):
     if not rh_identity_header:
         return
 
-    identity = json.loads(b64decode(rh_identity_header))
+    try:
+        identity = json.loads(b64decode(rh_identity_header))
+    except Exception:
+        return
 
     # non-entitlement certs (x509, SAML) have a different structure without identity.org_id
     if "identity" in identity and "org_id" in identity["identity"]:

--- a/pulp_service/pulp_service/tests/unit/test_content_org_id_middleware.py
+++ b/pulp_service/pulp_service/tests/unit/test_content_org_id_middleware.py
@@ -1,0 +1,167 @@
+"""
+Unit tests for add_rh_org_id_resp_header middleware.
+
+Verifies that X-RH-ORG-ID is injected into responses regardless of whether
+the content handler returns or raises an HTTPException.
+"""
+
+import json
+from base64 import b64encode
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from aiohttp import web
+
+from pulp_service.app.content import _set_org_id_header, add_rh_org_id_resp_header
+
+
+def _encode_identity(identity_dict):
+    return b64encode(json.dumps(identity_dict).encode()).decode()
+
+
+def _make_request(identity=None):
+    request = MagicMock()
+    headers = {}
+    if identity is not None:
+        headers["x-rh-identity"] = _encode_identity(identity)
+    request.headers = headers
+    return request
+
+
+STANDARD_IDENTITY = {"identity": {"org_id": "1979710", "user": {"username": "testuser"}}}
+X509_IDENTITY = {"identity": {"x509": {"subject_dn": "CN=service-account,O=Red Hat"}}}
+MINIMAL_IDENTITY = {"identity": {"user": {"username": "anotheruser"}}}
+
+
+class TestSetOrgIdHeader:
+    """Unit tests for the _set_org_id_header helper."""
+
+    def test_sets_header_with_standard_identity(self):
+        request = _make_request(STANDARD_IDENTITY)
+        response = web.Response()
+
+        _set_org_id_header(request, response)
+
+        assert response.headers["X-RH-ORG-ID"] == "1979710"
+
+    def test_skips_when_no_identity_header(self):
+        request = _make_request()
+        response = web.Response()
+
+        _set_org_id_header(request, response)
+
+        assert "X-RH-ORG-ID" not in response.headers
+
+    def test_skips_for_x509_identity(self):
+        request = _make_request(X509_IDENTITY)
+        response = web.Response()
+
+        _set_org_id_header(request, response)
+
+        assert "X-RH-ORG-ID" not in response.headers
+
+    def test_skips_for_identity_without_org_id(self):
+        request = _make_request(MINIMAL_IDENTITY)
+        response = web.Response()
+
+        _set_org_id_header(request, response)
+
+        assert "X-RH-ORG-ID" not in response.headers
+
+    def test_sets_header_on_http_exception(self):
+        request = _make_request(STANDARD_IDENTITY)
+        response = web.HTTPNotFound()
+
+        _set_org_id_header(request, response)
+
+        assert response.headers["X-RH-ORG-ID"] == "1979710"
+
+    def test_sets_header_on_redirect(self):
+        request = _make_request(STANDARD_IDENTITY)
+        response = web.HTTPFound(location="https://s3.example.com/artifact")
+
+        _set_org_id_header(request, response)
+
+        assert response.headers["X-RH-ORG-ID"] == "1979710"
+
+
+class TestAddRhOrgIdRespHeader:
+    """Integration tests for the full middleware."""
+
+    @pytest.mark.asyncio
+    async def test_normal_response_gets_org_id(self):
+        request = _make_request(STANDARD_IDENTITY)
+        handler = AsyncMock(return_value=web.Response())
+
+        response = await add_rh_org_id_resp_header(request, handler)
+
+        assert response.headers["X-RH-ORG-ID"] == "1979710"
+
+    @pytest.mark.asyncio
+    async def test_raised_404_gets_org_id(self):
+        request = _make_request(STANDARD_IDENTITY)
+        handler = AsyncMock(side_effect=web.HTTPNotFound())
+
+        response = await add_rh_org_id_resp_header(request, handler)
+
+        assert response.status == 404
+        assert response.headers["X-RH-ORG-ID"] == "1979710"
+
+    @pytest.mark.asyncio
+    async def test_raised_302_gets_org_id(self):
+        request = _make_request(STANDARD_IDENTITY)
+        handler = AsyncMock(side_effect=web.HTTPFound(location="https://s3.example.com/artifact"))
+
+        response = await add_rh_org_id_resp_header(request, handler)
+
+        assert response.status == 302
+        assert response.headers["X-RH-ORG-ID"] == "1979710"
+
+    @pytest.mark.asyncio
+    async def test_raised_301_gets_org_id(self):
+        request = _make_request(STANDARD_IDENTITY)
+        handler = AsyncMock(side_effect=web.HTTPMovedPermanently(location="/path/"))
+
+        response = await add_rh_org_id_resp_header(request, handler)
+
+        assert response.status == 301
+        assert response.headers["X-RH-ORG-ID"] == "1979710"
+
+    @pytest.mark.asyncio
+    async def test_raised_403_gets_org_id(self):
+        request = _make_request(STANDARD_IDENTITY)
+        handler = AsyncMock(side_effect=web.HTTPForbidden())
+
+        response = await add_rh_org_id_resp_header(request, handler)
+
+        assert response.status == 403
+        assert response.headers["X-RH-ORG-ID"] == "1979710"
+
+    @pytest.mark.asyncio
+    async def test_no_identity_header_returns_without_org_id(self):
+        request = _make_request()
+        handler = AsyncMock(return_value=web.Response())
+
+        response = await add_rh_org_id_resp_header(request, handler)
+
+        assert "X-RH-ORG-ID" not in response.headers
+
+    @pytest.mark.asyncio
+    async def test_no_identity_on_raised_exception(self):
+        request = _make_request()
+        handler = AsyncMock(side_effect=web.HTTPNotFound())
+
+        response = await add_rh_org_id_resp_header(request, handler)
+
+        assert response.status == 404
+        assert "X-RH-ORG-ID" not in response.headers
+
+    @pytest.mark.asyncio
+    async def test_x509_identity_on_raised_exception(self):
+        request = _make_request(X509_IDENTITY)
+        handler = AsyncMock(side_effect=web.HTTPNotFound())
+
+        response = await add_rh_org_id_resp_header(request, handler)
+
+        assert response.status == 404
+        assert "X-RH-ORG-ID" not in response.headers

--- a/pulp_service/pulp_service/tests/unit/test_content_org_id_middleware.py
+++ b/pulp_service/pulp_service/tests/unit/test_content_org_id_middleware.py
@@ -68,6 +68,24 @@ class TestSetOrgIdHeader:
 
         assert "X-RH-ORG-ID" not in response.headers
 
+    def test_skips_for_malformed_base64(self):
+        request = MagicMock()
+        request.headers = {"x-rh-identity": "not-valid-base64!!!"}
+        response = web.Response()
+
+        _set_org_id_header(request, response)
+
+        assert "X-RH-ORG-ID" not in response.headers
+
+    def test_skips_for_malformed_json(self):
+        request = MagicMock()
+        request.headers = {"x-rh-identity": b64encode(b"not json").decode()}
+        response = web.Response()
+
+        _set_org_id_header(request, response)
+
+        assert "X-RH-ORG-ID" not in response.headers
+
     def test_sets_header_on_http_exception(self):
         request = _make_request(STANDARD_IDENTITY)
         response = web.HTTPNotFound()


### PR DESCRIPTION
## Summary

The `add_rh_org_id_resp_header` middleware was skipping `X-RH-ORG-ID` injection when the content handler raised an `HTTPException` (404, 301, 302 on cache miss, 403, etc.). This caused authenticated requests that hit non-existent paths or S3 redirect cache misses to log `rh_org_id:"-"` instead of the actual org identity.

## Changes

- Extracted the identity-parsing and header-injection logic into a `_set_org_id_header()` helper
- Applied the helper in both the normal return path and the `except web.HTTPException` path
- Added unit tests covering all combinations: normal response, raised 404/302/301/403, missing identity, x509 identity
- Added towncrier changelog fragment

## Testing

Unit tests in `pulp_service/tests/unit/test_content_org_id_middleware.py` cover:
- Standard identity → org_id injected on normal response
- Standard identity → org_id injected on raised 404, 302, 301, 403
- No identity header → no org_id on both paths
- x509 identity (no org_id field) → no org_id on both paths

Post-deploy validation: run the CloudWatch query from PULP-1929 and confirm 404s on ccac33ac and lightwell now show `rh_org_id` populated.

## Jira

Closes: PULP-1959

---
Assisted-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

## Summary by Sourcery

Ensure the content middleware consistently injects X-RH-ORG-ID into responses, including those produced by HTTP exceptions.

Bug Fixes:
- Inject X-RH-ORG-ID on HTTPException responses from the content handler to preserve org identity in error and redirect logs.

Enhancements:
- Extract org ID parsing and header injection into a reusable helper shared by normal and exception response paths.

Tests:
- Add unit and integration tests covering org ID header behavior for normal responses, various HTTP exceptions, and identities without org_id.
- Add test coverage for x509 and minimal identities to confirm X-RH-ORG-ID is omitted when org_id is not present.

Chores:
- Add towncrier bugfix changelog fragment for issue 1959.