### PR TITLE
fix(agent-alertmanager): extract shared auth, support VERTEX_SA_JSON

### DIFF
--- a/tools/agents/agent-alertmanager/main.go
+++ b/tools/agents/agent-alertmanager/main.go
@@ -14,6 +14,8 @@ import (
 
 	"github.com/tmc/langchaingo/llms"
 
+	"github.com/pulp/pulp-service/tools/agents/shared/auth"
+
 	"github.com/pulp/pulp-service/tools/agents/agent-alertmanager/alertmanager"
 	"github.com/pulp/pulp-service/tools/agents/agent-alertmanager/cloudwatch"
 	"github.com/pulp/pulp-service/tools/agents/agent-alertmanager/dedup"
@@ -30,7 +32,6 @@ import (
 const (
 	defaultModel     = "claude-sonnet-4-6"
 	defaultQuestion  = "analyze all firing Pulp alerts and assess their severity and impact"
-	defaultRegion    = "us-east5"
 	defaultCooldown  = "30m"
 	defaultCachePath = "/tmp/agent-alertmanager-cache.json"
 	defaultLockPath  = "/tmp/agent-alertmanager.lock"
@@ -83,10 +84,13 @@ func run() error {
 		return runCheckOnly(clients)
 	}
 
-	// --- Full mode: validate additional requirements ---
-	vertexProjectID := os.Getenv("ANTHROPIC_VERTEX_PROJECT_ID")
-	if vertexProjectID == "" {
-		return fmt.Errorf("ANTHROPIC_VERTEX_PROJECT_ID environment variable is required in full mode")
+	// --- Full mode: resolve LLM auth ---
+	authConfig, authErr := auth.ResolveFromEnv()
+	if authErr != nil {
+		return fmt.Errorf("LLM auth: %w", authErr)
+	}
+	if authConfig.APIKey != "" {
+		fmt.Fprintf(os.Stderr, "[auth] using proxy mode (ANTHROPIC_BASE_URL=%s)\n", authConfig.BaseURL)
 	}
 
 	if !supportedModels[*modelFlag] {
@@ -117,11 +121,6 @@ func run() error {
 	defer timeoutCancel()
 
 	// --- Parse optional env vars ---
-	region := os.Getenv("CLOUD_ML_REGION")
-	if region == "" {
-		region = defaultRegion
-	}
-
 	cooldownStr := os.Getenv("DEDUP_COOLDOWN")
 	if cooldownStr == "" {
 		cooldownStr = defaultCooldown
@@ -290,14 +289,14 @@ func run() error {
 	if strings.HasPrefix(*modelFlag, "claude-") {
 		model = models.Claude{
 			Model:     *modelFlag,
-			ProjectID: vertexProjectID,
-			Region:    region,
+			ProjectID: authConfig.ProjectID,
+			Region:    authConfig.Region,
 		}
 	} else {
 		model = models.Gemini{
 			Model:     *modelFlag,
-			ProjectID: vertexProjectID,
-			Region:    region,
+			ProjectID: authConfig.ProjectID,
+			Region:    authConfig.Region,
 		}
 	}
 

--- a/tools/agents/shared/auth/auth.go
+++ b/tools/agents/shared/auth/auth.go
@@ -1,0 +1,61 @@
+package auth
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+)
+
+type Config struct {
+	ProjectID    string
+	Region       string
+	APIKey       string
+	BaseURL      string
+	SACredential []byte
+}
+
+func ResolveFromEnv() (*Config, error) {
+	config := &Config{
+		APIKey:    os.Getenv("ANTHROPIC_API_KEY"),
+		BaseURL:   normalizeBaseURL(os.Getenv("ANTHROPIC_BASE_URL")),
+		ProjectID: os.Getenv("ANTHROPIC_VERTEX_PROJECT_ID"),
+	}
+
+	if saJSON := os.Getenv("VERTEX_SA_JSON"); saJSON != "" {
+		config.SACredential = []byte(saJSON)
+	}
+
+	if config.ProjectID == "" && len(config.SACredential) > 0 {
+		var serviceAccount struct {
+			ProjectID string `json:"project_id"`
+		}
+		if err := json.Unmarshal(config.SACredential, &serviceAccount); err != nil {
+			return nil, fmt.Errorf("VERTEX_SA_JSON is not valid JSON: %w", err)
+		}
+		if serviceAccount.ProjectID == "" {
+			return nil, fmt.Errorf("VERTEX_SA_JSON does not contain a project_id field")
+		}
+		config.ProjectID = serviceAccount.ProjectID
+	}
+
+	config.Region = os.Getenv("CLOUD_ML_REGION")
+	if config.Region == "" {
+		config.Region = "us-east5"
+	}
+
+	if config.APIKey == "" && config.ProjectID == "" {
+		return nil, fmt.Errorf("set ANTHROPIC_API_KEY (proxy mode) or ANTHROPIC_VERTEX_PROJECT_ID / VERTEX_SA_JSON (Vertex AI mode)")
+	}
+
+	return config, nil
+}
+
+func normalizeBaseURL(url string) string {
+	if url == "" {
+		return ""
+	}
+	if url[len(url)-1] == '/' {
+		return url[:len(url)-1]
+	}
+	return url
+}

--- a/tools/agents/shared/auth/auth_test.go
+++ b/tools/agents/shared/auth/auth_test.go
@@ -1,0 +1,89 @@
+package auth
+
+import "testing"
+
+func TestResolveFromEnv_ExplicitProjectID(t *testing.T) {
+	t.Setenv("ANTHROPIC_VERTEX_PROJECT_ID", "my-project")
+	t.Setenv("VERTEX_SA_JSON", "")
+	t.Setenv("ANTHROPIC_API_KEY", "")
+
+	config, err := ResolveFromEnv()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if config.ProjectID != "my-project" {
+		t.Errorf("ProjectID = %q, want %q", config.ProjectID, "my-project")
+	}
+}
+
+func TestResolveFromEnv_ProjectIDFromSAJSON(t *testing.T) {
+	t.Setenv("ANTHROPIC_VERTEX_PROJECT_ID", "")
+	t.Setenv("ANTHROPIC_API_KEY", "")
+	t.Setenv("VERTEX_SA_JSON", `{"project_id":"sa-project","type":"service_account"}`)
+
+	config, err := ResolveFromEnv()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if config.ProjectID != "sa-project" {
+		t.Errorf("ProjectID = %q, want %q", config.ProjectID, "sa-project")
+	}
+	if len(config.SACredential) == 0 {
+		t.Error("SACredential should be set")
+	}
+}
+
+func TestResolveFromEnv_ProxyMode(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "sk-test-key")
+	t.Setenv("ANTHROPIC_BASE_URL", "http://localhost:8443/v1/")
+	t.Setenv("ANTHROPIC_VERTEX_PROJECT_ID", "")
+	t.Setenv("VERTEX_SA_JSON", "")
+
+	config, err := ResolveFromEnv()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if config.APIKey != "sk-test-key" {
+		t.Errorf("APIKey = %q", config.APIKey)
+	}
+	if config.BaseURL != "http://localhost:8443/v1" {
+		t.Errorf("BaseURL = %q, want trailing slash removed", config.BaseURL)
+	}
+}
+
+func TestResolveFromEnv_NoAuth(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "")
+	t.Setenv("ANTHROPIC_VERTEX_PROJECT_ID", "")
+	t.Setenv("VERTEX_SA_JSON", "")
+
+	_, err := ResolveFromEnv()
+	if err == nil {
+		t.Fatal("expected error when no auth configured")
+	}
+}
+
+func TestResolveFromEnv_InvalidSAJSON(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "")
+	t.Setenv("ANTHROPIC_VERTEX_PROJECT_ID", "")
+	t.Setenv("VERTEX_SA_JSON", "not json")
+
+	_, err := ResolveFromEnv()
+	if err == nil {
+		t.Fatal("expected error for invalid SA JSON")
+	}
+}
+
+func TestResolveFromEnv_DefaultRegion(t *testing.T) {
+	t.Setenv("ANTHROPIC_VERTEX_PROJECT_ID", "my-project")
+	t.Setenv("CLOUD_ML_REGION", "")
+	t.Setenv("VERTEX_SA_JSON", "")
+	t.Setenv("ANTHROPIC_API_KEY", "")
+
+	config, err := ResolveFromEnv()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if config.Region != "us-east5" {
+		t.Errorf("Region = %q, want %q", config.Region, "us-east5")
+	}
+}


### PR DESCRIPTION
## Summary

Agent-alertmanager was crashing on Alcove with `ANTHROPIC_VERTEX_PROJECT_ID environment variable is required` because Alcove injects Vertex AI credentials via `VERTEX_SA_JSON` (service account JSON), not as a separate project ID env var.

## Changes

- **`shared/auth/`** (new) — `ResolveFromEnv()` handles 3 auth modes: proxy (`ANTHROPIC_API_KEY`), explicit project ID (`ANTHROPIC_VERTEX_PROJECT_ID`), and SA JSON (`VERTEX_SA_JSON` with `project_id` extraction). 6 tests.
- **`agent-alertmanager/main.go`** — replaces hardcoded `ANTHROPIC_VERTEX_PROJECT_ID` check with `auth.ResolveFromEnv()`. Removes unused `defaultRegion` const.

Same auth logic that agent-splunk already uses, now in a shared package.

## Testing

- 6 unit tests in `shared/auth/` (explicit ID, SA JSON extraction, proxy mode, no auth error, invalid JSON, default region)
- All existing agent-alertmanager tests pass
- Agent builds cleanly

---
Assisted-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

## Summary by Sourcery

Centralize LLM authentication resolution in a shared auth package and update agent-alertmanager to use it, adding support for Vertex service account JSON credentials and proxy mode while keeping region handling consistent.

New Features:
- Introduce shared auth package for agents that resolves LLM authentication configuration from environment variables, including support for Vertex SA JSON credentials and proxy mode.

Bug Fixes:
- Prevent agent-alertmanager from crashing when only VERTEX_SA_JSON-based Vertex credentials are provided by correctly deriving the project ID and region from shared auth configuration.

Enhancements:
- Refactor agent-alertmanager to use shared auth configuration for LLM model setup, simplifying environment handling and centralizing auth logic.

Tests:
- Add unit tests covering explicit project ID, SA JSON-based project ID extraction, proxy mode, missing auth configuration, invalid SA JSON, and default region behavior in the shared auth package.