### PR TITLE
fix(agent-alertmanager): update release to 20260617-3ee37a3

### DIFF
--- a/.alcove/agents/alertmanager-analyzer.yml
+++ b/.alcove/agents/alertmanager-analyzer.yml
@@ -5,7 +5,7 @@ description: |
   Jira issues. Runs as a pre-compiled agent binary from GitHub Releases.
 
 executable:
-  url: https://github.com/pulp/pulp-service/releases/download/agent-alertmanager-20260617-3b2ac5e/agent-alertmanager
+  url: https://github.com/pulp/pulp-service/releases/download/agent-alertmanager-20260617-3ee37a3/agent-alertmanager
   args: ["--model", "claude-sonnet-4-6"]
   env:
     JIRA_URL: "https://redhat.atlassian.net/"


### PR DESCRIPTION
Update workflow to release with VERTEX_SA_JSON auth fix (#1292). Fixes agent crash on Alcove.

Release: https://github.com/pulp/pulp-service/releases/tag/agent-alertmanager-20260617-3ee37a3

---
Assisted-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

## Summary by Sourcery

Bug Fixes:
- Resolve Alcove agent crash by consuming the alertmanager release with the VERTEX_SA_JSON auth fix.