### PR TITLE
fix(shared/auth): skip VERTEX_SA_JSON parsing in proxy mode

### DIFF
--- a/tools/agents/shared/auth/auth.go
+++ b/tools/agents/shared/auth/auth.go
@@ -25,7 +25,8 @@ func ResolveFromEnv() (*Config, error) {
 		config.SACredential = []byte(saJSON)
 	}
 
-	if config.ProjectID == "" && len(config.SACredential) > 0 {
+	// Only parse SA JSON for project_id when not in proxy mode
+	if config.APIKey == "" && config.ProjectID == "" && len(config.SACredential) > 0 {
 		var serviceAccount struct {
 			ProjectID string `json:"project_id"`
 		}

--- a/tools/agents/shared/auth/auth_test.go
+++ b/tools/agents/shared/auth/auth_test.go
@@ -73,6 +73,21 @@ func TestResolveFromEnv_InvalidSAJSON(t *testing.T) {
 	}
 }
 
+func TestResolveFromEnv_ProxyModeIgnoresBadSAJSON(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "sk-test-key")
+	t.Setenv("ANTHROPIC_BASE_URL", "http://localhost:8443/v1")
+	t.Setenv("ANTHROPIC_VERTEX_PROJECT_ID", "")
+	t.Setenv("VERTEX_SA_JSON", `{"type":"authorized_user"}`)
+
+	config, err := ResolveFromEnv()
+	if err != nil {
+		t.Fatalf("proxy mode should not fail on SA JSON without project_id: %v", err)
+	}
+	if config.APIKey != "sk-test-key" {
+		t.Errorf("APIKey = %q", config.APIKey)
+	}
+}
+
 func TestResolveFromEnv_DefaultRegion(t *testing.T) {
 	t.Setenv("ANTHROPIC_VERTEX_PROJECT_ID", "my-project")
 	t.Setenv("CLOUD_ML_REGION", "")


### PR DESCRIPTION
Alcove injects both ANTHROPIC_API_KEY (proxy) and VERTEX_SA_JSON, but the SA JSON lacks project_id. In proxy mode the agent doesn't need project_id — the gate handles Vertex AI auth. Fix: only parse SA JSON when not in proxy mode.

---
Assisted-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

## Summary by Sourcery

Handle Vertex SA JSON parsing only in non-proxy mode to avoid auth resolution failures when using the Anthropic proxy.

Bug Fixes:
- Prevent ResolveFromEnv from failing when running in proxy mode with a malformed or incomplete VERTEX_SA_JSON.

Tests:
- Add a regression test verifying that proxy mode ignores bad or missing project_id in VERTEX_SA_JSON while still resolving the API key.