### PR TITLE
Upgrade pulp-maven to 0.21.0

### DIFF
--- a/pulp_service/requirements.txt
+++ b/pulp_service/requirements.txt
@@ -4,7 +4,7 @@ solv>=0.7.21,<0.7.38
 pulp-python==3.30.3
 pulp-npm==0.8.0
 pulp-container==2.28.0
-pulp-maven==0.20.0
+pulp-maven==0.21.0
 pulp-hugging-face==0.3.0
 pulp-cli
 requests


### PR DESCRIPTION
* Add repair_metadata API endpoint to regenerate all maven-metadata.xml and checksum files for a Maven repository.
* Auto-generate maven-metadata.xml and checksum files (.md5, .sha1, .sha256) in finalize_new_version when artifacts are added or removed from a repository version.
* Pull-through cache no longer saves maven-metadata.xml and its checksum sidecar files as persistent content. These files are now streamed directly from the remote so clients always get fresh metadata.