### PR TITLE
fix(agent-alertmanager): update release to 20260706-0f236fc

### DIFF
--- a/.alcove/agents/alertmanager-analyzer.yml
+++ b/.alcove/agents/alertmanager-analyzer.yml
@@ -5,7 +5,7 @@ description: |
   Jira issues. Runs as a pre-compiled agent binary from GitHub Releases.
 
 executable:
-  url: https://github.com/pulp/pulp-service/releases/download/agent-alertmanager-20260617-3ee37a3/agent-alertmanager
+  url: https://github.com/pulp/pulp-service/releases/download/agent-alertmanager-20260706-0f236fc/agent-alertmanager
   args: ["--model", "claude-sonnet-4-6"]
   env:
     JIRA_URL: "https://redhat.atlassian.net/"


### PR DESCRIPTION
Fixes agent crash on Alcove — proxy mode auth was failing because VERTEX_SA_JSON parsing wasn't skipped when ANTHROPIC_API_KEY was set.

Release: https://github.com/pulp/pulp-service/releases/tag/agent-alertmanager-20260706-0f236fc

---
Assisted-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

## Summary by Sourcery

Enhancements:
- Point the alertmanager analyzer agent executable URL to the 20260706-0f236fc release for crash and auth handling fixes.