### PR TITLE
fix(tests): fix lightwell readonly group permission tests

### DIFF
--- a/pulp_service/pulp_service/tests/functional/constants.py
+++ b/pulp_service/pulp_service/tests/functional/constants.py
@@ -43,7 +43,7 @@ CONTENT_GUARD_FILTER = ".identity.org_id"
 # "lightwell" domain's PyPI views. These are real staging Features Service accounts.
 LIGHTWELL_NETWORK_FEATURE = "lightwell-network"
 LIGHTWELL_ENTITLED_ORG_ID = "20368420"  # has the lightwell-network feature
-LIGHTWELL_NOT_ENTITLED_ORG_ID = "1979710"  # does not have the lightwell-network feature
+LIGHTWELL_NOT_ENTITLED_ORG_ID = "11111111"  # does not have the lightwell-network feature
 
 # VULNERABILITY REPORT CONSTANTS
 # NPM

--- a/pulp_service/pulp_service/tests/functional/test_lightwell_readonly_group_permission.py
+++ b/pulp_service/pulp_service/tests/functional/test_lightwell_readonly_group_permission.py
@@ -133,7 +133,12 @@ def gen_readonly_group_member(pulpcore_bindings, gen_object_with_cleanup, lightw
         combined_username = _combined_username(GROUP_MEMBER_ORG_ID, username)
         gen_object_with_cleanup(
             pulpcore_bindings.UsersApi,
-            {"username": combined_username, "groups": [lightwell_readonly_group.pulp_href]},
+            {"username": combined_username},
+        )
+        gen_object_with_cleanup(
+            pulpcore_bindings.GroupsUsersApi,
+            group_href=lightwell_readonly_group.pulp_href,
+            group_user={"username": combined_username},
         )
         return _identity_header(GROUP_MEMBER_ORG_ID, username)
 
@@ -219,16 +224,16 @@ def test_readonly_group_member_denied_on_other_domains(
 
 
 def test_readonly_group_member_sees_lightwell_domain_in_listing(
-    configure_lightwell_domain, gen_readonly_group_member, bindings_cfg
+    configure_lightwell_domain, gen_readonly_group_member, pulpcore_bindings, anonymous_user
 ):
     """The lightwell domain shows up in GET /domains/ for read-only group members, via
     DomainBasedPermission.scope_queryset()."""
     del configure_lightwell_domain  # ensure the "lightwell" domain exists
-    headers = {"x-rh-identity": gen_readonly_group_member("domain-list")}
-    domains_url = urljoin(bindings_cfg.host, "/api/pulp/api/v3/domains/")
+    member_header = gen_readonly_group_member("domain-list")
 
-    response = requests.get(domains_url, headers=headers, timeout=30)
+    with anonymous_user:
+        pulpcore_bindings.DomainsApi.api_client.default_headers["x-rh-identity"] = member_header
+        response = pulpcore_bindings.DomainsApi.list()
 
-    assert response.status_code == 200
-    domain_names = {domain["name"] for domain in response.json()["results"]}
+    domain_names = {domain.name for domain in response.results}
     assert LIGHTWELL_DOMAIN_NAME in domain_names


### PR DESCRIPTION
Use GroupsUsersApi to explicitly add users to the read-only group instead of passing groups during UsersApi creation (which is silently ignored by pulpcore's UserSerializer). Use DomainsApi bindings for domain listing instead of a manually-constructed URL that 404s when DOMAIN_ENABLED=True.

## Summary by Sourcery

Update Lightwell read-only group permission tests to correctly assign users to the read-only group and to use typed domain listing APIs.

Tests:
- Fix read-only group member generation by explicitly adding users to the Lightwell read-only group via GroupsUsersApi.
- Update domain listing test to use DomainsApi bindings under an anonymous user context instead of manual HTTP requests to a hard-coded URL.