### PR TITLE
chore(agent-alertmanager): update release to 20260706-285a73c

### DIFF
--- a/.alcove/agents/alertmanager-analyzer.yml
+++ b/.alcove/agents/alertmanager-analyzer.yml
@@ -5,7 +5,7 @@ description: |
   Jira issues. Runs as a pre-compiled agent binary from GitHub Releases.
 
 executable:
-  url: https://github.com/pulp/pulp-service/releases/download/agent-alertmanager-20260706-0f236fc/agent-alertmanager
+  url: https://github.com/pulp/pulp-service/releases/download/agent-alertmanager-20260706-285a73c/agent-alertmanager
   args: ["--model", "claude-sonnet-5"]
   env:
     JIRA_URL: "https://redhat.atlassian.net/"


### PR DESCRIPTION
Release with proxy mode auth + Sonnet 5. Fixes agent crash on Alcove.

Release: https://github.com/pulp/pulp-service/releases/tag/agent-alertmanager-20260706-285a73c

---
Assisted-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

## Summary by Sourcery

Chores:
- Bump agent-alertmanager analyzer binary URL to the 20260706-285a73c release build.