### PR TITLE
Upgrade pulp-maven to 0.21.2

### DIFF
--- a/pulp_service/requirements.txt
+++ b/pulp_service/requirements.txt
@@ -4,7 +4,7 @@ solv>=0.7.21,<0.7.38
 pulp-python==3.30.3
 pulp-npm==0.8.0
 pulp-container==2.28.0
-pulp-maven==0.21.0
+pulp-maven==0.21.2
 pulp-hugging-face==0.3.0
 pulp-cli
 requests


### PR DESCRIPTION
* Fixed repair_metadata not removing orphaned metadata for (group_id, artifact_id) pairs that no longer have any corresponding MavenArtifact in the repository. Previously it returned early when no artifacts existed and only cleaned up version=None metadata, leaving version-level metadata behind.
* Fixed repair_metadata failing with AssertionError in pulpcore's _compute_counts() due to finalize_new_version redundantly running _generate_metadata after repair_metadata had already managed all metadata content in the repository version.