### PR TITLE
Upgrade pulp-maven to 0.22.1

### DIFF
--- a/pulp_service/requirements.txt
+++ b/pulp_service/requirements.txt
@@ -4,7 +4,7 @@ solv>=0.7.21,<0.7.38
 pulp-python==3.30.3
 pulp-npm==0.8.0
 pulp-container==2.28.0
-pulp-maven==0.22.0
+pulp-maven==0.22.1
 pulp-hugging-face==0.3.0
 pulp-cli
 requests


### PR DESCRIPTION
* Materialized stale metadata querysets before passing them to remove_content to prevent content_ids/RepositoryContent mismatch on repositories with >= 65,535 content items.