### PR TITLE
fix: patch RepositoryVersion.remove_content re-evaluation bug (pulpco…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -150,6 +150,8 @@ RUN patch -p1 -d /usr/local/lib/pulp/lib/python${PYTHON_VERSION}/site-packages <
 COPY images/assets/patches/0058-fix-migrate.patch /tmp/
 RUN patch -p1 -d /usr/local/lib/pulp/lib/python${PYTHON_VERSION}/site-packages < /tmp/0058-fix-migrate.patch
 
+COPY images/assets/patches/0059-update-repo-version-remove-content.patch /tmp/
+RUN patch -p1 -d /usr/local/lib/pulp/lib/python${PYTHON_VERSION}/site-packages < /tmp/0059-update-repo-version-remove-content.patch
 
 RUN mkdir /licenses
 COPY LICENSE /licenses/LICENSE

--- a/images/assets/patches/0059-update-repo-version-remove-content.patch
+++ b/images/assets/patches/0059-update-repo-version-remove-content.patch
@@ -1,0 +1,20 @@
+diff --git a/pulpcore/app/models/repository.py b/pulpcore/app/models/repository.py
+index 5cbc51bef..10f661f62 100644
+--- a/pulpcore/app/models/repository.py
++++ b/pulpcore/app/models/repository.py
+@@ -1245,13 +1245,13 @@ class RepositoryVersion(BaseModel):
+             # Undo addition by deleting the RepositoryContent.
+             RepositoryContent.objects.filter(
+                 repository=self.repository,
+-                content_id__in=content,
++                content_id__in=to_remove,
+                 version_added=self,
+                 version_removed=None,
+             ).delete()
+ 
+             q_set = RepositoryContent.objects.filter(
+-                repository=self.repository, content_id__in=content, version_removed=None
++                repository=self.repository, content_id__in=to_remove, version_removed=None
+             )
+             q_set.update(version_removed=self)
+ 


### PR DESCRIPTION
…re#7851)

When a repository version has >= 65,535 content items, remove_content() re-evaluates the content queryset after self.save() updates content_ids in the DB. The subsequent RepositoryContent delete/update queries resolve to empty, leaving orphaned entries and failing the _compute_counts assertion.

Use the already-materialized `to_remove` set instead of re-evaluating the `content` queryset for the RepositoryContent queries.

## Summary by Sourcery

Apply a patch to correct RepositoryVersion.remove_content behavior for large repositories and ensure content removal is handled correctly.

Bug Fixes:
- Fix incorrect re-evaluation of RepositoryVersion.remove_content queries that left orphaned RepositoryContent entries for versions with very large content sets.

Build:
- Update Dockerfile to include and apply the new 0059-update-repo-version-remove-content.patch to the Pulp Python site-packages.