### PR TITLE
fix: strengthen plan-reviewer output writing prompt

### DIFF
--- a/.alcove/agents/plan-reviewer.yml
+++ b/.alcove/agents/plan-reviewer.yml
@@ -4,7 +4,7 @@ description: |
   correctness, and actionability. Read-only — surfaces problems but
   never modifies the plan directly.
 
-model: sonnet
+model: claude-sonnet-5
 
 prompt: |
   You are a critical reviewer of implementation plans for the pulp-service
@@ -79,18 +79,22 @@ prompt: |
   - approved: "true" if no 🔴 Blocking findings, "false" if any exist
   - feedback: your findings as a single string
 
-  Then run EXACTLY this (replace the values):
+  Then run this script. The heredoc handles quotes and newlines safely:
 
-    python3 -c "
+    python3 - <<'PYEOF'
     import json
-    output = {'approved': 'true', 'feedback': 'No issues found.'}
-    open('/tmp/alcove-outputs.json', 'w').write(json.dumps(output))
-    print('Outputs written:', output)
-    "
+    output = {
+        "approved": "true",
+        "feedback": "Your findings here. Can span multiple lines."
+    }
+    with open("/tmp/alcove-outputs.json", "w") as f:
+        json.dump(output, f)
+    print("OUTPUTS WRITTEN:", json.dumps(output)[:200])
+    PYEOF
 
-  Replace 'true'/'false' and the feedback string with your actual values.
-  For multi-line feedback, use \\n for newlines inside the string.
+  Replace "true"/"false" and the feedback value with your actual findings.
   ALL values MUST be strings — not booleans, not lists.
+  Verify "OUTPUTS WRITTEN:" appears in the terminal before ending your turn.
 
 repos:
   - name: pulp-service

--- a/.alcove/agents/plan-reviewer.yml
+++ b/.alcove/agents/plan-reviewer.yml
@@ -60,21 +60,37 @@ prompt: |
   - If there are ANY 🔴 Blocking findings: set approved to "false"
   - If there are only 🟡 and 💡 findings: set approved to "true"
     (include the findings so the planner can incorporate them)
+  - If there are NO findings at all: set approved to "true" with
+    feedback "No issues found."
 
-  CRITICAL — YOUR VERY LAST ACTION must be writing outputs to the pipeline file.
-  Use Python to safely serialize (handles quotes and newlines):
+  ## Workflow
 
-    python3 - <<'PYEOF'
+  1. Read the plan and the ticket description
+  2. Read relevant source code to verify the plan's claims
+  3. Produce your findings using the severity format above
+  4. Write the outputs file (step 4 is MANDATORY — the workflow fails without it)
+
+  ## Writing Outputs (MANDATORY)
+
+  You MUST run this Python script as your VERY LAST ACTION. The workflow
+  cannot proceed without it. If you skip this step, the entire pipeline fails.
+
+  First, decide your values:
+  - approved: "true" if no 🔴 Blocking findings, "false" if any exist
+  - feedback: your findings as a single string
+
+  Then run EXACTLY this (replace the values):
+
+    python3 -c "
     import json
-    output = {
-        "approved": "true",  # or "false"
-        "feedback": """Your findings here.
-    Can span multiple lines safely."""
-    }
-    # ALL values MUST be strings. Non-string values silently discard ALL outputs.
-    with open("/tmp/alcove-outputs.json", "w") as f:
-        json.dump(output, f)
-    PYEOF
+    output = {'approved': 'true', 'feedback': 'No issues found.'}
+    open('/tmp/alcove-outputs.json', 'w').write(json.dumps(output))
+    print('Outputs written:', output)
+    "
+
+  Replace 'true'/'false' and the feedback string with your actual values.
+  For multi-line feedback, use \\n for newlines inside the string.
+  ALL values MUST be strings — not booleans, not lists.
 
 repos:
   - name: pulp-service

--- a/.alcove/agents/planner.yml
+++ b/.alcove/agents/planner.yml
@@ -54,32 +54,35 @@ prompt: |
 
   ## Plan Format
 
-  Your output must follow this structure:
+  Your output will be posted as a Jira comment. Jira does NOT render
+  markdown — no #, *, -, ```, or []() syntax. Use plain text with
+  clear structure:
 
   ```
-  ## Implementation Plan
-  *Generated: YYYY-MM-DD by SDLC Planner*
+  IMPLEMENTATION PLAN
+  Generated: YYYY-MM-DD by SDLC Planner
 
-  ### Summary
+  SUMMARY
   [1-3 sentence overview of the approach]
 
-  ### Team Analysis
+  TEAM ANALYSIS
   [Key findings from each specialist perspective — NOT exhaustive,
-   only the non-obvious insights and concerns]
+   only the non-obvious insights and concerns. Use "Architect:" ,
+   "Security:", etc. prefixes for each perspective.]
 
-  ### Work Breakdown
-  [Ordered list of implementation steps, each with:]
-  - [ ] Step title
-    - Files/components affected
-    - Risk level (low/medium/high)
-    - Dependencies on other steps
-    - Estimated complexity
+  WORK BREAKDOWN
+  [Numbered list of implementation steps, each with:]
+  1) Step title
+     Files: list of files/components affected
+     Risk: low/medium/high
+     Dependencies: other steps this depends on
+     Complexity: estimate
 
-  ### Open Questions
-  [Things the team needs human input on before proceeding]
+  OPEN QUESTIONS
+  [Numbered list of things the team needs human input on]
 
-  ### Risks & Mitigations
-  [Top risks identified by Red Team + DevOps + QA]
+  RISKS AND MITIGATIONS
+  [Numbered list of top risks with mitigations]
   ```
 
   ## Rules


### PR DESCRIPTION
## Summary

The Plan Reviewer agent wasn't reliably writing `/tmp/alcove-outputs.json`, causing output contract violations (`required output field 'approved' is missing`). The planner workflow's reflection loop always fell through to the failure path.

## Changes

- Added explicit numbered workflow steps so the agent knows the sequence
- Simplified Python from heredoc to a one-liner — heredocs are less reliable in Sonnet sessions
- Added `print()` confirmation so the agent sees the output was written
- Made MANDATORY nature more prominent with a separate section header
- Added "no findings" case — prevents the agent from skipping outputs when the plan looks good

## Test plan

- [ ] Trigger Jira planner on a PULP ticket with `needs-planning` label
- [ ] Verify the reviewer writes outputs and the workflow reaches `post-plan` or `post-revised-plan` instead of `post-failure`

## Summary by Sourcery

Strengthen the plan reviewer agent prompt to reliably produce required outputs for the planner workflow.

Enhancements:
- Clarify the reviewer workflow with explicit numbered steps and a dedicated mandatory outputs section.
- Update the outputs-writing instructions to a simpler, more reliable Python one-liner with explicit guidance on approved/feedback values and newline handling.
- Add support for a "no findings" case so plans without issues still generate compliant outputs.