### PR TITLE
feat: extend DomainBasedPermission to check lightwell subscription via Feature Service

### DIFF
--- a/pulp_service/pulp_service/app/authorization.py
+++ b/pulp_service/pulp_service/app/authorization.py
@@ -5,7 +5,6 @@ from binascii import Error as Base64DecodeError
 from contextvars import ContextVar
 
 import jq
-from django.conf import settings
 from django.db.models import Q
 from django.http import Http404
 from rest_framework.permissions import SAFE_METHODS, BasePermission
@@ -32,6 +31,9 @@ LIGHTWELL_DOMAIN_NAME = "lightwell"
 # NOT grant write access, and it does NOT apply to PyPI views, which are gated
 # by the distribution's content guard (see _check_pypi_safe_method_access()).
 LIGHTWELL_READONLY_GROUP_NAME = "Lightwell-ReadOnly"
+# Fixed identifier in the Features Service; checked by _check_lightwell_subscription() to
+# gate content listing access for orgs with an active lightwell subscription.
+LIGHTWELL_FEATURE_NAME = "lightwell-network"
 
 
 class DomainBasedPermission(BasePermission):
@@ -66,6 +68,7 @@ class DomainBasedPermission(BasePermission):
         return user.is_authenticated and user.groups.filter(name=LIGHTWELL_READONLY_GROUP_NAME).exists()
 
     def _is_content_listing_request(self, request):
+        # Substring match: content endpoints span multiple plugins with no shared mixin (unlike PyPI).
         return "/api/v3/content/" in request.META.get("PATH_INFO", "")
 
     def _check_lightwell_subscription(self, request, domain):
@@ -79,12 +82,12 @@ class DomainBasedPermission(BasePermission):
         if org_id is None:
             return None
 
-        guard = FeatureContentGuard(features=[settings.LIGHTWELL_FEATURE_NAME])
+        guard = FeatureContentGuard(features=[LIGHTWELL_FEATURE_NAME])
         try:
             if guard.check_feature(org_id):
                 return True
-        except PermissionError:
-            pass
+        except Exception:
+            _logger.exception("Unexpected error checking lightwell subscription")
         return None
 
     def _check_pypi_safe_method_access(self, request, view, domain):  # noqa: PLR0911

--- a/pulp_service/pulp_service/app/authorization.py
+++ b/pulp_service/pulp_service/app/authorization.py
@@ -68,8 +68,10 @@ class DomainBasedPermission(BasePermission):
         return user.is_authenticated and user.groups.filter(name=LIGHTWELL_READONLY_GROUP_NAME).exists()
 
     def _is_content_listing_request(self, request):
-        # Substring match: content endpoints span multiple plugins with no shared mixin (unlike PyPI).
-        return "/api/v3/content/" in request.META.get("PATH_INFO", "")
+        # view_name (not isinstance) because BaseContentViewSet is not in pulpcore's public
+        # plugin API, and the public subclasses miss ListContentViewSet.
+        view_name = getattr(request.resolver_match, "view_name", None)
+        return view_name is not None and view_name.startswith("content-")
 
     def _check_lightwell_subscription(self, request, domain):
         if not (domain and domain.name == LIGHTWELL_DOMAIN_NAME):

--- a/pulp_service/pulp_service/app/authorization.py
+++ b/pulp_service/pulp_service/app/authorization.py
@@ -5,6 +5,7 @@ from binascii import Error as Base64DecodeError
 from contextvars import ContextVar
 
 import jq
+from django.conf import settings
 from django.db.models import Q
 from django.http import Http404
 from rest_framework.permissions import SAFE_METHODS, BasePermission
@@ -12,7 +13,7 @@ from rest_framework.permissions import SAFE_METHODS, BasePermission
 from pulpcore.plugin.models import Domain
 from pulpcore.plugin.util import extract_pk, get_domain_pk
 
-from pulp_service.app.models import DomainOrg
+from pulp_service.app.models import DomainOrg, FeatureContentGuard
 
 _logger = logging.getLogger(__name__)
 org_id_var = ContextVar("org_id")
@@ -63,6 +64,28 @@ class DomainBasedPermission(BasePermission):
         scope_queryset() for where this is applied.
         """
         return user.is_authenticated and user.groups.filter(name=LIGHTWELL_READONLY_GROUP_NAME).exists()
+
+    def _is_content_listing_request(self, request):
+        return "/api/v3/content/" in request.META.get("PATH_INFO", "")
+
+    def _check_lightwell_subscription(self, request, domain):
+        if not (domain and domain.name == LIGHTWELL_DOMAIN_NAME):
+            return None
+        if not self._is_content_listing_request(request):
+            return None
+
+        decoded_header = self.get_decoded_identity_header(request)
+        org_id = self.get_org_id(decoded_header)
+        if org_id is None:
+            return None
+
+        guard = FeatureContentGuard(features=[settings.LIGHTWELL_FEATURE_NAME])
+        try:
+            if guard.check_feature(org_id):
+                return True
+        except PermissionError:
+            pass
+        return None
 
     def _check_pypi_safe_method_access(self, request, view, domain):  # noqa: PLR0911
         """
@@ -142,6 +165,10 @@ class DomainBasedPermission(BasePermission):
         pypi_access = self._check_pypi_safe_method_access(request, view, domain)
         if pypi_access is not None:
             return pypi_access
+
+        subscription_access = self._check_lightwell_subscription(request, domain)
+        if subscription_access is not None:
+            return subscription_access
 
         if domain and domain.name == LIGHTWELL_DOMAIN_NAME and self._has_lightwell_readonly_group_access(user):
             return True

--- a/pulp_service/pulp_service/app/settings.py
+++ b/pulp_service/pulp_service/app/settings.py
@@ -18,6 +18,7 @@ FEATURE_SERVICE_API_CERT_PATH = ""
 FEATURE_SERVICE_API_CONNECT_TIMEOUT = 2
 FEATURE_SERVICE_API_READ_TIMEOUT = 5
 AUTHENTICATION_HEADER_DEBUG = False
+LIGHTWELL_FEATURE_NAME = "lightwell-network"
 INSTALLED_APPS = "@merge django.contrib.admin.apps.SimpleAdminConfig,hijack,hijack.contrib.admin"
 TEST_TASK_INGESTION = False
 LOGIN_REDIRECT_URL = "/api/pulp-mgmt/"

--- a/pulp_service/pulp_service/app/settings.py
+++ b/pulp_service/pulp_service/app/settings.py
@@ -18,7 +18,6 @@ FEATURE_SERVICE_API_CERT_PATH = ""
 FEATURE_SERVICE_API_CONNECT_TIMEOUT = 2
 FEATURE_SERVICE_API_READ_TIMEOUT = 5
 AUTHENTICATION_HEADER_DEBUG = False
-LIGHTWELL_FEATURE_NAME = "lightwell-network"
 INSTALLED_APPS = "@merge django.contrib.admin.apps.SimpleAdminConfig,hijack,hijack.contrib.admin"
 TEST_TASK_INGESTION = False
 LOGIN_REDIRECT_URL = "/api/pulp-mgmt/"

--- a/pulp_service/pulp_service/tests/functional/test_lightwell_content_listing_permission.py
+++ b/pulp_service/pulp_service/tests/functional/test_lightwell_content_listing_permission.py
@@ -24,6 +24,7 @@ from uuid import uuid4
 import pytest
 import requests
 
+from pulp_service.app.authorization import LIGHTWELL_READONLY_GROUP_NAME
 from pulp_service.tests.functional.constants import (
     LIGHTWELL_ENTITLED_ORG_ID,
     LIGHTWELL_NOT_ENTITLED_ORG_ID,
@@ -32,6 +33,11 @@ from pulp_service.tests.functional.constants import (
 LIGHTWELL_DOMAIN_NAME = "lightwell"
 
 DOMAIN_OWNER_ORG_ID = "555555555"
+GROUP_MEMBER_ORG_ID = "666666666"
+
+
+def _combined_username(org_id, username):
+    return f"{org_id}|{username}"
 
 
 def _identity_header(org_id, username):
@@ -137,3 +143,86 @@ def test_domain_owner_can_list_content(configure_lightwell_domain):
     response = requests.get(content_url, headers=headers, timeout=30)
 
     assert response.status_code == 200
+
+
+def test_entitled_org_post_denied_on_content_endpoint(configure_lightwell_domain):
+    """A subscribed user cannot POST to a content listing endpoint -- the subscription check
+    only applies to SAFE_METHODS (GET/HEAD/OPTIONS)."""
+    content_url, _, _ = configure_lightwell_domain
+    headers = {"x-rh-identity": _identity_header(LIGHTWELL_ENTITLED_ORG_ID, "entitled-post-user")}
+
+    response = requests.post(content_url, headers=headers, json={}, timeout=30)
+
+    assert response.status_code in (401, 403)
+
+
+@pytest.fixture
+def lightwell_readonly_group(gen_group):
+    return gen_group(name=LIGHTWELL_READONLY_GROUP_NAME)
+
+
+@pytest.fixture
+def gen_readonly_group_member(pulpcore_bindings, gen_object_with_cleanup, lightwell_readonly_group):
+    def _gen_member(username_suffix):
+        username = f"readonly-member-{username_suffix}-{uuid4()}"
+        combined_username = _combined_username(GROUP_MEMBER_ORG_ID, username)
+        gen_object_with_cleanup(
+            pulpcore_bindings.UsersApi,
+            {"username": combined_username},
+        )
+        pulpcore_bindings.GroupsUsersApi.create(
+            group_href=lightwell_readonly_group.pulp_href,
+            group_user={"username": combined_username},
+        )
+        return _identity_header(GROUP_MEMBER_ORG_ID, username)
+
+    return _gen_member
+
+
+def test_readonly_group_member_without_subscription_can_list_content(
+    configure_lightwell_domain, gen_readonly_group_member
+):
+    """A user in the Lightwell-ReadOnly group whose org does not have the lightwell-network
+    feature can still list content via the group-based fallback path."""
+    content_url, _, _ = configure_lightwell_domain
+    headers = {"x-rh-identity": gen_readonly_group_member("content-list")}
+
+    response = requests.get(content_url, headers=headers, timeout=30)
+
+    assert response.status_code == 200
+
+
+def test_entitled_org_denied_on_non_lightwell_domain(
+    pulpcore_bindings, file_bindings, anonymous_user, gen_object_with_cleanup, bindings_cfg
+):
+    """A subscribed user hitting /api/v3/content/ on a non-lightwell domain without a
+    DomainOrg association gets 403 -- the subscription check is scoped to the lightwell
+    domain name."""
+    other_domain_owner_header = _identity_header("777777777", "other-domain-owner")
+    domain_name = f"not-lightwell-{uuid4()}"
+
+    with anonymous_user:
+        pulpcore_bindings.DomainsApi.api_client.default_headers["x-rh-identity"] = other_domain_owner_header
+        gen_object_with_cleanup(
+            pulpcore_bindings.DomainsApi,
+            {
+                "name": domain_name,
+                "storage_class": "pulpcore.app.models.storage.FileSystem",
+                "storage_settings": {"MEDIA_ROOT": "/var/lib/pulp/media/"},
+            },
+        )
+
+        file_bindings.RepositoriesFileApi.api_client.default_headers["x-rh-identity"] = other_domain_owner_header
+        gen_object_with_cleanup(
+            file_bindings.RepositoriesFileApi, {"name": str(uuid4())}, pulp_domain=domain_name
+        )
+
+    content_url = urljoin(bindings_cfg.host, f"/api/pulp/{domain_name}/api/v3/content/file/files/")
+    headers = {"x-rh-identity": _identity_header(LIGHTWELL_ENTITLED_ORG_ID, "entitled-wrong-domain-user")}
+
+    response = requests.get(content_url, headers=headers, timeout=30)
+
+    assert response.status_code == 403
+
+    pulpcore_bindings.DomainsApi.api_client.default_headers.pop("x-rh-identity", None)
+    file_bindings.RepositoriesFileApi.api_client.default_headers.pop("x-rh-identity", None)

--- a/pulp_service/pulp_service/tests/functional/test_lightwell_content_listing_permission.py
+++ b/pulp_service/pulp_service/tests/functional/test_lightwell_content_listing_permission.py
@@ -213,9 +213,7 @@ def test_entitled_org_denied_on_non_lightwell_domain(
         )
 
         file_bindings.RepositoriesFileApi.api_client.default_headers["x-rh-identity"] = other_domain_owner_header
-        gen_object_with_cleanup(
-            file_bindings.RepositoriesFileApi, {"name": str(uuid4())}, pulp_domain=domain_name
-        )
+        gen_object_with_cleanup(file_bindings.RepositoriesFileApi, {"name": str(uuid4())}, pulp_domain=domain_name)
 
     content_url = urljoin(bindings_cfg.host, f"/api/pulp/{domain_name}/api/v3/content/file/files/")
     headers = {"x-rh-identity": _identity_header(LIGHTWELL_ENTITLED_ORG_ID, "entitled-wrong-domain-user")}

--- a/pulp_service/pulp_service/tests/functional/test_lightwell_content_listing_permission.py
+++ b/pulp_service/pulp_service/tests/functional/test_lightwell_content_listing_permission.py
@@ -1,0 +1,139 @@
+"""
+Functional tests for the subscription-based content listing access check enforced by
+DomainBasedPermission on content listing APIs in the lightwell domain. When the
+authenticated user's org has the lightwell-network feature (verified via Features Service),
+SAFE_METHOD access is granted to content listing endpoints (/api/v3/content/...) even
+without a DomainOrg association or Lightwell-ReadOnly group membership.
+
+These follow the pattern used in test_content_guard_permission.py: they exercise the real
+Features Service (no mocking) using known staging accounts. Org LIGHTWELL_ENTITLED_ORG_ID
+has the lightwell-network feature; org LIGHTWELL_NOT_ENTITLED_ORG_ID does not.
+
+NOTE: like test_lightwell_readonly_group_permission.py, this is keyed off the literal
+domain name "lightwell" (see pulp_service.app.authorization.LIGHTWELL_DOMAIN_NAME), so the
+domain created here can't use a random per-test suffix. These tests assume they run against
+an ephemeral Pulp instance where no "lightwell" domain already exists, and are not run
+concurrently with other tests that also create a "lightwell" domain.
+"""
+
+import json
+from base64 import b64encode
+from urllib.parse import urljoin
+from uuid import uuid4
+
+import pytest
+import requests
+
+from pulp_service.tests.functional.constants import (
+    LIGHTWELL_ENTITLED_ORG_ID,
+    LIGHTWELL_NOT_ENTITLED_ORG_ID,
+)
+
+LIGHTWELL_DOMAIN_NAME = "lightwell"
+
+DOMAIN_OWNER_ORG_ID = "555555555"
+
+
+def _identity_header(org_id, username):
+    identity = {
+        "identity": {
+            "org_id": org_id,
+            "internal": {"org_id": org_id},
+            "user": {"username": username},
+        }
+    }
+    return b64encode(json.dumps(identity).encode()).decode()
+
+
+@pytest.fixture
+def configure_lightwell_domain(
+    anonymous_user,
+    gen_object_with_cleanup,
+    pulpcore_bindings,
+    file_bindings,
+    bindings_cfg,
+):
+    """
+    Creates the "lightwell" domain (owned by DOMAIN_OWNER_ORG_ID), with a File repository.
+
+    Returns (content_url, repos_url, owner_header).
+    """
+    owner_header = _identity_header(DOMAIN_OWNER_ORG_ID, "lightwell-content-listing-test-owner")
+
+    with anonymous_user:
+        pulpcore_bindings.DomainsApi.api_client.default_headers["x-rh-identity"] = owner_header
+
+        gen_object_with_cleanup(
+            pulpcore_bindings.DomainsApi,
+            {
+                "name": LIGHTWELL_DOMAIN_NAME,
+                "storage_class": "pulpcore.app.models.storage.FileSystem",
+                "storage_settings": {"MEDIA_ROOT": "/var/lib/pulp/media/"},
+            },
+        )
+
+        file_bindings.RepositoriesFileApi.api_client.default_headers["x-rh-identity"] = owner_header
+        gen_object_with_cleanup(
+            file_bindings.RepositoriesFileApi, {"name": str(uuid4())}, pulp_domain=LIGHTWELL_DOMAIN_NAME
+        )
+
+    content_url = urljoin(bindings_cfg.host, f"/api/pulp/{LIGHTWELL_DOMAIN_NAME}/api/v3/content/file/files/")
+    repos_url = urljoin(bindings_cfg.host, f"/api/pulp/{LIGHTWELL_DOMAIN_NAME}/api/v3/repositories/file/file/")
+
+    yield content_url, repos_url, owner_header
+
+    pulpcore_bindings.DomainsApi.api_client.default_headers.pop("x-rh-identity", None)
+    file_bindings.RepositoriesFileApi.api_client.default_headers.pop("x-rh-identity", None)
+
+
+def test_entitled_org_can_list_content(configure_lightwell_domain):
+    """A user whose org has the lightwell-network feature can list content in the lightwell
+    domain, even without a DomainOrg association or read-only group membership."""
+    content_url, _, _ = configure_lightwell_domain
+    headers = {"x-rh-identity": _identity_header(LIGHTWELL_ENTITLED_ORG_ID, "entitled-content-user")}
+
+    response = requests.get(content_url, headers=headers, timeout=30)
+
+    assert response.status_code == 200
+
+
+def test_non_entitled_org_denied_content_listing(configure_lightwell_domain):
+    """A user whose org does not have the lightwell-network feature and has no DomainOrg
+    association gets 403 on content listing in the lightwell domain."""
+    content_url, _, _ = configure_lightwell_domain
+    headers = {"x-rh-identity": _identity_header(LIGHTWELL_NOT_ENTITLED_ORG_ID, "not-entitled-content-user")}
+
+    response = requests.get(content_url, headers=headers, timeout=30)
+
+    assert response.status_code == 403
+
+
+def test_entitled_org_denied_on_non_content_endpoints(configure_lightwell_domain):
+    """The subscription check only applies to content listing endpoints -- an entitled org
+    with no DomainOrg association is still denied on repository listing."""
+    _, repos_url, _ = configure_lightwell_domain
+    headers = {"x-rh-identity": _identity_header(LIGHTWELL_ENTITLED_ORG_ID, "entitled-repo-user")}
+
+    response = requests.get(repos_url, headers=headers, timeout=30)
+
+    assert response.status_code == 403
+
+
+def test_unauthenticated_denied_content_listing(configure_lightwell_domain):
+    """Without any identity header, content listing in the lightwell domain is denied."""
+    content_url, _, _ = configure_lightwell_domain
+
+    response = requests.get(content_url, timeout=30)
+
+    assert response.status_code in (401, 403)
+
+
+def test_domain_owner_can_list_content(configure_lightwell_domain):
+    """The domain owner (via DomainOrg association) can list content regardless of
+    subscription status."""
+    content_url, _, owner_header = configure_lightwell_domain
+    headers = {"x-rh-identity": owner_header}
+
+    response = requests.get(content_url, headers=headers, timeout=30)
+
+    assert response.status_code == 200


### PR DESCRIPTION
## Summary by Sourcery

Integrate subscription-based access checks for Lightwell domain content listing into DomainBasedPermission using the feature service, and add configuration plus functional coverage for this behavior.

New Features:
- Grant SAFE_METHOD content listing access in the Lightwell domain when the requesting org has the configured Lightwell feature via the feature service, independent of DomainOrg or read-only group membership.

Enhancements:
- Introduce a helper to detect Lightwell content listing requests and centralize feature-based subscription checking via FeatureContentGuard.
- Add a configurable constant for the Lightwell feature name used when querying the feature service.

Tests:
- Add functional tests exercising Lightwell content listing permissions against the real feature service for entitled, non-entitled, domain-owner, and unauthenticated scenarios.