### PR TITLE
ci: add alcove workflow for agent-akamai-report

### DIFF
--- a/.alcove/agents/akamai-report.yml
+++ b/.alcove/agents/akamai-report.yml
@@ -1,0 +1,24 @@
+name: Akamai Report
+description: |
+  Analyzes 7-day Akamai traffic data via Splunk and produces a formatted
+  traffic report with LLM-driven analysis. Runs as a pre-compiled agent
+  binary from GitHub Releases.
+
+executable:
+  url: https://github.com/pulp/pulp-service/releases/download/agent-akamai-report-20260715-d2f911e/agent-akamai-report
+  args: ["--model", "claude-opus-4-6"]
+  env:
+    SPLUNK_INSECURE_SKIP_VERIFY: "true"
+    SPLUNK_URL: "https://splunk-api.corp.redhat.com:8089/"
+
+timeout: 1800
+enforcement_mode: monitor
+
+direct_outbound: true
+
+credentials:
+  SPLUNK_TOKEN: splunk
+
+schedule:
+  cron: "0 3 * * 1"
+  enabled: true

--- a/.alcove/workflows/akamai-report-pipeline.yml
+++ b/.alcove/workflows/akamai-report-pipeline.yml
@@ -1,0 +1,7 @@
+name: Akamai Report Pipeline
+
+workflow:
+  - id: generate-report
+    type: agent
+    agent: Akamai Report
+    outputs: [report_path, traffic_summary]


### PR DESCRIPTION
## Summary by Sourcery

Add an Alcove agent and workflow to generate and analyze weekly Akamai traffic reports via Splunk.

CI:
- Introduce an Akamai Report Alcove agent configuration for running a pre-compiled reporting binary with scheduled execution.
- Define an Akamai Report Pipeline Alcove workflow that invokes the agent and exposes report path and traffic summary outputs.