### PR TITLE
Upgrade pulp-python to 3.31.2

### DIFF
--- a/images/assets/patches/CLAUDE.md
+++ b/images/assets/patches/CLAUDE.md
@@ -10,7 +10,7 @@ Each patch modifies files installed into site-packages via the Dockerfile.
 | `pulpcore/`      | [pulp/pulpcore](https://github.com/pulp/pulpcore)          | pulpcore         | 3.112.0             |
 | `pulp_file/`     | [pulp/pulpcore](https://github.com/pulp/pulpcore)          | (bundled)        | 3.112.0             |
 | `pulp_container/`| [pulp/pulp_container](https://github.com/pulp/pulp_container) | pulp-container | 2.28.0              |
-| `pulp_python/`   | [pulp/pulp_python](https://github.com/pulp/pulp_python)    | pulp-python      | 3.30.3              |
+| `pulp_python/`   | [pulp/pulp_python](https://github.com/pulp/pulp_python)    | pulp-python      | 3.31.2              |
 | `pulp_maven/`    | [pulp/pulp_maven](https://github.com/pulp/pulp_maven)      | pulp-maven       | 0.12.0              |
 | `storages/`      | [jschneier/django-storages](https://github.com/jschneier/django-storages) | django-storages | 1.14.6 |
 

--- a/pulp_service/requirements.txt
+++ b/pulp_service/requirements.txt
@@ -1,7 +1,7 @@
 pulpcore==3.113.0
 pulp-rpm==3.37.1
 solv>=0.7.21,<0.7.38
-pulp-python==3.30.3
+pulp-python==3.31.2
 pulp-npm==0.8.0
 pulp-container==2.28.0
 pulp-maven==0.22.1


### PR DESCRIPTION
## Summary
- Upgrade pulp-python from 3.30.3 to 3.31.2
- Update patches documentation version tag

## Test plan
- [ ] Verify pulp_python patches (0047, 0048) apply cleanly in container build
- [ ] Run functional tests in dev container

Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Upgrade the pulp-python dependency version used by the service and align the corresponding patches documentation.

Enhancements:
- Bump pulp-python from 3.30.3 to 3.31.2 in the service requirements.
- Update patches documentation to reference the new pulp-python version.