### PR TITLE
fix: append /v1 to base URL for langchaingo anthropic client

### DIFF
--- a/tools/agents/shared/auth/auth.go
+++ b/tools/agents/shared/auth/auth.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strings"
 )
 
 type Config struct {
@@ -55,8 +56,11 @@ func normalizeBaseURL(url string) string {
 	if url == "" {
 		return ""
 	}
-	if url[len(url)-1] == '/' {
-		return url[:len(url)-1]
+	url = strings.TrimRight(url, "/")
+	// langchaingo's anthropic client expects the base URL to include /v1
+	// (it appends /messages, not /v1/messages)
+	if !strings.HasSuffix(url, "/v1") {
+		url += "/v1"
 	}
 	return url
 }

--- a/tools/agents/shared/auth/auth_test.go
+++ b/tools/agents/shared/auth/auth_test.go
@@ -88,6 +88,25 @@ func TestResolveFromEnv_ProxyModeIgnoresBadSAJSON(t *testing.T) {
 	}
 }
 
+func TestNormalizeBaseURL_AppendsV1(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"http://localhost:8443", "http://localhost:8443/v1"},
+		{"http://localhost:8443/", "http://localhost:8443/v1"},
+		{"http://localhost:8443/v1", "http://localhost:8443/v1"},
+		{"http://localhost:8443/v1/", "http://localhost:8443/v1"},
+		{"", ""},
+	}
+	for _, tt := range tests {
+		got := normalizeBaseURL(tt.input)
+		if got != tt.want {
+			t.Errorf("normalizeBaseURL(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}
+
 func TestResolveFromEnv_DefaultRegion(t *testing.T) {
 	t.Setenv("ANTHROPIC_VERTEX_PROJECT_ID", "my-project")
 	t.Setenv("CLOUD_ML_REGION", "")
@@ -98,7 +117,7 @@ func TestResolveFromEnv_DefaultRegion(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if config.Region != "us-east5" {
-		t.Errorf("Region = %q, want %q", config.Region, "us-east5")
+	if config.Region != "global" {
+		t.Errorf("Region = %q, want %q", config.Region, "global")
 	}
 }


### PR DESCRIPTION
langchaingo's anthropic client uses DefaultBaseURL="https://api.anthropic.com/v1" and appends "/messages" (not "/v1/messages"). When alcove sets ANTHROPIC_BASE_URL=http://localhost:8443 (without /v1), requests hit /messages which doesn't match Gate's /v1/* handler, causing a 404.

Also fixes TestResolveFromEnv_DefaultRegion to match actual default ("global").

## Summary by Sourcery

Normalize Anthropic base URLs to include the /v1 path segment and align tests with the current default region behavior.

Bug Fixes:
- Ensure Anthropic base URLs without a trailing path are normalized to include /v1 so requests hit the correct /v1 endpoints.
- Update the default-region test to expect the actual default region value of "global" instead of "us-east5".

Tests:
- Add unit coverage for base URL normalization across common input variants, including handling of trailing slashes and existing /v1 suffixes.