### PR TITLE
fix: print LLM report output in agent-akamai-report

### DIFF
--- a/tools/agents/agent-akamai-report/main.go
+++ b/tools/agents/agent-akamai-report/main.go
@@ -121,7 +121,7 @@ func run() error {
 		}
 	}
 
-	_, err = model.ModelRun(ctx, models.RunConfig{
+	report, err := model.ModelRun(ctx, models.RunConfig{
 		Prompt: prompt,
 		Tools:  tools,
 		MCP:    mcpMgr,
@@ -130,5 +130,6 @@ func run() error {
 		return fmt.Errorf("model run: %w", err)
 	}
 
+	fmt.Println(report)
 	return nil
 }


### PR DESCRIPTION
The ModelRun() return value was discarded, so the generated report was never printed to stdout.

## Summary by Sourcery

Bug Fixes:
- Capture the result of ModelRun in agent-akamai-report and print the generated report to stdout.