### PR TITLE
ci: update agent-akamai-report executable to latest release

### DIFF
--- a/.alcove/agents/akamai-report.yml
+++ b/.alcove/agents/akamai-report.yml
@@ -5,7 +5,7 @@ description: |
   binary from GitHub Releases.
 
 executable:
-  url: https://github.com/pulp/pulp-service/releases/download/agent-akamai-report-20260715-0b3283d/agent-akamai-report
+  url: https://github.com/pulp/pulp-service/releases/download/agent-akamai-report-20260715-d744cd4/agent-akamai-report
   args: ["--model", "claude-opus-4-6"]
   env:
     SPLUNK_INSECURE_SKIP_VERIFY: "true"


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Update the Akamai report agent executable URL to the latest GitHub release artifact.