### PR TITLE
feat: add request_time_ms to pulp-content access logs and exporter

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -449,7 +449,7 @@ objects:
           annotations:
             "kubectl.kubernetes.io/default-container": pulp-content
         image: ${IMAGE}:${IMAGE_TAG}
-        command: ['pulpcore-content', '-b', '0.0.0.0:8000', '--workers', '${PULP_CONTENT_GUNICORN_WORKERS}', '--max-requests', '${PULP_CONTENT_GUNICORN_MAX_REQUESTS}', '--max-requests-jitter', '${PULP_CONTENT_GUNICORN_MAX_REQUESTS_JITTER}', '--timeout', '${PULP_CONTENT_GUNICORN_TIMEOUT}', '--graceful-timeout', '${PULP_CONTENT_GUNICORN_GRACEFUL_TIMEOUT}', '--access-logfile', '-', '--access-logformat', '%a %t "%r" %s %b "%{Referer}i" "%{User-Agent}i" cache:"%{X-PULP-CACHE}o" artifact_size:"%{X-PULP-ARTIFACT-SIZE}o" rh_org_id:"%{X-RH-ORG-ID}o" x_forwarded_for:"%{X-Forwarded-For}i"']
+        command: ['pulpcore-content', '-b', '0.0.0.0:8000', '--workers', '${PULP_CONTENT_GUNICORN_WORKERS}', '--max-requests', '${PULP_CONTENT_GUNICORN_MAX_REQUESTS}', '--max-requests-jitter', '${PULP_CONTENT_GUNICORN_MAX_REQUESTS_JITTER}', '--timeout', '${PULP_CONTENT_GUNICORN_TIMEOUT}', '--graceful-timeout', '${PULP_CONTENT_GUNICORN_GRACEFUL_TIMEOUT}', '--access-logfile', '-', '--access-logformat', '%a %t "%r" %s %b "%{Referer}i" "%{User-Agent}i" cache:"%{X-PULP-CACHE}o" artifact_size:"%{X-PULP-ARTIFACT-SIZE}o" rh_org_id:"%{X-RH-ORG-ID}o" x_forwarded_for:"%{X-Forwarded-For}i" request_time:"%Tf"']
         volumeMounts:
           - name: secret-volume
             mountPath: "/etc/pulp/keys"

--- a/management_tools/pulp-access-logs-exporter/src/pulp_access_logs_exporter/content_cloudwatch.py
+++ b/management_tools/pulp-access-logs-exporter/src/pulp_access_logs_exporter/content_cloudwatch.py
@@ -60,7 +60,7 @@ def _parse_request_time_ms(value):
     if not value or value == "-":
         return None
     try:
-        return int(float(value) * 1000)
+        return round(float(value) * 1000)
     except (ValueError, TypeError):
         return None
 

--- a/management_tools/pulp-access-logs-exporter/src/pulp_access_logs_exporter/content_cloudwatch.py
+++ b/management_tools/pulp-access-logs-exporter/src/pulp_access_logs_exporter/content_cloudwatch.py
@@ -56,6 +56,15 @@ def _parse_org_id(org_value):
     return org_value
 
 
+def _parse_request_time_ms(value):
+    if not value or value == "-":
+        return None
+    try:
+        return int(float(value) * 1000)
+    except (ValueError, TypeError):
+        return None
+
+
 def _parse_timestamp(timestamp_str):
     if not timestamp_str:
         return None
@@ -142,6 +151,7 @@ def convert_content_to_arrow_table(results, content_type):
             "user_agent": parsed_line["user_agent"],
             "org_id": _parse_org_id(parsed_line["rh_org_id"]),
             "x_forwarded_for": parsed_line["x_forwarded_for"],
+            "request_time_ms": _parse_request_time_ms(parsed_line.get("request_time")),
         }
         record.update(parsed_filename)
         records.append(record)

--- a/management_tools/pulp-access-logs-exporter/src/pulp_access_logs_exporter/content_parser.py
+++ b/management_tools/pulp-access-logs-exporter/src/pulp_access_logs_exporter/content_parser.py
@@ -12,6 +12,7 @@ CONTENT_LOG_REGEX = re.compile(
     r'artifact_size:"(?P<artifact_size>[^"]*)"\s+'
     r'rh_org_id:"(?P<rh_org_id>[^"]*)"\s+'
     r'x_forwarded_for:"(?P<x_forwarded_for>[^"]*)"'
+    r'(?:\s+request_time:"(?P<request_time>[^"]*)")?'
 )
 
 # From pulp_python/app/utils.py:80-85 (regex sourced from pip)

--- a/management_tools/pulp-access-logs-exporter/src/pulp_access_logs_exporter/content_schemas.py
+++ b/management_tools/pulp-access-logs-exporter/src/pulp_access_logs_exporter/content_schemas.py
@@ -14,6 +14,7 @@ COMMON_FIELDS = [
     ("user_agent", pa.string()),
     ("org_id", pa.string()),
     ("x_forwarded_for", pa.string()),
+    ("request_time_ms", pa.int32()),
 ]
 
 PYTHON_SCHEMA = pa.schema(

--- a/management_tools/pulp-access-logs-exporter/tests/conftest.py
+++ b/management_tools/pulp-access-logs-exporter/tests/conftest.py
@@ -46,23 +46,23 @@ def sample_content_cloudwatch_results():
     return [
         {
             '@timestamp': '2026-06-09 14:30:00.000',
-            'message': '10.128.4.123 [09/Jun/2026:14:30:00 +0000] "GET /api/pulp-content/public-rhai/rhoai/3.5-EA2/cpu-ubi9/requests-2.34.2-2-py3-none-any.whl HTTP/1.1" 200 19456789 "-" "pip/24.0" cache:"HIT" artifact_size:"19456789" rh_org_id:"123456" x_forwarded_for:"23.48.249.160,10.0.0.1"',
+            'message': '10.128.4.123 [09/Jun/2026:14:30:00 +0000] "GET /api/pulp-content/public-rhai/rhoai/3.5-EA2/cpu-ubi9/requests-2.34.2-2-py3-none-any.whl HTTP/1.1" 200 19456789 "-" "pip/24.0" cache:"HIT" artifact_size:"19456789" rh_org_id:"123456" x_forwarded_for:"23.48.249.160,10.0.0.1" request_time:"0.003200"',
         },
         {
             '@timestamp': '2026-06-09 14:30:01.000',
-            'message': '10.128.4.124 [09/Jun/2026:14:30:01 +0000] "GET /api/pulp-content/public-rhai/rhoai/3.5-EA2/cpu-ubi9/numpy-1.26.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata HTTP/1.1" 200 1234 "-" "uv/0.9.26" cache:"MISS" artifact_size:"1234" rh_org_id:"789012" x_forwarded_for:"10.20.30.40"',
+            'message': '10.128.4.124 [09/Jun/2026:14:30:01 +0000] "GET /api/pulp-content/public-rhai/rhoai/3.5-EA2/cpu-ubi9/numpy-1.26.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata HTTP/1.1" 200 1234 "-" "uv/0.9.26" cache:"MISS" artifact_size:"1234" rh_org_id:"789012" x_forwarded_for:"10.20.30.40" request_time:"0.045600"',
         },
         {
             '@timestamp': '2026-06-09 14:30:02.000',
-            'message': '10.128.4.125 [09/Jun/2026:14:30:02 +0000] "GET /api/pulp-content/public-copr/packit/teemtee-tmt-4901/fedora-43-x86_64/Packages/b/bash-5.2.26-4.fc43.x86_64.rpm HTTP/1.1" 200 5678901 "-" "dnf/4.18.0" cache:"MISS" artifact_size:"5678901" rh_org_id:"-" x_forwarded_for:"192.168.1.1"',
+            'message': '10.128.4.125 [09/Jun/2026:14:30:02 +0000] "GET /api/pulp-content/public-copr/packit/teemtee-tmt-4901/fedora-43-x86_64/Packages/b/bash-5.2.26-4.fc43.x86_64.rpm HTTP/1.1" 200 5678901 "-" "dnf/4.18.0" cache:"MISS" artifact_size:"5678901" rh_org_id:"-" x_forwarded_for:"192.168.1.1" request_time:"0.078300"',
         },
         {
             '@timestamp': '2026-06-09 14:30:03.000',
-            'message': '10.128.4.126 [09/Jun/2026:14:30:03 +0000] "GET /api/pulp-content/public-copr/packit/teemtee-tmt-4901/fedora-43-x86_64/repodata/repomd.xml HTTP/1.1" 200 3456 "-" "dnf/4.18.0" cache:"HIT" artifact_size:"3456" rh_org_id:"-" x_forwarded_for:"192.168.1.2"',
+            'message': '10.128.4.126 [09/Jun/2026:14:30:03 +0000] "GET /api/pulp-content/public-copr/packit/teemtee-tmt-4901/fedora-43-x86_64/repodata/repomd.xml HTTP/1.1" 200 3456 "-" "dnf/4.18.0" cache:"HIT" artifact_size:"3456" rh_org_id:"-" x_forwarded_for:"192.168.1.2" request_time:"0.001200"',
         },
         {
             '@timestamp': '2026-06-09 14:30:04.000',
-            'message': '10.128.4.127 [09/Jun/2026:14:30:04 +0000] "GET /api/pulp-content/ccac33ac/templates/kernel-core-6.8.0-300.fc40.x86_64.rpm HTTP/1.1" 200 99887766 "-" "yum/4.0" cache:"HIT" artifact_size:"99887766" rh_org_id:"555666" x_forwarded_for:"172.16.0.1"',
+            'message': '10.128.4.127 [09/Jun/2026:14:30:04 +0000] "GET /api/pulp-content/ccac33ac/templates/kernel-core-6.8.0-300.fc40.x86_64.rpm HTTP/1.1" 200 99887766 "-" "yum/4.0" cache:"HIT" artifact_size:"99887766" rh_org_id:"555666" x_forwarded_for:"172.16.0.1" request_time:"0.002500"',
         },
     ]
 
@@ -73,15 +73,15 @@ def sample_maven_cloudwatch_results():
     return [
         {
             "@timestamp": "2026-06-20 13:47:49.000",
-            "message": '10.131.32.14 [20/Jun/2026:13:47:49 +0000] "GET /api/pulp-content/balor-stage/maven-releases/org/springframework/cloud/spring-cloud-config-server/4.3.0-redhat-1/spring-cloud-config-server-4.3.0-redhat-1.jar HTTP/1.1" 302 727 "-" "curl/8.15.0" cache:"MISS" artifact_size:"18432000" rh_org_id:"5894300" x_forwarded_for:"66.187.232.140, 66.187.232.140, 23.220.105.201"',
+            "message": '10.131.32.14 [20/Jun/2026:13:47:49 +0000] "GET /api/pulp-content/balor-stage/maven-releases/org/springframework/cloud/spring-cloud-config-server/4.3.0-redhat-1/spring-cloud-config-server-4.3.0-redhat-1.jar HTTP/1.1" 302 727 "-" "curl/8.15.0" cache:"MISS" artifact_size:"18432000" rh_org_id:"5894300" x_forwarded_for:"66.187.232.140, 66.187.232.140, 23.220.105.201" request_time:"0.156000"',
         },
         {
             "@timestamp": "2026-06-20 13:47:50.000",
-            "message": '10.128.2.5 [20/Jun/2026:13:47:50 +0000] "GET /api/pulp-content/balor-stage/maven-releases/org/springframework/spring-expression/5.3.18-redhat-1/spring-expression-5.3.18-redhat-1.pom HTTP/1.1" 302 729 "-" "Apache-Maven/3.9.11 (Java 25.0.3; Linux 7.0.12-201.fc44.x86_64)" cache:"MISS" artifact_size:"2048" rh_org_id:"5894300" x_forwarded_for:"66.187.232.140"',
+            "message": '10.128.2.5 [20/Jun/2026:13:47:50 +0000] "GET /api/pulp-content/balor-stage/maven-releases/org/springframework/spring-expression/5.3.18-redhat-1/spring-expression-5.3.18-redhat-1.pom HTTP/1.1" 302 729 "-" "Apache-Maven/3.9.11 (Java 25.0.3; Linux 7.0.12-201.fc44.x86_64)" cache:"MISS" artifact_size:"2048" rh_org_id:"5894300" x_forwarded_for:"66.187.232.140" request_time:"0.089000"',
         },
         {
             "@timestamp": "2026-06-20 13:47:51.000",
-            "message": '10.129.8.16 [20/Jun/2026:13:47:51 +0000] "GET /api/pulp-content/balor-stage/maven-releases/net/minidev/json-smart/2.5.0/json-smart-2.5.0-sources.jar HTTP/1.1" 302 733 "-" "curl/8.15.0" cache:"HIT" artifact_size:"45056" rh_org_id:"5894300" x_forwarded_for:"66.187.232.140"',
+            "message": '10.129.8.16 [20/Jun/2026:13:47:51 +0000] "GET /api/pulp-content/balor-stage/maven-releases/net/minidev/json-smart/2.5.0/json-smart-2.5.0-sources.jar HTTP/1.1" 302 733 "-" "curl/8.15.0" cache:"HIT" artifact_size:"45056" rh_org_id:"5894300" x_forwarded_for:"66.187.232.140" request_time:"0.004200"',
         },
     ]
 

--- a/management_tools/pulp-access-logs-exporter/tests/test_content_export.py
+++ b/management_tools/pulp-access-logs-exporter/tests/test_content_export.py
@@ -11,6 +11,7 @@ from pulp_access_logs_exporter.content_parser import (
     parse_wheel_filename,
 )
 from pulp_access_logs_exporter.content_cloudwatch import (
+    _parse_request_time_ms,
     build_content_query,
     convert_content_to_arrow_table,
 )
@@ -50,6 +51,39 @@ class TestParseContentLogLine:
         line = '10.0.0.1 [09/Jun/2026:14:30:00 +0000] "GET /api/pulp-content/d/r/file.whl HTTP/1.1" 200 100 "-" "pip/24.0" cache:"HIT" artifact_size:"100" rh_org_id:"-" x_forwarded_for:"1.2.3.4"'
         result = parse_content_log_line(line)
         assert result["rh_org_id"] == "-"
+
+    def test_parses_request_time(self):
+        line = '10.128.4.123 [09/Jun/2026:14:30:00 +0000] "GET /api/pulp-content/default/dist/pkg-1.0-py3-none-any.whl HTTP/1.1" 200 19456789 "-" "pip/24.0" cache:"HIT" artifact_size:"19456789" rh_org_id:"123456" x_forwarded_for:"23.48.249.160,10.0.0.1" request_time:"0.042000"'
+        result = parse_content_log_line(line)
+        assert result is not None
+        assert result["request_time"] == "0.042000"
+
+    def test_parses_without_request_time(self):
+        line = '10.0.0.1 [09/Jun/2026:14:30:00 +0000] "GET /api/pulp-content/d/r/file.rpm HTTP/1.1" 200 100 "-" "dnf/4.0" cache:"MISS" artifact_size:"100" rh_org_id:"-" x_forwarded_for:"1.2.3.4"'
+        result = parse_content_log_line(line)
+        assert result is not None
+        assert result["request_time"] is None
+
+
+class TestParseRequestTimeMs:
+    def test_converts_seconds_to_milliseconds(self):
+        assert _parse_request_time_ms("0.042000") == 42
+        assert _parse_request_time_ms("0.003200") == 3
+        assert _parse_request_time_ms("0.156000") == 156
+        assert _parse_request_time_ms("1.234567") == 1234
+
+    def test_handles_none_and_dash(self):
+        assert _parse_request_time_ms(None) is None
+        assert _parse_request_time_ms("-") is None
+        assert _parse_request_time_ms("") is None
+
+    def test_handles_invalid_values(self):
+        assert _parse_request_time_ms("invalid") is None
+        assert _parse_request_time_ms("not_a_number") is None
+
+    def test_truncates_to_integer_milliseconds(self):
+        assert _parse_request_time_ms("0.0016") == 1  # 1.6ms truncates to 1
+        assert _parse_request_time_ms("0.0019") == 1  # 1.9ms truncates to 1
 
 
 class TestParseWheelFilename:
@@ -374,6 +408,9 @@ class TestContentToParquetPython:
         assert rows["cache_hit"][1] is False
         assert rows["distribution"][1] == "rhoai/3.5-EA2/cpu-ubi9"
 
+        assert rows["request_time_ms"][0] == 3  # 0.003200s = 3ms
+        assert rows["request_time_ms"][1] == 45  # 0.045600s = 45ms
+
     def test_skips_invalid_and_non_matching_records(
         self, sample_content_cloudwatch_results
     ):
@@ -449,6 +486,9 @@ class TestContentToParquetRpm:
         assert rows["org_id"][1] == "555666"
         assert rows["distribution"][1] == "templates"
 
+        assert rows["request_time_ms"][0] == 78  # 0.078300s = 78ms
+        assert rows["request_time_ms"][1] == 2  # 0.002500s = 2ms
+
 
 class TestContentToParquetMaven:
     def test_converts_maven_downloads(
@@ -486,6 +526,10 @@ class TestContentToParquetMaven:
         assert rows["packaging"][2] == "jar"
         assert rows["cache_hit"][2] is True
 
+        assert rows["request_time_ms"][0] == 156  # 0.156000s = 156ms
+        assert rows["request_time_ms"][1] == 89  # 0.089000s = 89ms
+        assert rows["request_time_ms"][2] == 4  # 0.004200s = 4ms
+
     def test_skips_checksum_files(self):
         results = [
             {
@@ -522,6 +566,21 @@ class TestEmptyContentResults:
         table = convert_content_to_arrow_table([], "maven")
         assert table.num_rows == 0
         assert table.schema == MAVEN_SCHEMA
+
+
+class TestContentBackwardCompatibility:
+    def test_old_format_without_request_time(self):
+        """Old-format log lines (before request_time was added) produce request_time_ms=None."""
+        results = [
+            {
+                "@timestamp": "2026-06-09 14:30:00.000",
+                "message": '10.128.4.123 [09/Jun/2026:14:30:00 +0000] "GET /api/pulp-content/public-rhai/rhoai/3.5-EA2/cpu-ubi9/requests-2.34.2-2-py3-none-any.whl HTTP/1.1" 200 19456789 "-" "pip/24.0" cache:"HIT" artifact_size:"19456789" rh_org_id:"123456" x_forwarded_for:"23.48.249.160,10.0.0.1"',
+            },
+        ]
+        table = convert_content_to_arrow_table(results, "python")
+        assert table.num_rows == 1
+        rows = table.to_pydict()
+        assert rows["request_time_ms"][0] is None
 
 
 class TestContentQueryBuilding:

--- a/management_tools/pulp-access-logs-exporter/tests/test_content_export.py
+++ b/management_tools/pulp-access-logs-exporter/tests/test_content_export.py
@@ -70,7 +70,7 @@ class TestParseRequestTimeMs:
         assert _parse_request_time_ms("0.042000") == 42
         assert _parse_request_time_ms("0.003200") == 3
         assert _parse_request_time_ms("0.156000") == 156
-        assert _parse_request_time_ms("1.234567") == 1234
+        assert _parse_request_time_ms("1.234567") == 1235
 
     def test_handles_none_and_dash(self):
         assert _parse_request_time_ms(None) is None
@@ -81,9 +81,9 @@ class TestParseRequestTimeMs:
         assert _parse_request_time_ms("invalid") is None
         assert _parse_request_time_ms("not_a_number") is None
 
-    def test_truncates_to_integer_milliseconds(self):
-        assert _parse_request_time_ms("0.0016") == 1  # 1.6ms truncates to 1
-        assert _parse_request_time_ms("0.0019") == 1  # 1.9ms truncates to 1
+    def test_rounds_to_integer_milliseconds(self):
+        assert _parse_request_time_ms("0.0016") == 2  # 1.6ms rounds to 2
+        assert _parse_request_time_ms("0.0019") == 2  # 1.9ms rounds to 2
 
 
 class TestParseWheelFilename:
@@ -409,7 +409,7 @@ class TestContentToParquetPython:
         assert rows["distribution"][1] == "rhoai/3.5-EA2/cpu-ubi9"
 
         assert rows["request_time_ms"][0] == 3  # 0.003200s = 3ms
-        assert rows["request_time_ms"][1] == 45  # 0.045600s = 45ms
+        assert rows["request_time_ms"][1] == 46  # 0.045600s = 45.6ms, rounds to 46
 
     def test_skips_invalid_and_non_matching_records(
         self, sample_content_cloudwatch_results


### PR DESCRIPTION
Add request duration to the content access log format and export it as request_time_ms (int32, truncated) in Parquet. Parser handles old log lines without the field gracefully.

Uses aiohttp's %Tf atom (fractional seconds) instead of the originally planned %(M)s (gunicorn milliseconds) because pulp-content runs aiohttp.GunicornWebWorker, which explicitly rejects gunicorn-style %(...)s format patterns at startup.

Using %(M)s would crash the service. Since aiohttp has no native millisecond atom, the exporter converts seconds to integer milliseconds (float * 1000, truncated).

## Summary by Sourcery

Capture request duration from pulp-content access logs and export it as a request_time_ms column in Parquet while preserving compatibility with existing log formats.

New Features:
- Add request_time_ms as a derived request duration field in exported pulp-content Parquet data

Enhancements:
- Extend the content access log parser to capture optional request_time values while remaining backward compatible with older log lines

Build:
- Update pulp-content deployment configuration to emit request_time in access logs using aiohttp’s fractional-seconds format atom

Tests:
- Add unit tests covering request_time parsing, milliseconds conversion, inclusion in Python/RPM/Maven export paths, and handling of legacy logs without the field