### PR TITLE
fix: use explicit claude-sonnet-4-6 model for Plan Reviewer

### DIFF
--- a/.alcove/agents/plan-reviewer.yml
+++ b/.alcove/agents/plan-reviewer.yml
@@ -4,7 +4,7 @@ description: |
   correctness, and actionability. Read-only — surfaces problems but
   never modifies the plan directly.
 
-model: claude-sonnet-5
+model: claude-sonnet-4-6
 
 prompt: |
   You are a critical reviewer of implementation plans for the pulp-service


### PR DESCRIPTION
## Summary

The Plan Reviewer agent uses `model: sonnet` which resolves to Sonnet 5 on Vertex AI. This model has a separate quota bucket that's frequently exhausted by concurrent sessions, causing the reviewer to fail with 429 RESOURCE_EXHAUSTED after 10 retries.

Switching to the explicit `claude-sonnet-4-6` model ID targets a model with available quota and avoids ambiguity in model resolution.

## Changes

- `.alcove/agents/plan-reviewer.yml`: `model: sonnet` → `model: claude-sonnet-4-6`

## Context

The Jira Planner workflow (`planner.yml`) has been failing consistently because the Plan Reviewer step never gets an LLM response — all attempts hit 429. The planner (Opus) and reviser (Opus) work fine since Opus has separate quota.

## Summary by Sourcery

Switch Plan Reviewer agent configuration to use the explicit claude-sonnet-4-6 model instead of the generic sonnet alias to avoid quota-related failures.