### PR TITLE
refactor: replace hardcoded lightwell permission logic with generic DOMAIN_ACCESS_POLICIES

### DIFF
--- a/dev-container/settings.py
+++ b/dev-container/settings.py
@@ -50,3 +50,11 @@ AUTHENTICATION_JSON_HEADER = "HTTP_X_RH_IDENTITY"
 AUTHENTICATION_JSON_HEADER_JQ_FILTER = ".identity.user.username"
 
 ATTESTATION_VERIFICATION_KEY = "/etc/pki/attestation/test-key.pem"
+
+DOMAIN_ACCESS_POLICIES = {
+    "lightwell": {
+        "readonly_group": "Lightwell-ReadOnly",
+        "subscription_feature": "lightwell-network",
+        "subscription_endpoints": ["/api/v3/content/"],
+    },
+}

--- a/pulp_service/pulp_service/app/authorization.py
+++ b/pulp_service/pulp_service/app/authorization.py
@@ -5,6 +5,7 @@ from binascii import Error as Base64DecodeError
 from contextvars import ContextVar
 
 import jq
+from django.conf import settings
 from django.db.models import Q
 from django.http import Http404
 from rest_framework.permissions import SAFE_METHODS, BasePermission
@@ -20,20 +21,6 @@ org_id_json_path = jq.compile(".identity.internal.org_id")
 
 user_id_var = ContextVar("user_id")
 group_var = ContextVar("group")
-
-# The hardcoded domain name used by the lightwell read-only group check (see
-# _has_lightwell_readonly_group_access and _check_safe_method_access).
-LIGHTWELL_DOMAIN_NAME = "lightwell"
-# Hardcoded group whose members get read-only (SAFE_METHODS) access to the lightwell
-# domain's non-PyPI endpoints (repository/content/artifact listing, Pulp REST API, Maven
-# content API), independent of any DomainOrg association. This is a plain Group -- there is
-# no DomainOrg row backing this access, unlike the normal group-based access model. It does
-# NOT grant write access, and it does NOT apply to PyPI views, which are gated
-# by the distribution's content guard (see _check_pypi_safe_method_access()).
-LIGHTWELL_READONLY_GROUP_NAME = "Lightwell-ReadOnly"
-# Fixed identifier in the Features Service; checked by _check_lightwell_subscription() to
-# gate content listing access for orgs with an active lightwell subscription.
-LIGHTWELL_FEATURE_NAME = "lightwell-network"
 
 
 class DomainBasedPermission(BasePermission):
@@ -55,42 +42,6 @@ class DomainBasedPermission(BasePermission):
             query |= Q(domains__pk=domain_pk, org_id=org_id)
 
         return DomainOrg.objects.filter(query).exists()
-
-    def _has_lightwell_readonly_group_access(self, user):
-        """
-        Members of the hardcoded LIGHTWELL_READONLY_GROUP_NAME group get read-only
-        (SAFE_METHODS) access to the lightwell domain's non-PyPI endpoints, independent of
-        any DomainOrg association. Unlike normal groups (linked to a domain via DomainOrg,
-        which grant unrestricted read+write access), this is a standalone check based purely
-        on group membership + the hardcoded lightwell domain name -- see has_permission() and
-        scope_queryset() for where this is applied.
-        """
-        return user.is_authenticated and user.groups.filter(name=LIGHTWELL_READONLY_GROUP_NAME).exists()
-
-    def _is_content_listing_request(self, request):
-        # view_name (not isinstance) because BaseContentViewSet is not in pulpcore's public
-        # plugin API, and the public subclasses miss ListContentViewSet.
-        view_name = getattr(request.resolver_match, "view_name", None)
-        return view_name is not None and view_name.startswith("content-")
-
-    def _check_lightwell_subscription(self, request, domain):
-        if not (domain and domain.name == LIGHTWELL_DOMAIN_NAME):
-            return None
-        if not self._is_content_listing_request(request):
-            return None
-
-        decoded_header = self.get_decoded_identity_header(request)
-        org_id = self.get_org_id(decoded_header)
-        if org_id is None:
-            return None
-
-        guard = FeatureContentGuard(features=[LIGHTWELL_FEATURE_NAME])
-        try:
-            if guard.check_feature(org_id):
-                return True
-        except Exception:
-            _logger.exception("Unexpected error checking lightwell subscription")
-        return None
 
     def _check_pypi_safe_method_access(self, request, view, domain):  # noqa: PLR0911
         """
@@ -158,6 +109,30 @@ class DomainBasedPermission(BasePermission):
             _logger.exception("Unexpected error evaluating content guard permit")
             return False
 
+    def _check_domain_policy(self, request, domain, user, policy):
+        """
+        Returns True if the policy grants access, or None if it does not apply.
+        """
+        subscription_feature = policy.get("subscription_feature")
+        subscription_endpoints = policy.get("subscription_endpoints", [])
+        if subscription_feature and subscription_endpoints:
+            path = request.path_info
+            if any(endpoint in path for endpoint in subscription_endpoints):
+                decoded_header = self.get_decoded_identity_header(request)
+                org_id = self.get_org_id(decoded_header)
+                guard = FeatureContentGuard(features=[subscription_feature])
+                try:
+                    if org_id and guard.check_feature(org_id):
+                        return True
+                except Exception:
+                    _logger.exception("Unexpected error checking %s subscription", subscription_feature)
+
+        readonly_group = policy.get("readonly_group", "")
+        if readonly_group and user.is_authenticated and user.groups.filter(name=readonly_group).exists():
+            return True
+
+        return None
+
     def _check_safe_method_access(self, request, view, domain, user):
         """
         Returns True/False for a SAFE_METHOD request, or None if none of the SAFE_METHOD
@@ -171,14 +146,16 @@ class DomainBasedPermission(BasePermission):
         if pypi_access is not None:
             return pypi_access
 
-        subscription_access = self._check_lightwell_subscription(request, domain)
-        if subscription_access is not None:
-            return subscription_access
+        domain_policy_settings = getattr(settings, "DOMAIN_ACCESS_POLICIES", {})
 
-        if domain and domain.name == LIGHTWELL_DOMAIN_NAME and self._has_lightwell_readonly_group_access(user):
-            return True
+        if not domain:
+            return None
 
-        return None
+        policy = domain_policy_settings.get(domain.name, {})
+        if not policy:
+            return None
+
+        return self._check_domain_policy(request, domain, user, policy)
 
     def has_permission(self, request, view):  # noqa: PLR0911
         # Admins have all permissions
@@ -293,7 +270,11 @@ class DomainBasedPermission(BasePermission):
         if org_id is not None:
             query |= Q(domain_orgs__org_id=org_id)
 
-        if self._has_lightwell_readonly_group_access(user):
-            query |= Q(name=LIGHTWELL_DOMAIN_NAME)
+        domain_policy_settings = getattr(settings, "DOMAIN_ACCESS_POLICIES", {})
+
+        for domain_name, policy in domain_policy_settings.items():
+            group = policy.get("readonly_group")
+            if group and user.is_authenticated and user.groups.filter(name=group).exists():
+                query |= Q(name=domain_name)
 
         return qs.filter(query).distinct()

--- a/pulp_service/pulp_service/app/authorization.py
+++ b/pulp_service/pulp_service/app/authorization.py
@@ -109,15 +109,28 @@ class DomainBasedPermission(BasePermission):
             _logger.exception("Unexpected error evaluating content guard permit")
             return False
 
+    @staticmethod
+    def _get_domain_policies():
+        return getattr(settings, "DOMAIN_ACCESS_POLICIES", {})
+
     def _check_domain_policy(self, request, domain, user, policy):
         """
         Returns True if the policy grants access, or None if it does not apply.
+
+        ``subscription_endpoints`` are treated as path prefixes: a policy applies
+        when the request path (after stripping the domain routing prefix) starts
+        with one of the configured endpoint values.
         """
         subscription_feature = policy.get("subscription_feature")
         subscription_endpoints = policy.get("subscription_endpoints", [])
         if subscription_feature and subscription_endpoints:
             path = request.path_info
-            if any(endpoint in path for endpoint in subscription_endpoints):
+            if domain:
+                api_root = getattr(settings, "API_ROOT", "/api/pulp/")
+                domain_prefix = f"{api_root.rstrip('/')}/{domain.name}/"
+                if path.startswith(domain_prefix):
+                    path = "/" + path[len(domain_prefix) :]
+            if any(path.startswith(endpoint) for endpoint in subscription_endpoints):
                 decoded_header = self.get_decoded_identity_header(request)
                 org_id = self.get_org_id(decoded_header)
                 guard = FeatureContentGuard(features=[subscription_feature])
@@ -146,12 +159,10 @@ class DomainBasedPermission(BasePermission):
         if pypi_access is not None:
             return pypi_access
 
-        domain_policy_settings = getattr(settings, "DOMAIN_ACCESS_POLICIES", {})
-
         if not domain:
             return None
 
-        policy = domain_policy_settings.get(domain.name, {})
+        policy = self._get_domain_policies().get(domain.name, {})
         if not policy:
             return None
 
@@ -270,9 +281,7 @@ class DomainBasedPermission(BasePermission):
         if org_id is not None:
             query |= Q(domain_orgs__org_id=org_id)
 
-        domain_policy_settings = getattr(settings, "DOMAIN_ACCESS_POLICIES", {})
-
-        for domain_name, policy in domain_policy_settings.items():
+        for domain_name, policy in self._get_domain_policies().items():
             group = policy.get("readonly_group")
             if group and user.is_authenticated and user.groups.filter(name=group).exists():
                 query |= Q(name=domain_name)

--- a/pulp_service/pulp_service/app/settings.py
+++ b/pulp_service/pulp_service/app/settings.py
@@ -30,3 +30,12 @@ HIJACK_ALLOW_GET_REQUESTS = True
 
 # RDS Test endpoints setting
 RDS_CONNECTION_TESTS_ENABLED = False
+
+
+DOMAIN_ACCESS_POLICIES = {
+    "lightwell": {
+        "readonly_group": "Lightwell-ReadOnly",
+        "subscription_feature": "lightwell-network",
+        "subscription_endpoints": ["/api/v3/content/"],
+    },
+}

--- a/pulp_service/pulp_service/tests/functional/test_lightwell_content_listing_permission.py
+++ b/pulp_service/pulp_service/tests/functional/test_lightwell_content_listing_permission.py
@@ -24,13 +24,14 @@ from uuid import uuid4
 import pytest
 import requests
 
-from pulp_service.app.authorization import LIGHTWELL_READONLY_GROUP_NAME
 from pulp_service.tests.functional.constants import (
     LIGHTWELL_ENTITLED_ORG_ID,
     LIGHTWELL_NOT_ENTITLED_ORG_ID,
 )
 
+# See DOMAIN_ACCESS_POLICIES in settings.py
 LIGHTWELL_DOMAIN_NAME = "lightwell"
+LIGHTWELL_READONLY_GROUP_NAME = "Lightwell-ReadOnly"
 
 DOMAIN_OWNER_ORG_ID = "555555555"
 GROUP_MEMBER_ORG_ID = "666666666"

--- a/pulp_service/pulp_service/tests/functional/test_lightwell_readonly_group_permission.py
+++ b/pulp_service/pulp_service/tests/functional/test_lightwell_readonly_group_permission.py
@@ -29,10 +29,7 @@ from uuid import uuid4
 
 import pytest
 import requests
-
-from pulp_service.app.authorization import LIGHTWELL_READONLY_GROUP_NAME
-
-LIGHTWELL_DOMAIN_NAME = "lightwell"
+from django.conf import settings
 
 # An org with no DomainOrg association with the test domain and no lightwell-network
 # feature entitlement; only used to own the test domain/repo/distribution.
@@ -40,6 +37,8 @@ DOMAIN_OWNER_ORG_ID = "555555555"
 # A distinct org used for the group members created in these tests, so they never
 # accidentally collide with the domain owner's DomainOrg association.
 GROUP_MEMBER_ORG_ID = "666666666"
+# See DOMAIN_ACCESS_POLICIES in settings.py
+LIGHTWELL_DOMAIN_NAME = "lightwell"
 
 
 def _identity_header(org_id, username):
@@ -62,7 +61,14 @@ def _combined_username(org_id, username):
 @pytest.fixture
 def lightwell_readonly_group(gen_group):
     """The hardcoded read-only group, created with its real (hardcoded) name."""
-    return gen_group(name=LIGHTWELL_READONLY_GROUP_NAME)
+    group = (
+        getattr(settings, "DOMAIN_ACCESS_POLICIES", {})
+        .get(
+            "lightwell",
+        )
+        .get("readonly_group")
+    )
+    return gen_group(name=group)
 
 
 @pytest.fixture

--- a/pulp_service/pulp_service/tests/functional/test_lightwell_readonly_group_permission.py
+++ b/pulp_service/pulp_service/tests/functional/test_lightwell_readonly_group_permission.py
@@ -61,13 +61,8 @@ def _combined_username(org_id, username):
 @pytest.fixture
 def lightwell_readonly_group(gen_group):
     """The hardcoded read-only group, created with its real (hardcoded) name."""
-    group = (
-        getattr(settings, "DOMAIN_ACCESS_POLICIES", {})
-        .get(
-            "lightwell",
-        )
-        .get("readonly_group")
-    )
+    policy = getattr(settings, "DOMAIN_ACCESS_POLICIES", {}).get("lightwell", {})
+    group = policy.get("readonly_group")
     return gen_group(name=group)
 
 

--- a/pulp_service/pulp_service/tests/unit/test_domain_based_permission.py
+++ b/pulp_service/pulp_service/tests/unit/test_domain_based_permission.py
@@ -15,6 +15,8 @@ from unittest.mock import MagicMock, patch
 
 from django.test import override_settings
 
+from pulpcore.plugin.models import Domain
+
 from pulp_service.app.authorization import DomainBasedPermission
 
 
@@ -732,3 +734,127 @@ class TestGenericDomainAccessPolicies:
         view = _make_regular_view()
 
         assert permission.has_permission(request, view) is False
+
+    @override_settings(
+        DOMAIN_ACCESS_POLICIES={
+            "lightwell": {
+                "readonly_group": "",
+                "subscription_feature": "lightwell-network",
+                "subscription_endpoints": ["/api/v3/content/"],
+            },
+        }
+    )
+    @patch("pulp_service.app.authorization.FeatureContentGuard")
+    @patch("pulp_service.app.authorization.get_domain_pk", return_value=42)
+    @patch("pulp_service.app.authorization.DomainOrg.objects")
+    def test_subscription_feature_guard_exception_denies_access(
+        self, mock_domain_org, mock_get_domain_pk, mock_guard_cls
+    ):
+        """If FeatureContentGuard.check_feature raises, access denied and guard still invoked."""
+        mock_domain_org.filter.return_value.exists.return_value = False
+        mock_guard_cls.return_value.check_feature.side_effect = Exception("guard-error")
+        permission = DomainBasedPermission()
+        domain = _make_domain("lightwell")
+        request = _make_request(
+            method="GET",
+            user=_make_authenticated_user(),
+            domain=domain,
+            path_info="/api/v3/content/rpm/packages/",
+            org_id="12345",
+        )
+        view = _make_regular_view()
+
+        assert permission.has_permission(request, view) is False
+        mock_guard_cls.return_value.check_feature.assert_called_once_with("12345")
+
+    @override_settings(
+        DOMAIN_ACCESS_POLICIES={
+            "lightwell": {
+                "readonly_group": "Lightwell-ReadOnly",
+                "subscription_feature": "lightwell-network",
+            },
+        }
+    )
+    def test_subscription_feature_without_endpoints_only_grants_via_readonly_group(self):
+        """Policy with subscription_feature but no subscription_endpoints skips
+        subscription logic; only readonly_group grants access."""
+        permission = DomainBasedPermission()
+        domain = _make_domain("lightwell")
+        request = _make_request(
+            method="GET",
+            user=_make_authenticated_user(in_readonly_group=True),
+            domain=domain,
+            path_info="/api/v3/content/rpm/packages/",
+            org_id="12345",
+        )
+
+        assert permission.has_permission(request, _make_regular_view()) is True
+
+    @override_settings(
+        DOMAIN_ACCESS_POLICIES={
+            "lightwell": {
+                "readonly_group": "Lightwell-ReadOnly",
+                "subscription_feature": "lightwell-network",
+                "subscription_endpoints": [],
+            },
+        }
+    )
+    def test_empty_subscription_endpoints_only_grants_via_readonly_group(self):
+        """Policy with empty subscription_endpoints list skips subscription logic;
+        only readonly_group grants access."""
+        permission = DomainBasedPermission()
+        domain = _make_domain("lightwell")
+        request = _make_request(
+            method="GET",
+            user=_make_authenticated_user(in_readonly_group=True),
+            domain=domain,
+            path_info="/api/v3/content/rpm/packages/",
+            org_id="12345",
+        )
+
+        assert permission.has_permission(request, _make_regular_view()) is True
+
+
+class TestScopeQueryset:
+    """Verify scope_queryset includes domains from DOMAIN_ACCESS_POLICIES
+    when user belongs to the readonly_group."""
+
+    @override_settings(DOMAIN_ACCESS_POLICIES=_MULTI_DOMAIN_POLICIES)
+    def test_scope_queryset_includes_readonly_policy_domains(self):
+        """User in readonly groups sees domains from matching policies in queryset."""
+        permission = DomainBasedPermission()
+        user = _make_authenticated_user(in_readonly_group=True)
+        request = _make_request(method="GET", user=user)
+
+        view = MagicMock()
+        view.request = request
+        qs = MagicMock()
+        qs.model = Domain
+
+        permission.scope_queryset(view, qs)
+
+        qs.filter.assert_called_once()
+        filter_arg = qs.filter.call_args[0][0]
+        q_str = str(filter_arg)
+        assert "lightwell" in q_str
+        assert "acme" in q_str
+
+    @override_settings(DOMAIN_ACCESS_POLICIES={})
+    def test_scope_queryset_empty_policies_no_policy_domains(self):
+        """With no policies, scope_queryset filters by DomainOrg only."""
+        permission = DomainBasedPermission()
+        user = _make_authenticated_user(in_readonly_group=True)
+        request = _make_request(method="GET", user=user, org_id="12345")
+
+        view = MagicMock()
+        view.request = request
+        qs = MagicMock()
+        qs.model = Domain
+
+        permission.scope_queryset(view, qs)
+
+        qs.filter.assert_called_once()
+        filter_arg = qs.filter.call_args[0][0]
+        q_str = str(filter_arg)
+        assert "lightwell" not in q_str
+        assert "acme" not in q_str

--- a/pulp_service/pulp_service/tests/unit/test_domain_based_permission.py
+++ b/pulp_service/pulp_service/tests/unit/test_domain_based_permission.py
@@ -13,6 +13,8 @@ from base64 import b64encode
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
+from django.test import override_settings
+
 from pulp_service.app.authorization import DomainBasedPermission
 
 
@@ -21,7 +23,14 @@ def _encode_identity_header(org_id):
     return b64encode(json.dumps(identity).encode()).decode()
 
 
-def _make_request(method="GET", user=None, domain=None, view_name="pypi-metadata", org_id=None):
+def _make_request(
+    method="GET",
+    user=None,
+    domain=None,
+    view_name="pypi-metadata",
+    org_id=None,
+    path_info="/api/pypi/test/main/simple/",
+):
     """Build a mock DRF request."""
     request = MagicMock()
     request.method = method
@@ -29,7 +38,8 @@ def _make_request(method="GET", user=None, domain=None, view_name="pypi-metadata
     request.pulp_domain = domain
     request.resolver_match = MagicMock()
     request.resolver_match.view_name = view_name
-    request.META = {"REQUEST_METHOD": method, "PATH_INFO": "/api/pypi/test/main/simple/"}
+    request.path_info = path_info
+    request.META = {"REQUEST_METHOD": method, "PATH_INFO": path_info}
     if org_id is not None:
         request.META["HTTP_X_RH_IDENTITY"] = _encode_identity_header(org_id)
     return request
@@ -564,3 +574,161 @@ class TestPermitUnexpectedError:
             permission.has_permission(request, view)
 
         assert any("Unexpected error" in r.message and "guard permit" in r.message for r in caplog.records)
+
+
+_MULTI_DOMAIN_POLICIES = {
+    "lightwell": {
+        "readonly_group": "Lightwell-ReadOnly",
+        "subscription_feature": "lightwell-network",
+        "subscription_endpoints": ["/api/v3/content/"],
+    },
+    "acme": {
+        "readonly_group": "Acme-ReadOnly",
+        "subscription_feature": "acme-feature",
+        "subscription_endpoints": ["/api/v3/content/"],
+    },
+}
+
+
+class TestGenericDomainAccessPolicies:
+    """Verify DOMAIN_ACCESS_POLICIES supports multiple domains, that an empty
+    config disables policy-based access, and that subscription endpoint path
+    matching works correctly."""
+
+    @override_settings(DOMAIN_ACCESS_POLICIES={})
+    @patch("pulp_service.app.authorization.get_domain_pk", return_value=42)
+    @patch("pulp_service.app.authorization.DomainOrg.objects")
+    def test_empty_policies_readonly_group_no_access(self, mock_domain_org, mock_get_domain_pk):
+        """With no policies configured, readonly group membership grants nothing."""
+        mock_domain_org.filter.return_value.exists.return_value = False
+        permission = DomainBasedPermission()
+        domain = _make_domain("lightwell")
+        request = _make_request(method="GET", user=_make_authenticated_user(in_readonly_group=True), domain=domain)
+        view = _make_regular_view()
+
+        assert permission.has_permission(request, view) is False
+
+    @override_settings(DOMAIN_ACCESS_POLICIES=_MULTI_DOMAIN_POLICIES)
+    def test_second_domain_readonly_group_grants_access(self):
+        """A second domain's readonly_group policy grants read access."""
+        permission = DomainBasedPermission()
+        domain = _make_domain("acme")
+        request = _make_request(method="GET", user=_make_authenticated_user(in_readonly_group=True), domain=domain)
+        view = _make_regular_view()
+
+        assert permission.has_permission(request, view) is True
+
+    @override_settings(DOMAIN_ACCESS_POLICIES=_MULTI_DOMAIN_POLICIES)
+    @patch("pulp_service.app.authorization.get_domain_pk", return_value=42)
+    @patch("pulp_service.app.authorization.DomainOrg.objects")
+    def test_second_domain_write_denied(self, mock_domain_org, mock_get_domain_pk):
+        """Readonly group on a second domain still denies write access."""
+        mock_domain_org.filter.return_value.exists.return_value = False
+        permission = DomainBasedPermission()
+        domain = _make_domain("acme")
+        request = _make_request(
+            method="POST",
+            user=_make_authenticated_user(in_readonly_group=True),
+            domain=domain,
+            view_name="repositories-list",
+        )
+
+        assert permission.has_permission(request, MagicMock()) is False
+
+    @override_settings(DOMAIN_ACCESS_POLICIES={"acme": {"readonly_group": "Acme-ReadOnly"}})
+    @patch("pulp_service.app.authorization.get_domain_pk", return_value=42)
+    @patch("pulp_service.app.authorization.DomainOrg.objects")
+    def test_policy_scoped_to_own_domain(self, mock_domain_org, mock_get_domain_pk):
+        """A policy for 'acme' grants nothing on 'other-domain'."""
+        mock_domain_org.filter.return_value.exists.return_value = False
+        permission = DomainBasedPermission()
+        domain = _make_domain("other-domain")
+        request = _make_request(method="GET", user=_make_authenticated_user(in_readonly_group=True), domain=domain)
+        view = _make_regular_view()
+
+        assert permission.has_permission(request, view) is False
+
+    @override_settings(
+        DOMAIN_ACCESS_POLICIES={
+            "lightwell": {
+                "readonly_group": "",
+                "subscription_feature": "lightwell-network",
+                "subscription_endpoints": ["/api/v3/content/"],
+            },
+        }
+    )
+    @patch("pulp_service.app.authorization.get_domain_pk", return_value=42)
+    @patch("pulp_service.app.authorization.DomainOrg.objects")
+    def test_subscription_path_no_match_skips_check(self, mock_domain_org, mock_get_domain_pk):
+        """When request path doesn't match subscription_endpoints and no readonly_group,
+        no policy-based access is granted."""
+        mock_domain_org.filter.return_value.exists.return_value = False
+        permission = DomainBasedPermission()
+        domain = _make_domain("lightwell")
+        request = _make_request(
+            method="GET",
+            user=_make_authenticated_user(),
+            domain=domain,
+            path_info="/api/v3/repositories/",
+            org_id="12345",
+        )
+        view = _make_regular_view()
+
+        assert permission.has_permission(request, view) is False
+
+    @override_settings(
+        DOMAIN_ACCESS_POLICIES={
+            "lightwell": {
+                "readonly_group": "",
+                "subscription_feature": "lightwell-network",
+                "subscription_endpoints": ["/api/v3/content/"],
+            },
+        }
+    )
+    @patch("pulp_service.app.authorization.FeatureContentGuard")
+    def test_subscription_path_matches_and_entitled(self, mock_guard_cls):
+        """When path matches subscription_endpoints and org has the feature, access granted."""
+        mock_guard_cls.return_value.check_feature.return_value = True
+        permission = DomainBasedPermission()
+        domain = _make_domain("lightwell")
+        request = _make_request(
+            method="GET",
+            user=_make_authenticated_user(),
+            domain=domain,
+            path_info="/api/v3/content/rpm/packages/",
+            org_id="12345",
+        )
+        view = _make_regular_view()
+
+        assert permission.has_permission(request, view) is True
+        mock_guard_cls.assert_called_once_with(features=["lightwell-network"])
+        mock_guard_cls.return_value.check_feature.assert_called_once_with("12345")
+
+    @override_settings(
+        DOMAIN_ACCESS_POLICIES={
+            "lightwell": {
+                "readonly_group": "",
+                "subscription_feature": "lightwell-network",
+                "subscription_endpoints": ["/api/v3/content/"],
+            },
+        }
+    )
+    @patch("pulp_service.app.authorization.FeatureContentGuard")
+    @patch("pulp_service.app.authorization.get_domain_pk", return_value=42)
+    @patch("pulp_service.app.authorization.DomainOrg.objects")
+    def test_subscription_path_matches_but_not_entitled(self, mock_domain_org, mock_get_domain_pk, mock_guard_cls):
+        """When path matches but org lacks the feature and no readonly_group, denied."""
+        mock_domain_org.filter.return_value.exists.return_value = False
+        mock_guard_cls.return_value.check_feature.return_value = False
+        permission = DomainBasedPermission()
+        domain = _make_domain("lightwell")
+        request = _make_request(
+            method="GET",
+            user=_make_authenticated_user(),
+            domain=domain,
+            path_info="/api/v3/content/rpm/packages/",
+            org_id="12345",
+        )
+        view = _make_regular_view()
+
+        assert permission.has_permission(request, view) is False


### PR DESCRIPTION
Move lightwell-specific constants and methods out of DomainBasedPermission into a settings-driven DOMAIN_ACCESS_POLICIES dict.

A new _check_domain_policy method handles readonly group and subscription checks generically based on the policy config, making it straightforward to add future domain policies without touching authorization logic.

JIRA: PULP-2050

Needed for #1344

## Summary by Sourcery

Replace hardcoded Lightwell-specific access checks with configurable domain access policies used by DomainBasedPermission for read-only and subscription-based access control.

New Features:
- Introduce settings-driven DOMAIN_ACCESS_POLICIES to define per-domain readonly groups and subscription-based access rules.
- Add generic domain policy evaluation in DomainBasedPermission that applies configured readonly group and subscription feature checks across domains.

Enhancements:
- Update permission scoping logic to honor readonly group mappings from DOMAIN_ACCESS_POLICIES for multiple domains instead of a single hardcoded domain.

Documentation:
- Clarify behavior of domain access policies via updated test docstrings and comments in authorization and test modules.

Tests:
- Extend unit tests to cover generic DOMAIN_ACCESS_POLICIES behavior, including multi-domain support, empty configuration, and subscription endpoint path matching.
- Adapt functional Lightwell tests to rely on DOMAIN_ACCESS_POLICIES settings instead of hardcoded group and domain constants.