### PR TITLE
feat: add pulp-docs as context source for Jira Planner

### DIFF
--- a/.alcove/agents/planner.yml
+++ b/.alcove/agents/planner.yml
@@ -47,10 +47,14 @@ prompt: |
   ## Interaction Protocol
 
   1. Read the full ticket description above
-  2. Analyze the problem from every team perspective above
-  3. Read the relevant source code in the repository to ground your analysis
-  4. Produce a concrete implementation plan
-  5. Write the plan as your output (it will be posted as a Jira comment)
+  2. Check /workspace/pulp-docs/ for relevant documented decisions,
+     architecture notes, CLI guides, and past constraints that affect
+     this ticket. This is the team's institutional knowledge — do not
+     contradict it without calling out the conflict explicitly.
+  3. Analyze the problem from every team perspective above
+  4. Read the relevant source code in the repository to ground your analysis
+  5. Produce a concrete implementation plan
+  6. Write the plan as your output (it will be posted as a Jira comment)
 
   ## Plan Format
 
@@ -114,6 +118,8 @@ prompt: |
 repos:
   - name: pulp-service
     url: https://github.com/pulp/pulp-service.git
+  - name: pulp-docs
+    url: https://gitlab.cee.redhat.com/hosted-pulp/pulp-docs.git
 
 timeout: 900
 enforcement_mode: monitor


### PR DESCRIPTION
## Summary

The Jira Planner agent now clones `hosted-pulp/pulp-docs` from GitLab alongside `pulp-service`, giving it access to the team's documented decisions, architecture notes, CLI guides, and constraints.

## Changes

- `.alcove/agents/planner.yml`: added `pulp-docs` repo + interaction protocol step to check it before planning

## Why

The planner currently produces plans in a vacuum — it reads the code but ignores institutional knowledge. Example: on PULP-2057, the planner assumed OAuth2 auth for the CLI when the team already decided on BasicAuth (documented in pulp-docs/cli-guide.md). With this change, the planner checks pulp-docs first and flags conflicts with existing decisions.

## Prerequisites

- GitLab credential (`pulp-docs-bot`) added to the Hosted Pulp team on the Alcove dashboard (done)
- `GATE_GITLAB_HOST` passthrough for `gitlab.cee.redhat.com` (alcove#746 — planner says it's already implemented)

## Summary by Sourcery

Integrate the pulp-docs repository into the Jira Planner agent to ground plans in documented team decisions and constraints.

New Features:
- Add pulp-docs GitLab repository as an additional context source for the Jira Planner agent.

Enhancements:
- Update the planner interaction protocol to consult pulp-docs for institutional knowledge before analyzing tickets and producing implementation plans.