### PR TITLE
feat: redesign Jira Planner for epic-aware planning with plan tasks

### DIFF
--- a/.alcove/agents/planner.yml
+++ b/.alcove/agents/planner.yml
@@ -1,119 +1,130 @@
 name: Planner
 description: |
-  Multi-perspective planning agent for Jira tickets. Reads a Jira issue,
-  convenes a diverse team of specialist perspectives, and produces an
-  implementation plan posted as a Jira comment.
+  Implementation planner for Jira tickets. Reads a Jira issue, checks
+  documented team decisions in pulp-docs, analyzes the codebase, and
+  produces an actionable implementation plan.
+
+  Supports two flows:
+  - epic: plan goes into a child Task's description with proposed task breakdown
+  - standalone: plan posted as a Jira comment (legacy behavior)
 
 prompt: |
-  You are an SDLC Planning Committee for the pulp-service project. You operate
-  as a diverse team of specialists who collaboratively produce and refine
-  implementation plans.
-
-  ## Your Team
-
-  For every planning cycle, you MUST produce analysis from each perspective:
-
-  - **System Architect** — component boundaries, data flow, API design,
-    migration strategy, backward compatibility, Django/DRF patterns
-  - **UI/UX Designer** — API ergonomics, error responses, documentation
-    for API consumers, CLI experience
-  - **Security (Red Team)** — threat modeling, X-RH-IDENTITY auth,
-    multi-tenancy isolation, injection vectors, blast radius
-  - **DevOps Engineer** — CI/CD impact, container image changes, deployment
-    strategy, rollback plan, three-service architecture (api/content/worker)
-  - **Technical Writer** — documentation needs, API reference updates,
-    changelog entries, user-facing impact
-  - **QA/Testing Specialist** — test strategy, edge cases, functional test
-    needs, manual verification checklist, regression risks
-  - **Performance Engineer** — database query impact, migration costs,
-    content serving performance, worker task throughput
+  You are an implementation planner for the pulp-service project (a Django
+  REST Framework plugin for Pulpcore on Red Hat's cloud platform).
 
   ## Ticket
 
   Key: {{issue_key}}
   Title: {{issue_title}}
   URL: {{issue_url}}
+  Flow: {{flow}}
 
   ### Description
   {{issue_body}}
 
-  ## Review Feedback (if revising)
-  {{review_feedback}}
-
-  If review feedback is present above, you are revising a previous plan.
-  Address every 🔴 Blocking finding. Incorporate 🟡 Should Fix findings
-  where reasonable. 💡 Suggestions are optional.
+  ## Plan Task Context (epic flow only)
+  New plan task key: {{new_plan_task_key}}
+  Existing plan task keys: {{existing_plan_task_keys}}
 
   ## Interaction Protocol
 
   1. Read the full ticket description above
   2. Check /workspace/pulp-docs/ for relevant documented decisions,
-     architecture notes, CLI guides, and past constraints that affect
-     this ticket. This is the team's institutional knowledge — do not
-     contradict it without calling out the conflict explicitly.
-  3. Analyze the problem from every team perspective above
-  4. Read the relevant source code in the repository to ground your analysis
-  5. Produce a concrete implementation plan
-  6. Write the plan as your output (it will be posted as a Jira comment)
+     architecture notes, CLI guides, and past constraints. This is the
+     team's institutional knowledge — do not contradict it without
+     calling out the conflict explicitly.
+  3. Read the relevant source code in /workspace/pulp-service/ to
+     ground your analysis in actual implementation
+  4. Analyze the problem — focus on non-obvious concerns:
+     - Security: auth patterns, multi-tenancy, blast radius
+     - Architecture: component boundaries, migration risks
+     - Testing: edge cases, regression risks
+     - DevOps: deployment impact, rollback safety
+     Only surface perspectives that have substantive findings.
+     Do NOT produce filler analysis for perspectives with nothing to add.
+  5. Produce the implementation plan
+  6. Write outputs (see below)
 
   ## Plan Format
 
-  Your output will be posted as a Jira comment. Jira does NOT render
-  markdown — no #, *, -, ```, or []() syntax. Use plain text with
-  clear structure:
+  Use plain text — Jira does NOT render markdown.
 
-  ```
   IMPLEMENTATION PLAN
   Generated: YYYY-MM-DD by SDLC Planner
 
   SUMMARY
-  [1-3 sentence overview of the approach]
+  1-3 sentence overview of the approach.
 
-  TEAM ANALYSIS
-  [Key findings from each specialist perspective — NOT exhaustive,
-   only the non-obvious insights and concerns. Use "Architect:" ,
-   "Security:", etc. prefixes for each perspective.]
+  KEY FINDINGS
+  Only non-obvious concerns from your analysis. Skip this section
+  entirely if everything is straightforward. Use "Security:", "Arch:",
+  etc. prefixes only for perspectives with real findings.
 
   WORK BREAKDOWN
-  [Numbered list of implementation steps, each with:]
+  Numbered list of implementation steps:
   1) Step title
-     Files: list of files/components affected
+     Files: files/components affected
      Risk: low/medium/high
-     Dependencies: other steps this depends on
+     Dependencies: other steps
      Complexity: estimate
 
-  OPEN QUESTIONS
-  [Numbered list of things the team needs human input on]
+  PROPOSED TASKS (epic flow only)
+  If flow is "epic", list the child tasks you recommend creating:
+  1) Task title
+     Description: what this task accomplishes
+     Acceptance criteria: how to verify it's done
 
-  RISKS AND MITIGATIONS
-  [Numbered list of top risks with mitigations]
-  ```
+  OPEN QUESTIONS
+  Numbered list of things needing human input before proceeding.
+
+  ## Resolving the plan task key (epic flow)
+
+  If flow is "epic", determine which plan task to use:
+  - If new_plan_task_key is not empty, use it (task was just created)
+  - If existing_plan_task_keys is not empty, use the first key
+  - Output the resolved key as plan_task_key
 
   ## Rules
 
-  - Be clear, lean, brief, and direct. Use the fewest words possible
-    without losing meaning or comprehension.
-  - Call out disagreements between specialists explicitly
-  - Keep the plan actionable — each step should be a single PR worth of work
-  - Reference existing code patterns by file path when relevant
-  - When steps are ready for implementation, note which could use `agentic-sdlc`
-  - Be concrete. Name files, functions, classes. Do not be vague.
+  - Be clear, lean, brief, and direct
+  - Reference existing code by file path — be concrete, not vague
+  - Each step should be a single PR worth of work
+  - Note which steps could use the agentic-sdlc label for automation
+  - If pulp-docs documents a relevant decision, cite it
 
-  CRITICAL — YOUR VERY LAST ACTION must be writing outputs to the pipeline file.
-  Use Python to safely serialize your plan (handles quotes and newlines):
+  ## Writing Outputs (MANDATORY)
+
+  Your VERY LAST ACTION must be writing outputs. The workflow fails without it.
+
+  For epic flow — output both plan and plan_task_key:
 
     python3 - <<'PYEOF'
     import json
     output = {
-        "plan": """Your detailed implementation plan here.
-    Can span multiple lines safely."""
+        "plan": """Your implementation plan here.
+    Can span multiple lines.""",
+        "plan_task_key": "PULP-NNNN"
     }
-    # ALL values MUST be strings. Non-string values silently discard ALL outputs.
     with open("/tmp/alcove-outputs.json", "w") as f:
         json.dump(output, f)
+    print("OUTPUTS WRITTEN:", json.dumps(output)[:200])
     PYEOF
 
-  Replace the plan value with your actual plan.
+  For standalone flow — output plan only:
+
+    python3 - <<'PYEOF'
+    import json
+    output = {
+        "plan": """Your implementation plan here.
+    Can span multiple lines."""
+    }
+    with open("/tmp/alcove-outputs.json", "w") as f:
+        json.dump(output, f)
+    print("OUTPUTS WRITTEN:", json.dumps(output)[:200])
+    PYEOF
+
+  ALL values MUST be strings. Replace placeholders with actual content.
+  Verify "OUTPUTS WRITTEN:" appears before ending your turn.
 
 repos:
   - name: pulp-service
@@ -129,3 +140,4 @@ profiles:
 
 outputs:
   - plan
+  - plan_task_key

--- a/.alcove/workflows/planner.yml
+++ b/.alcove/workflows/planner.yml
@@ -113,13 +113,13 @@ workflow:
     depends: "plan-changelog.Succeeded"
     inputs:
       issue_key: "{{trigger.issue_key}}"
-      body: "Implementation plan created at {{steps.plan-epic.outputs.plan_task_key}}. The plan includes a draft task breakdown. Reply here to discuss or request changes. When ready, reply 'approve plan' and I'll create the tasks."
+      body: "Implementation plan created at {{steps.plan-epic.outputs.plan_task_key}}. The plan includes a draft task breakdown. Reply here to discuss or request changes."
 
   # --- Failure handling ---
   - id: post-failure
     type: bridge
     action: jira-add-comment
-    depends: "plan-epic.Failed || plan-standalone.Failed"
+    depends: "detect.Failed || find-plan-task.Failed || create-plan-task.Failed || plan-epic.Failed || plan-standalone.Failed"
     inputs:
       issue_key: "{{trigger.issue_key}}"
       body: "Automated planning failed. Check the workflow logs for details."

--- a/.alcove/workflows/planner.yml
+++ b/.alcove/workflows/planner.yml
@@ -5,87 +5,121 @@ trigger:
     labels: [needs-planning]
 
 workflow:
-  - id: plan
-    type: agent
-    agent: Planner
+  # Step 1: Detect issue type and parent
+  - id: detect
+    type: bridge
+    action: jira-get-issue
     inputs:
       issue_key: "{{trigger.issue_key}}"
-      issue_title: "{{trigger.issue_title}}"
-      issue_body: "{{trigger.issue_body}}"
-      issue_url: "{{trigger.issue_url}}"
-    outputs: [plan]
+    outputs: [issue_type, parent_key]
 
-  - id: review
-    type: agent
-    agent: Plan Reviewer
-    depends: "plan.Succeeded"
-    max_iterations: 3
-    inputs:
-      issue_key: "{{trigger.issue_key}}"
-      issue_title: "{{trigger.issue_title}}"
-      issue_body: "{{trigger.issue_body}}"
-      issue_url: "{{trigger.issue_url}}"
-      plan: "{{steps.plan.outputs.plan}}"
-    outputs: [approved, feedback]
-    output_contract:
-      required: [approved, feedback]
-      allowed_values:
-        approved: ["true", "false"]
-      routing_field: approved
-      success_value: "true"
-
-  - id: revise
-    type: agent
-    agent: Planner
-    depends: "review.Failed"
-    max_iterations: 2
-    inputs:
-      issue_key: "{{trigger.issue_key}}"
-      issue_title: "{{trigger.issue_title}}"
-      issue_body: "{{trigger.issue_body}}"
-      issue_url: "{{trigger.issue_url}}"
-      review_feedback: "{{steps.review.outputs.feedback}}"
-    outputs: [plan]
-
-  - id: review-revised
-    type: agent
-    agent: Plan Reviewer
-    depends: "revise.Succeeded"
-    max_iterations: 2
-    inputs:
-      issue_key: "{{trigger.issue_key}}"
-      issue_title: "{{trigger.issue_title}}"
-      issue_body: "{{trigger.issue_body}}"
-      issue_url: "{{trigger.issue_url}}"
-      plan: "{{steps.revise.outputs.plan}}"
-    outputs: [approved, feedback]
-    output_contract:
-      required: [approved, feedback]
-      allowed_values:
-        approved: ["true", "false"]
-      routing_field: approved
-      success_value: "true"
-
-  - id: post-plan
+  # --- Flow 2: Non-epic WITH parent → redirect to epic ---
+  - id: redirect-comment
     type: bridge
     action: jira-add-comment
-    depends: "review.Succeeded"
+    depends: "detect.Succeeded"
+    condition: "steps.detect.outputs.issue_type != 'Epic' && steps.detect.outputs.parent_key != ''"
     inputs:
       issue_key: "{{trigger.issue_key}}"
-      body: "{{steps.plan.outputs.plan}}"
+      body: "Planning should be done at the epic level. Please add needs-planning to {{steps.detect.outputs.parent_key}} instead."
 
-  - id: post-revised-plan
+  - id: redirect-remove-label
+    type: bridge
+    action: jira-update-issue
+    depends: "redirect-comment.Succeeded"
+    inputs:
+      issue_key: "{{trigger.issue_key}}"
+      remove_labels: ["needs-planning"]
+
+  # --- Flow 3: Standalone non-epic (no parent) → comment-based plan ---
+  - id: plan-standalone
+    type: agent
+    agent: Planner
+    depends: "detect.Succeeded"
+    condition: "steps.detect.outputs.issue_type != 'Epic' && steps.detect.outputs.parent_key == ''"
+    inputs:
+      issue_key: "{{trigger.issue_key}}"
+      issue_title: "{{trigger.issue_title}}"
+      issue_body: "{{trigger.issue_body}}"
+      issue_url: "{{trigger.issue_url}}"
+      flow: "standalone"
+    outputs: [plan]
+
+  - id: post-standalone-plan
     type: bridge
     action: jira-add-comment
-    depends: "review-revised.Succeeded"
+    depends: "plan-standalone.Succeeded"
     inputs:
       issue_key: "{{trigger.issue_key}}"
-      body: "{{steps.revise.outputs.plan}}"
+      body: "{{steps.plan-standalone.outputs.plan}}"
 
+  # --- Flow 1: Epic → plan task lifecycle ---
+  - id: find-plan-task
+    type: bridge
+    action: jira-search-issues
+    depends: "detect.Succeeded"
+    condition: "steps.detect.outputs.issue_type == 'Epic'"
+    inputs:
+      jql: "parent = {{trigger.issue_key}} AND summary ~ 'Implementation Plan'"
+      max_results: 1
+    outputs: [issue_keys, total]
+
+  - id: create-plan-task
+    type: bridge
+    action: jira-create-issue
+    depends: "find-plan-task.Succeeded"
+    condition: "steps.find-plan-task.outputs.total == 0"
+    inputs:
+      project: "PULP"
+      summary: "Implementation Plan for {{trigger.issue_key}}"
+      issue_type: "Task"
+      parent: "{{trigger.issue_key}}"
+      labels: ["plan"]
+    outputs: [issue_key]
+
+  - id: plan-epic
+    type: agent
+    agent: Planner
+    depends: "create-plan-task.Succeeded || find-plan-task.Succeeded"
+    inputs:
+      issue_key: "{{trigger.issue_key}}"
+      issue_title: "{{trigger.issue_title}}"
+      issue_body: "{{trigger.issue_body}}"
+      issue_url: "{{trigger.issue_url}}"
+      flow: "epic"
+      new_plan_task_key: "{{steps.create-plan-task.outputs.issue_key}}"
+      existing_plan_task_keys: "{{steps.find-plan-task.outputs.issue_keys}}"
+    outputs: [plan, plan_task_key]
+
+  - id: update-plan-task
+    type: bridge
+    action: jira-update-issue
+    depends: "plan-epic.Succeeded"
+    inputs:
+      issue_key: "{{steps.plan-epic.outputs.plan_task_key}}"
+      description: "{{steps.plan-epic.outputs.plan}}"
+
+  - id: plan-changelog
+    type: bridge
+    action: jira-add-comment
+    depends: "update-plan-task.Succeeded"
+    inputs:
+      issue_key: "{{steps.plan-epic.outputs.plan_task_key}}"
+      body: "Plan created/updated. See the description for the current version."
+
+  - id: notify-epic
+    type: bridge
+    action: jira-add-comment
+    depends: "plan-changelog.Succeeded"
+    inputs:
+      issue_key: "{{trigger.issue_key}}"
+      body: "Implementation plan created at {{steps.plan-epic.outputs.plan_task_key}}. The plan includes a draft task breakdown. Reply here to discuss or request changes. When ready, reply 'approve plan' and I'll create the tasks."
+
+  # --- Failure handling ---
   - id: post-failure
     type: bridge
     action: jira-add-comment
-    depends: "plan.Failed || review-revised.Failed"
+    depends: "plan-epic.Failed || plan-standalone.Failed"
     inputs:
       issue_key: "{{trigger.issue_key}}"
-      body: "⚠️ Automated planning could not converge after multiple review rounds. Manual planning needed. Remove the `needs-planning` label to prevent re-triggering."
+      body: "Automated planning failed. Check the workflow logs for details."


### PR DESCRIPTION
## Summary

Redesigns the Jira Planner workflow to create implementation plans as first-class Jira artifacts instead of buried comments.

## Three Flows

| Trigger | Flow | What happens |
|---------|------|-------------|
| Epic + `needs-planning` | **Plan Task** | Creates child Task "Implementation Plan for PULP-XXXX", writes plan in description, notifies epic |
| Non-epic with parent | **Redirect** | Comments "add needs-planning to the epic instead", removes label |
| Standalone non-epic | **Comment** | Current behavior — plan as comment |

## Key Changes

- **Workflow** (`.alcove/workflows/planner.yml`): three-flow routing using `condition:` gates on issue type
- **Agent** (`.alcove/agents/planner.yml`): accepts `flow` input, adds `pulp-docs` repo for institutional knowledge, drops 7-specialist roleplay, removes reviewer step

## What's Removed

- **Reviewer step** — was the #1 failure point (429 quota, output contract violations). Humans review via Jira comments instead.
- **7-specialist team roleplay** — replaced with focused analysis that only surfaces non-obvious findings

## Dependencies

Requires [alcove#747](https://github.com/alcove-ai/alcove/issues/747) for bridge action enhancements:
- `jira-get-issue`: detect issue type (Epic vs Task)
- `jira-create-issue`: `parent` input for child task creation
- `jira-update-issue`: `description` input for plan updates

The workflow will show sync validation errors until alcove#747 is deployed. This is expected and non-blocking for other workflows.

## Summary by Sourcery

Redesign Jira planning workflow to support epic-aware implementation plans as dedicated child tasks while simplifying the planner agent and removing the review loop.

New Features:
- Introduce separate flows for epic issues, non-epic issues with a parent, and standalone non-epic issues in the Jira Planner workflow.
- Create or reuse dedicated child plan tasks for epics and store implementation plans in the task description, including a draft task breakdown.
- Add support for proposed child task definitions in epic planning outputs and optional agentic-sdlc automation hints.

Enhancements:
- Simplify the Planner agent prompt to focus on grounded, non-obvious analysis using pulp-service code and pulp-docs institutional knowledge.
- Adjust planner outputs to include an optional plan_task_key alongside the plan, with explicit output-writing protocols for different flows.
- Update failure handling to report generic planning failures rather than multi-round review convergence issues.

Chores:
- Remove the multi-specialist roleplay and reviewer agent loop from the planning workflow, streamlining it to a single planner pass.
- Integrate pulp-docs as an additional repository for documented decisions and architecture notes used during planning.