### PR TITLE
refactor: extract subscription check into features_service module

### DIFF
--- a/pulp_service/pulp_service/app/authorization.py
+++ b/pulp_service/pulp_service/app/authorization.py
@@ -13,7 +13,8 @@ from rest_framework.permissions import SAFE_METHODS, BasePermission
 from pulpcore.plugin.models import Domain
 from pulpcore.plugin.util import extract_pk, get_domain_pk
 
-from pulp_service.app.models import DomainOrg, FeatureContentGuard
+from pulp_service.app.features_service import check_subscription
+from pulp_service.app.models import DomainOrg
 
 _logger = logging.getLogger(__name__)
 org_id_var = ContextVar("org_id")
@@ -133,9 +134,8 @@ class DomainBasedPermission(BasePermission):
             if any(path.startswith(endpoint) for endpoint in subscription_endpoints):
                 decoded_header = self.get_decoded_identity_header(request)
                 org_id = self.get_org_id(decoded_header)
-                guard = FeatureContentGuard(features=[subscription_feature])
                 try:
-                    if org_id and guard.check_feature(org_id):
+                    if org_id and check_subscription(org_id, [subscription_feature]):
                         return True
                 except Exception:
                     _logger.exception("Unexpected error checking %s subscription", subscription_feature)

--- a/pulp_service/pulp_service/app/features_service.py
+++ b/pulp_service/pulp_service/app/features_service.py
@@ -1,0 +1,137 @@
+import json
+import logging
+import threading
+import time
+from datetime import UTC, datetime
+from gettext import gettext as _
+from hashlib import sha256
+
+import requests
+from django.conf import settings
+
+from pulpcore.cache import Cache
+
+_logger = logging.getLogger(__name__)
+_session_lock = threading.Lock()
+_session = None
+
+
+class FeatureContentGuardCache(Cache):
+    default_base_key = "PULP_FEATURE_CONTENTGUARD_CACHE"
+    default_expires_ttl = 86400  # The key expires in one day.
+
+
+def _get_session():
+    global _session
+    if _session is None:
+        with _session_lock:
+            if _session is None:
+                s = requests.Session()
+                s.cert = settings.FEATURE_SERVICE_API_CERT_PATH
+                _session = s
+    return _session
+
+
+def _get_cached_result(feature_cache, key):
+    """
+    Returns the cached True/False result for `key`, or None if there is no live entry.
+
+    `Cache.set`'s `expires` argument calls Redis' `EXPIRE` on the *entire* hash the
+    entry lives under, not on the individual field (Redis hash fields don't carry their
+    own TTL). Every account sharing `FeatureContentGuardCache`'s single base key would
+    therefore have its cached result's lifetime reset by any *other* account's write,
+    which can prematurely evict still-valid entries. Instead, the expiration is embedded
+    in the cached value itself and validated on read here, matching the pattern
+    `pulpcore.cache.AsyncContentCache` already uses for the same reason.
+    """
+    raw = feature_cache.get(key)
+    if not raw:
+        return None
+    try:
+        entry = json.loads(raw)
+        if entry["expires_at"] < time.time():
+            return None
+        return entry["allowed"]
+    except (TypeError, ValueError, KeyError):
+        return None
+
+
+def _set_cached_result(feature_cache, key, allowed):
+    entry = {"allowed": allowed, "expires_at": time.time() + feature_cache.default_expires_ttl}
+    feature_cache.set(key, json.dumps(entry), expires=feature_cache.default_expires_ttl)
+
+
+def _call_features_service(account_id, features):
+    params = [("accountId", account_id), *(("features", feature) for feature in features)]
+    # This function may run synchronously on the content app's shared sync-to-async
+    # worker thread (via FeatureContentGuard.permit and pulpcore's sync_to_async). A
+    # slow or hanging call here doesn't just delay this request -- it can stall every
+    # other request being served through that same thread, so this must be bounded.
+    #
+    # This must be a real Python tuple built here, not a settings value passed through
+    # as-is: `requests` only splits a *tuple* into (connect, read) timeouts, and Pulp's
+    # settings pipeline can silently turn a tuple default into a list, which `requests`
+    # then treats as a single (invalid) timeout value and raises a ValueError.
+    timeout = (settings.FEATURE_SERVICE_API_CONNECT_TIMEOUT, settings.FEATURE_SERVICE_API_READ_TIMEOUT)
+
+    try:
+        _logger.info("[%s] Making a request to feature service API ...", datetime.now(tz=UTC))
+        session = _get_session()
+        response = session.get(
+            settings.FEATURE_SERVICE_API_URL,
+            params=params,
+            timeout=timeout,
+        )
+        response.raise_for_status()
+        _logger.info("[%s] Got a response from feature service API!", datetime.now(tz=UTC))
+
+        features_available = {feature["name"] for feature in response.json()["features"]}
+        return features_available == set(features)
+    except requests.Timeout as err:
+        _logger.warning(
+            "Failed to fetch the Subscription feature information for a user. "
+            "The Features Service API did not respond within %s seconds.",
+            timeout,
+        )
+        raise PermissionError(_("Access denied.")) from err
+    except requests.HTTPError as err:
+        status_code = err.response.status_code if err.response is not None else None
+        if status_code == 400:
+            _logger.exception("Failed to request information for a user. BadRequest. URL: %s", err.request.url)
+
+        if status_code == 403:
+            _logger.exception(
+                "Failed to request information for a user. Permission Denied. Verify if the certificate is still valid."
+            )
+
+        _logger.warning(_("Failed to fetch the Subscription feature information for a user."))
+        raise PermissionError(_("Access denied.")) from err
+    except requests.RequestException as err:
+        _logger.warning("Failed to reach the Features Service API: %s", err)
+        raise PermissionError(_("Access denied.")) from err
+    except Exception as err:
+        # Callers expect either a normal return or PermissionError -- nothing else.
+        # FeatureContentGuard.permit() in particular requires this contract
+        # (pulpcore.content.handler.Handler.auth_cached assumes exactly that).
+        # Anything else -- a bug, a misconfigured setting, an unexpected response
+        # shape -- would escape and crash with a confusing, unrelated
+        # UnboundLocalError in pulpcore's guard-caching finally block, masking the
+        # real error entirely. Fail closed and log loudly instead.
+        _logger.exception("Unexpected error while checking the Features Service.")
+        raise PermissionError(_("Access denied.")) from err
+
+
+def check_subscription(account_id, features):
+    cache_key = f"{account_id}-{','.join(features)}"
+    cache_key_digest = sha256(bytes(cache_key, "utf8")).hexdigest()
+    feature_cache = FeatureContentGuardCache()
+    account_allowed = _get_cached_result(feature_cache, cache_key_digest)
+
+    if account_allowed is None:
+        _logger.debug("Feature cache MISS for key %s", cache_key_digest)
+        account_allowed = _call_features_service(account_id, features)
+        _set_cached_result(feature_cache, cache_key_digest, account_allowed)
+    else:
+        _logger.debug("Feature cache HIT for key %s", cache_key_digest)
+
+    return account_allowed

--- a/pulp_service/pulp_service/app/models.py
+++ b/pulp_service/pulp_service/app/models.py
@@ -1,23 +1,19 @@
 import json
 import logging
-import threading
-import time
 from base64 import b64decode
 from binascii import Error as Base64DecodeError
-from datetime import UTC, datetime
 from gettext import gettext as _
-from hashlib import sha256
 
 import jq
-import requests
 from django.conf import settings
 from django.contrib.postgres.fields import ArrayField, HStoreField
 from django.db import models
 
 from pulpcore.app.models import HeaderContentGuard
-from pulpcore.cache import Cache
 from pulpcore.plugin.models import AutoAddObjPermsMixin, BaseModel, Domain, Group
 from pulpcore.plugin.util import get_domain_pk
+
+from pulp_service.app.features_service import check_subscription
 
 _logger = logging.getLogger(__name__)
 
@@ -46,147 +42,18 @@ class DomainOrg(models.Model):
         return f"DomainOrg(org_id={self.org_id})"
 
 
-class FeatureContentGuardCache(Cache):
-    default_base_key = "PULP_FEATURE_CONTENTGUARD_CACHE"
-    default_expires_ttl = 86400  # The key expires in one day.
-
-
 class FeatureContentGuard(HeaderContentGuard, AutoAddObjPermsMixin):
     features = ArrayField(models.TextField())
 
-    _session_lock = threading.Lock()
-    _session = None
-
-    @classmethod
-    def _get_session(cls):
-        """
-        Returns a process-wide ``requests.Session`` configured with the client certificate.
-
-        The previous implementation built a brand new ``ssl.SSLContext`` (re-reading and
-        re-parsing the certificate off disk), a new ``aiohttp.ClientSession``, and a brand
-        new asyncio event loop (via ``asyncio.run``) on *every single content request* that
-        missed the cache. Reusing a session lets urllib3 keep a warm, pooled TLS connection
-        to the Features Service and avoids that repeated setup cost.
-        """
-        if cls._session is None:
-            with cls._session_lock:
-                if cls._session is None:
-                    session = requests.Session()
-                    session.cert = settings.FEATURE_SERVICE_API_CERT_PATH
-                    cls._session = session
-        return cls._session
-
-    def _check_for_feature(self, account_id):
-        session = self._get_session()
-        params = [("accountId", account_id), *(("features", feature) for feature in self.features)]
-        # permit() runs synchronously on the content app's shared sync-to-async worker thread
-        # (pulpcore.content.handler.Handler._permit is invoked via sync_to_async). A slow or
-        # hanging call here doesn't just delay this request -- it can stall every other
-        # request being served through that same thread, so this must be bounded.
-        #
-        # This must be a real Python tuple built here, not a settings value passed through
-        # as-is: `requests` only splits a *tuple* into (connect, read) timeouts, and Pulp's
-        # settings pipeline can silently turn a tuple default into a list, which `requests`
-        # then treats as a single (invalid) timeout value and raises a ValueError.
-        timeout = (settings.FEATURE_SERVICE_API_CONNECT_TIMEOUT, settings.FEATURE_SERVICE_API_READ_TIMEOUT)
-
-        try:
-            _logger.info("[%s] Making a request to feature service API ...", datetime.now(tz=UTC))
-            response = session.get(
-                settings.FEATURE_SERVICE_API_URL,
-                params=params,
-                timeout=timeout,
-            )
-            response.raise_for_status()
-            _logger.info("[%s] Got a response from feature service API!", datetime.now(tz=UTC))
-
-            features_available = {feature["name"] for feature in response.json()["features"]}
-            return features_available == set(self.features)
-        except requests.Timeout as err:
-            _logger.warning(
-                "Failed to fetch the Subscription feature information for a user. "
-                "The Features Service API did not respond within %s seconds.",
-                timeout,
-            )
-            raise PermissionError(_("Access denied.")) from err
-        except requests.HTTPError as err:
-            status_code = err.response.status_code if err.response is not None else None
-            if status_code == 400:
-                _logger.exception("Failed to request information for a user. BadRequest. URL: %s", err.request.url)
-
-            if status_code == 403:
-                _logger.exception(
-                    "Failed to request information for a user. "
-                    "Permission Denied. Verify if the certificate is still valid."
-                )
-
-            _logger.warning(_("Failed to fetch the Subscription feature information for a user."))
-            raise PermissionError(_("Access denied.")) from err
-        except requests.RequestException as err:
-            _logger.warning("Failed to reach the Features Service API: %s", err)
-            raise PermissionError(_("Access denied.")) from err
-        except Exception as err:
-            # `permit()` is only ever allowed to return normally or raise `PermissionError`
-            # (pulpcore.content.handler.Handler.auth_cached assumes exactly that contract).
-            # Anything else -- a bug here, a misconfigured setting, an unexpected response
-            # shape -- would otherwise escape as-is and crash with a confusing, unrelated
-            # `UnboundLocalError` in pulpcore's guard-caching `finally` block, masking the
-            # real error entirely. Fail closed and log loudly instead.
-            _logger.exception("Unexpected error while checking the Features Service.")
-            raise PermissionError(_("Access denied.")) from err
-
-    @staticmethod
-    def _get_cached_result(feature_cache, key):
-        """
-        Returns the cached True/False result for `key`, or None if there is no live entry.
-
-        `Cache.set`'s `expires` argument calls Redis' `EXPIRE` on the *entire* hash the
-        entry lives under, not on the individual field (Redis hash fields don't carry their
-        own TTL). Every account sharing `FeatureContentGuardCache`'s single base key would
-        therefore have its cached result's lifetime reset by any *other* account's write,
-        which can prematurely evict still-valid entries. Instead, the expiration is embedded
-        in the cached value itself and validated on read here, matching the pattern
-        `pulpcore.cache.AsyncContentCache` already uses for the same reason.
-        """
-        raw = feature_cache.get(key)
-        if not raw:
-            return None
-        try:
-            entry = json.loads(raw)
-            if entry["expires_at"] < time.time():
-                return None
-            return entry["allowed"]
-        except (TypeError, ValueError, KeyError):
-            return None
-
-    @staticmethod
-    def _set_cached_result(feature_cache, key, allowed):
-        entry = {"allowed": allowed, "expires_at": time.time() + feature_cache.default_expires_ttl}
-        feature_cache.set(key, json.dumps(entry), expires=feature_cache.default_expires_ttl)
-
     def check_feature(self, account_id):
         """
-        Returns whether `account_id` has all of `self.features`, per the Features Service.
+        Returns whether ``account_id`` has all of ``self.features``, per the Features Service.
 
-        Reuses the same `FeatureContentGuardCache` cache key scheme as `permit()` so that
-        callers checking the same (account_id, features) pair -- e.g. `DomainBasedPermission`
-        checking the `lightwell-network` feature -- share cache entries with this guard and
-        avoid redundant Features Service calls. May raise `PermissionError` if the Features
-        Service call fails (see `_check_for_feature`).
+        Delegates to check_subscription(), which caches results so that callers checking
+        the same (account_id, features) pair share cache entries. May raise PermissionError
+        if the Features Service call fails.
         """
-        cache_key = f"{account_id}-{','.join(self.features)}"
-        cache_key_digest = sha256(bytes(cache_key, "utf8")).hexdigest()
-        feature_cache = FeatureContentGuardCache()
-        account_allowed = self._get_cached_result(feature_cache, cache_key_digest)
-
-        if account_allowed is None:
-            _logger.debug("Feature cache MISS for key %s", cache_key_digest)
-            account_allowed = self._check_for_feature(account_id)
-            self._set_cached_result(feature_cache, cache_key_digest, account_allowed)
-        else:
-            _logger.debug("Feature cache HIT for key %s", cache_key_digest)
-
-        return account_allowed
+        return check_subscription(account_id, self.features)
 
     def permit(self, request):
         try:

--- a/pulp_service/pulp_service/tests/unit/test_domain_based_permission.py
+++ b/pulp_service/pulp_service/tests/unit/test_domain_based_permission.py
@@ -687,10 +687,9 @@ class TestGenericDomainAccessPolicies:
             },
         }
     )
-    @patch("pulp_service.app.authorization.FeatureContentGuard")
-    def test_subscription_path_matches_and_entitled(self, mock_guard_cls):
+    @patch("pulp_service.app.authorization.check_subscription", return_value=True)
+    def test_subscription_path_matches_and_entitled(self, mock_check_sub):
         """When path matches subscription_endpoints and org has the feature, access granted."""
-        mock_guard_cls.return_value.check_feature.return_value = True
         permission = DomainBasedPermission()
         domain = _make_domain("lightwell")
         request = _make_request(
@@ -703,8 +702,7 @@ class TestGenericDomainAccessPolicies:
         view = _make_regular_view()
 
         assert permission.has_permission(request, view) is True
-        mock_guard_cls.assert_called_once_with(features=["lightwell-network"])
-        mock_guard_cls.return_value.check_feature.assert_called_once_with("12345")
+        mock_check_sub.assert_called_once_with("12345", ["lightwell-network"])
 
     @override_settings(
         DOMAIN_ACCESS_POLICIES={
@@ -715,13 +713,12 @@ class TestGenericDomainAccessPolicies:
             },
         }
     )
-    @patch("pulp_service.app.authorization.FeatureContentGuard")
+    @patch("pulp_service.app.authorization.check_subscription", return_value=False)
     @patch("pulp_service.app.authorization.get_domain_pk", return_value=42)
     @patch("pulp_service.app.authorization.DomainOrg.objects")
-    def test_subscription_path_matches_but_not_entitled(self, mock_domain_org, mock_get_domain_pk, mock_guard_cls):
+    def test_subscription_path_matches_but_not_entitled(self, mock_domain_org, mock_get_domain_pk, mock_check_sub):
         """When path matches but org lacks the feature and no readonly_group, denied."""
         mock_domain_org.filter.return_value.exists.return_value = False
-        mock_guard_cls.return_value.check_feature.return_value = False
         permission = DomainBasedPermission()
         domain = _make_domain("lightwell")
         request = _make_request(
@@ -744,15 +741,14 @@ class TestGenericDomainAccessPolicies:
             },
         }
     )
-    @patch("pulp_service.app.authorization.FeatureContentGuard")
+    @patch("pulp_service.app.authorization.check_subscription", side_effect=Exception("sub-error"))
     @patch("pulp_service.app.authorization.get_domain_pk", return_value=42)
     @patch("pulp_service.app.authorization.DomainOrg.objects")
     def test_subscription_feature_guard_exception_denies_access(
-        self, mock_domain_org, mock_get_domain_pk, mock_guard_cls
+        self, mock_domain_org, mock_get_domain_pk, mock_check_sub
     ):
-        """If FeatureContentGuard.check_feature raises, access denied and guard still invoked."""
+        """If check_subscription raises, access denied and subscription still checked."""
         mock_domain_org.filter.return_value.exists.return_value = False
-        mock_guard_cls.return_value.check_feature.side_effect = Exception("guard-error")
         permission = DomainBasedPermission()
         domain = _make_domain("lightwell")
         request = _make_request(
@@ -765,7 +761,7 @@ class TestGenericDomainAccessPolicies:
         view = _make_regular_view()
 
         assert permission.has_permission(request, view) is False
-        mock_guard_cls.return_value.check_feature.assert_called_once_with("12345")
+        mock_check_sub.assert_called_once_with("12345", ["lightwell-network"])
 
     @override_settings(
         DOMAIN_ACCESS_POLICIES={

--- a/pulp_service/pulp_service/tests/unit/test_domain_based_permission.py
+++ b/pulp_service/pulp_service/tests/unit/test_domain_based_permission.py
@@ -810,6 +810,60 @@ class TestGenericDomainAccessPolicies:
 
         assert permission.has_permission(request, _make_regular_view()) is True
 
+    @override_settings(
+        DOMAIN_ACCESS_POLICIES={
+            "lightwell": {
+                "readonly_group": "",
+                "subscription_feature": "lightwell-network",
+                "subscription_endpoints": ["/api/v3/content/"],
+            },
+        },
+        API_ROOT="/api/pulp/",
+    )
+    @patch("pulp_service.app.authorization.check_subscription", return_value=True)
+    def test_domain_prefix_stripped_before_endpoint_matching(self, mock_check_sub):
+        """Requests routed through the domain prefix (e.g. /api/pulp/lightwell/api/v3/content/...)
+        must have the prefix stripped before matching against subscription_endpoints."""
+        permission = DomainBasedPermission()
+        domain = _make_domain("lightwell")
+        request = _make_request(
+            method="GET",
+            user=_make_authenticated_user(),
+            domain=domain,
+            path_info="/api/pulp/lightwell/api/v3/content/rpm/packages/",
+            org_id="12345",
+        )
+        view = _make_regular_view()
+
+        assert permission.has_permission(request, view) is True
+        mock_check_sub.assert_called_once_with("12345", ["lightwell-network"])
+
+    @override_settings(
+        DOMAIN_ACCESS_POLICIES={
+            "lightwell": {
+                "readonly_group": "Lightwell-ReadOnly",
+                "subscription_feature": "lightwell-network",
+                "subscription_endpoints": ["/api/v3/content/"],
+            },
+        }
+    )
+    @patch("pulp_service.app.authorization.check_subscription", side_effect=Exception("service down"))
+    def test_subscription_failure_falls_back_to_readonly_group(self, mock_check_sub):
+        """When check_subscription raises but user is in the readonly_group,
+        access is still granted via the group fallback."""
+        permission = DomainBasedPermission()
+        domain = _make_domain("lightwell")
+        request = _make_request(
+            method="GET",
+            user=_make_authenticated_user(in_readonly_group=True),
+            domain=domain,
+            path_info="/api/v3/content/rpm/packages/",
+            org_id="12345",
+        )
+        view = _make_regular_view()
+
+        assert permission.has_permission(request, view) is True
+
 
 class TestScopeQueryset:
     """Verify scope_queryset includes domains from DOMAIN_ACCESS_POLICIES

--- a/pulp_service/pulp_service/tests/unit/test_feature_content_guard.py
+++ b/pulp_service/pulp_service/tests/unit/test_feature_content_guard.py
@@ -181,6 +181,39 @@ class TestFeatureContentGuardCaching:
         payload = json.loads(mock_set.call_args.args[1])
         assert payload["allowed"] is False
 
+    @patch(_GET_SESSION)
+    @patch.object(FeatureContentGuardCache, "set")
+    @patch.object(FeatureContentGuardCache, "get")
+    def test_multi_feature_guard_allows_when_all_features_present(self, mock_get, mock_set, mock_get_session):
+        multi = ["lightwell-network", "lightwell-analytics"]
+        mock_get.return_value = None
+        session = MagicMock()
+        session.get.return_value = _feature_response(multi)
+        mock_get_session.return_value = session
+        guard = _make_guard(features=multi)
+
+        guard.permit(_make_request())
+
+        payload = json.loads(mock_set.call_args.args[1])
+        assert payload["allowed"] is True
+
+    @patch(_GET_SESSION)
+    @patch.object(FeatureContentGuardCache, "set")
+    @patch.object(FeatureContentGuardCache, "get")
+    def test_multi_feature_guard_denies_when_only_partial_match(self, mock_get, mock_set, mock_get_session):
+        multi = ["lightwell-network", "lightwell-analytics"]
+        mock_get.return_value = None
+        session = MagicMock()
+        session.get.return_value = _feature_response(["lightwell-network"])
+        mock_get_session.return_value = session
+        guard = _make_guard(features=multi)
+
+        with pytest.raises(PermissionError):
+            guard.permit(_make_request())
+
+        payload = json.loads(mock_set.call_args.args[1])
+        assert payload["allowed"] is False
+
 
 class TestFeatureContentGuardFeatureServiceCall:
     @patch(_GET_SESSION)

--- a/pulp_service/pulp_service/tests/unit/test_feature_content_guard.py
+++ b/pulp_service/pulp_service/tests/unit/test_feature_content_guard.py
@@ -17,10 +17,14 @@ from unittest.mock import MagicMock, patch
 import pytest
 import requests
 
-from pulp_service.app.models import FeatureContentGuard, FeatureContentGuardCache
+import pulp_service.app.features_service as _features_mod
+from pulp_service.app.features_service import FeatureContentGuardCache
+from pulp_service.app.models import FeatureContentGuard
 
 FEATURES = ["lightwell-network"]
 ACCOUNT_ID = "1979710"
+
+_GET_SESSION = "pulp_service.app.features_service._get_session"
 
 
 def _make_guard(features=FEATURES):
@@ -51,48 +55,48 @@ def _feature_response(feature_names):
 
 @pytest.fixture(autouse=True)
 def _reset_shared_session():
-    # `_session` is a class-level singleton; make sure tests don't share mocked state.
-    FeatureContentGuard._session = None
+    _features_mod._session = None
     yield
-    FeatureContentGuard._session = None
+    _features_mod._session = None
 
 
 class TestFeatureContentGuardCaching:
+    @patch(_GET_SESSION)
     @patch.object(FeatureContentGuardCache, "set")
     @patch.object(FeatureContentGuardCache, "get")
-    def test_cache_hit_skips_feature_service_call(self, mock_get, mock_set):
+    def test_cache_hit_skips_feature_service_call(self, mock_get, mock_set, mock_get_session):
         entry = json.dumps({"allowed": True, "expires_at": time.time() + 3600})
         mock_get.return_value = entry.encode()
         guard = _make_guard()
-        guard._get_session = MagicMock()
 
         guard.permit(_make_request())
 
-        guard._get_session.assert_not_called()
+        mock_get_session.assert_not_called()
         mock_set.assert_not_called()
 
+    @patch(_GET_SESSION)
     @patch.object(FeatureContentGuardCache, "set")
     @patch.object(FeatureContentGuardCache, "get")
-    def test_cache_hit_denied_skips_feature_service_call_and_raises(self, mock_get, mock_set):
+    def test_cache_hit_denied_skips_feature_service_call_and_raises(self, mock_get, mock_set, mock_get_session):
         entry = json.dumps({"allowed": False, "expires_at": time.time() + 3600})
         mock_get.return_value = entry.encode()
         guard = _make_guard()
-        guard._get_session = MagicMock()
 
         with pytest.raises(PermissionError):
             guard.permit(_make_request())
 
-        guard._get_session.assert_not_called()
+        mock_get_session.assert_not_called()
         mock_set.assert_not_called()
 
+    @patch(_GET_SESSION)
     @patch.object(FeatureContentGuardCache, "set")
     @patch.object(FeatureContentGuardCache, "get")
-    def test_cache_miss_calls_feature_service_and_populates_cache(self, mock_get, mock_set):
+    def test_cache_miss_calls_feature_service_and_populates_cache(self, mock_get, mock_set, mock_get_session):
         mock_get.return_value = None
-        guard = _make_guard()
         session = MagicMock()
         session.get.return_value = _feature_response(FEATURES)
-        guard._get_session = MagicMock(return_value=session)
+        mock_get_session.return_value = session
+        guard = _make_guard()
 
         guard.permit(_make_request())
 
@@ -104,49 +108,54 @@ class TestFeatureContentGuardCaching:
         assert payload["allowed"] is True
         assert payload["expires_at"] > 0
 
+    @patch(_GET_SESSION)
     @patch.object(FeatureContentGuardCache, "set")
     @patch.object(FeatureContentGuardCache, "get")
-    def test_expired_cache_entry_is_treated_as_a_miss(self, mock_get, mock_set):
+    def test_expired_cache_entry_is_treated_as_a_miss(self, mock_get, mock_set, mock_get_session):
         stale_entry = json.dumps({"allowed": True, "expires_at": time.time() - 1})
         mock_get.return_value = stale_entry.encode()
-        guard = _make_guard()
         session = MagicMock()
         session.get.return_value = _feature_response(FEATURES)
-        guard._get_session = MagicMock(return_value=session)
+        mock_get_session.return_value = session
+        guard = _make_guard()
 
         guard.permit(_make_request())
 
         session.get.assert_called_once()
         mock_set.assert_called_once()
 
+    @patch(_GET_SESSION)
     @patch.object(FeatureContentGuardCache, "set")
     @patch.object(FeatureContentGuardCache, "get")
-    def test_legacy_cache_format_does_not_crash_and_is_treated_as_a_miss(self, mock_get, mock_set):
+    def test_legacy_cache_format_does_not_crash_and_is_treated_as_a_miss(self, mock_get, mock_set, mock_get_session):
         # Cached values written by the pre-fix code were bare "true"/"false" strings, not
         # a {"allowed": ..., "expires_at": ...} object. Confirm the new reader degrades
         # gracefully instead of raising.
         mock_get.return_value = b"true"
-        guard = _make_guard()
         session = MagicMock()
         session.get.return_value = _feature_response(FEATURES)
-        guard._get_session = MagicMock(return_value=session)
+        mock_get_session.return_value = session
+        guard = _make_guard()
 
         guard.permit(_make_request())
 
         session.get.assert_called_once()
 
     @pytest.mark.parametrize("corrupted_value", [b"{not-json", b"{}", b"[]", b"null"])
+    @patch(_GET_SESSION)
     @patch.object(FeatureContentGuardCache, "set")
     @patch.object(FeatureContentGuardCache, "get")
-    def test_corrupted_cache_entry_does_not_crash_and_is_treated_as_a_miss(self, mock_get, mock_set, corrupted_value):
+    def test_corrupted_cache_entry_does_not_crash_and_is_treated_as_a_miss(
+        self, mock_get, mock_set, mock_get_session, corrupted_value
+    ):
         # Malformed or structurally invalid payloads (truncated writes, unrelated data,
         # a schema change, etc.) must degrade to a cache miss rather than raising out of
         # permit() and turning a caching bug into an outage.
         mock_get.return_value = corrupted_value
-        guard = _make_guard()
         session = MagicMock()
         session.get.return_value = _feature_response(FEATURES)
-        guard._get_session = MagicMock(return_value=session)
+        mock_get_session.return_value = session
+        guard = _make_guard()
 
         guard.permit(_make_request())
 
@@ -156,14 +165,15 @@ class TestFeatureContentGuardCaching:
         assert set(payload.keys()) == {"allowed", "expires_at"}
         assert payload["allowed"] is True
 
+    @patch(_GET_SESSION)
     @patch.object(FeatureContentGuardCache, "set")
     @patch.object(FeatureContentGuardCache, "get")
-    def test_account_without_feature_is_denied_and_result_is_cached(self, mock_get, mock_set):
+    def test_account_without_feature_is_denied_and_result_is_cached(self, mock_get, mock_set, mock_get_session):
         mock_get.return_value = None
-        guard = _make_guard()
         session = MagicMock()
         session.get.return_value = _feature_response(["some-other-feature"])
-        guard._get_session = MagicMock(return_value=session)
+        mock_get_session.return_value = session
+        guard = _make_guard()
 
         with pytest.raises(PermissionError):
             guard.permit(_make_request())
@@ -173,14 +183,15 @@ class TestFeatureContentGuardCaching:
 
 
 class TestFeatureContentGuardFeatureServiceCall:
+    @patch(_GET_SESSION)
     @patch.object(FeatureContentGuardCache, "set")
     @patch.object(FeatureContentGuardCache, "get")
-    def test_feature_service_timeout_fails_closed_without_hanging(self, mock_get, mock_set):
+    def test_feature_service_timeout_fails_closed_without_hanging(self, mock_get, mock_set, mock_get_session):
         mock_get.return_value = None
-        guard = _make_guard()
         session = MagicMock()
         session.get.side_effect = requests.Timeout("Features Service did not respond")
-        guard._get_session = MagicMock(return_value=session)
+        mock_get_session.return_value = session
+        guard = _make_guard()
 
         with pytest.raises(PermissionError):
             guard.permit(_make_request())
@@ -191,14 +202,15 @@ class TestFeatureContentGuardFeatureServiceCall:
         # outage clears.
         mock_set.assert_not_called()
 
+    @patch(_GET_SESSION)
     @patch.object(FeatureContentGuardCache, "set")
     @patch.object(FeatureContentGuardCache, "get")
-    def test_feature_service_call_passes_a_bounded_timeout(self, mock_get, mock_set):
+    def test_feature_service_call_passes_a_bounded_timeout(self, mock_get, mock_set, mock_get_session):
         mock_get.return_value = None
-        guard = _make_guard()
         session = MagicMock()
         session.get.return_value = _feature_response(FEATURES)
-        guard._get_session = MagicMock(return_value=session)
+        mock_get_session.return_value = session
+        guard = _make_guard()
 
         guard.permit(_make_request())
 
@@ -206,28 +218,32 @@ class TestFeatureContentGuardFeatureServiceCall:
         assert "timeout" in kwargs
         assert kwargs["timeout"] is not None
 
+    @patch(_GET_SESSION)
     @patch.object(FeatureContentGuardCache, "set")
     @patch.object(FeatureContentGuardCache, "get")
-    def test_feature_service_timeout_is_a_real_tuple_not_a_list(self, mock_get, mock_set):
+    def test_feature_service_timeout_is_a_real_tuple_not_a_list(self, mock_get, mock_set, mock_get_session):
         # Regression test: `requests`/`urllib3` only splits a *tuple* into (connect, read)
         # timeouts -- a list is treated as a single scalar value and raises a ValueError.
         # Pulp's settings pipeline can silently turn a tuple *setting* into a list, which is
         # exactly what happened in production, so the (connect, read) pair must be
         # constructed as a plain tuple in code rather than passed through from settings as-is.
         mock_get.return_value = None
-        guard = _make_guard()
         session = MagicMock()
         session.get.return_value = _feature_response(FEATURES)
-        guard._get_session = MagicMock(return_value=session)
+        mock_get_session.return_value = session
+        guard = _make_guard()
 
         guard.permit(_make_request())
 
         _, kwargs = session.get.call_args
         assert type(kwargs["timeout"]) is tuple
 
+    @patch(_GET_SESSION)
     @patch.object(FeatureContentGuardCache, "set")
     @patch.object(FeatureContentGuardCache, "get")
-    def test_unexpected_error_from_feature_service_fails_closed_without_crashing(self, mock_get, mock_set):
+    def test_unexpected_error_from_feature_service_fails_closed_without_crashing(
+        self, mock_get, mock_set, mock_get_session
+    ):
         # Regression test: `permit()` must only ever return normally or raise
         # `PermissionError`. pulpcore's `Handler.auth_cached` wraps the guard call in a
         # try/except that only handles `HTTPForbidden`; any other exception type leaves its
@@ -235,10 +251,10 @@ class TestFeatureContentGuardFeatureServiceCall:
         # its `finally` block, masking the real error. This previously happened for real:
         # a misconfigured timeout setting raised a bare `ValueError` that escaped uncaught.
         mock_get.return_value = None
-        guard = _make_guard()
         session = MagicMock()
         session.get.side_effect = ValueError("Timeout value connect was [2, 5]...")
-        guard._get_session = MagicMock(return_value=session)
+        mock_get_session.return_value = session
+        guard = _make_guard()
 
         with pytest.raises(PermissionError):
             guard.permit(_make_request())
@@ -246,13 +262,10 @@ class TestFeatureContentGuardFeatureServiceCall:
         mock_set.assert_not_called()
 
     def test_session_is_a_process_wide_singleton(self):
-        guard_a = FeatureContentGuard(name="a", header_name="x-rh-identity", features=FEATURES, pulp_domain=None)
-        guard_b = FeatureContentGuard(name="b", header_name="x-rh-identity", features=FEATURES, pulp_domain=None)
-
-        with patch("pulp_service.app.models.requests.Session") as mock_session_cls:
+        with patch("pulp_service.app.features_service.requests.Session") as mock_session_cls:
             mock_session_cls.return_value = MagicMock()
-            first = guard_a._get_session()
-            second = guard_b._get_session()
+            first = _features_mod._get_session()
+            second = _features_mod._get_session()
 
         assert first is second
         mock_session_cls.assert_called_once()
@@ -262,69 +275,73 @@ class TestFeatureContentGuardCheckFeature:
     """Unit tests for `check_feature()`, the caching entry point reused by `permit()` and by
     `DomainBasedPermission` (for the lightwell-network feature check on PyPI views)."""
 
+    @patch(_GET_SESSION)
     @patch.object(FeatureContentGuardCache, "set")
     @patch.object(FeatureContentGuardCache, "get")
-    def test_cache_hit_skips_feature_service_call(self, mock_get, mock_set):
+    def test_cache_hit_skips_feature_service_call(self, mock_get, mock_set, mock_get_session):
         entry = json.dumps({"allowed": True, "expires_at": time.time() + 3600})
         mock_get.return_value = entry.encode()
         guard = _make_guard()
-        guard._get_session = MagicMock()
 
         assert guard.check_feature(ACCOUNT_ID) is True
 
-        guard._get_session.assert_not_called()
+        mock_get_session.assert_not_called()
         mock_set.assert_not_called()
 
+    @patch(_GET_SESSION)
     @patch.object(FeatureContentGuardCache, "set")
     @patch.object(FeatureContentGuardCache, "get")
-    def test_cache_miss_calls_feature_service_and_populates_cache(self, mock_get, mock_set):
+    def test_cache_miss_calls_feature_service_and_populates_cache(self, mock_get, mock_set, mock_get_session):
         mock_get.return_value = None
-        guard = _make_guard()
         session = MagicMock()
         session.get.return_value = _feature_response(FEATURES)
-        guard._get_session = MagicMock(return_value=session)
+        mock_get_session.return_value = session
+        guard = _make_guard()
 
         assert guard.check_feature(ACCOUNT_ID) is True
 
         session.get.assert_called_once()
         mock_set.assert_called_once()
 
+    @patch(_GET_SESSION)
     @patch.object(FeatureContentGuardCache, "set")
     @patch.object(FeatureContentGuardCache, "get")
-    def test_account_without_feature_returns_false_without_raising(self, mock_get, mock_set):
+    def test_account_without_feature_returns_false_without_raising(self, mock_get, mock_set, mock_get_session):
         mock_get.return_value = None
-        guard = _make_guard()
         session = MagicMock()
         session.get.return_value = _feature_response(["some-other-feature"])
-        guard._get_session = MagicMock(return_value=session)
+        mock_get_session.return_value = session
+        guard = _make_guard()
 
         assert guard.check_feature(ACCOUNT_ID) is False
 
+    @patch(_GET_SESSION)
     @patch.object(FeatureContentGuardCache, "set")
     @patch.object(FeatureContentGuardCache, "get")
-    def test_feature_service_failure_raises_permission_error(self, mock_get, mock_set):
+    def test_feature_service_failure_raises_permission_error(self, mock_get, mock_set, mock_get_session):
         mock_get.return_value = None
-        guard = _make_guard()
         session = MagicMock()
         session.get.side_effect = requests.Timeout("Features Service did not respond")
-        guard._get_session = MagicMock(return_value=session)
+        mock_get_session.return_value = session
+        guard = _make_guard()
 
         with pytest.raises(PermissionError):
             guard.check_feature(ACCOUNT_ID)
 
         mock_set.assert_not_called()
 
+    @patch(_GET_SESSION)
     @patch.object(FeatureContentGuardCache, "set")
     @patch.object(FeatureContentGuardCache, "get")
-    def test_permit_and_check_feature_share_the_same_cache_key(self, mock_get, mock_set):
+    def test_permit_and_check_feature_share_the_same_cache_key(self, mock_get, mock_set, mock_get_session):
         """`permit()` and `check_feature()` must compute identical cache keys for the same
         (account_id, features) pair, so a lookup made through one path is reused by the
         other and the Features Service isn't hit twice for the same account/feature."""
         mock_get.return_value = None
-        guard = _make_guard()
         session = MagicMock()
         session.get.return_value = _feature_response(FEATURES)
-        guard._get_session = MagicMock(return_value=session)
+        mock_get_session.return_value = session
+        guard = _make_guard()
 
         guard.permit(_make_request(account_id=ACCOUNT_ID))
         permit_cache_key = mock_set.call_args.args[0]


### PR DESCRIPTION
Pull HTTP call, caching, and session logic out of FeatureContentGuard into check_subscription() so DomainBasedPermission can call it directly without creating an unsaved model instance.

Same cache keys and TTL.

Signed-off-by: Bryan Ramos <bramos@redhat.com>

Relies on #1339

## Summary by Sourcery

Extract subscription feature checking and caching into a dedicated features_service module and update callers to use the shared helper.

New Features:
- Provide a reusable check_subscription helper for querying the Features Service and caching subscription entitlement results.

Enhancements:
- Refactor FeatureContentGuard to delegate subscription checks to the shared features_service helper while preserving existing behavior and cache semantics.
- Update DomainBasedPermission to call the shared subscription check instead of instantiating FeatureContentGuard, simplifying subscription enforcement logic.

Tests:
- Adjust and extend unit tests for FeatureContentGuard and DomainBasedPermission to cover the new features_service module, shared cache behavior, and subscription fallback scenarios.