### PR TITLE
feat: add GitLab Pages publishing to agent-akamai-report

### DIFF
--- a/.alcove/agents/akamai-report.yml
+++ b/.alcove/agents/akamai-report.yml
@@ -1,12 +1,13 @@
 name: Akamai Report
 description: |
   Analyzes 7-day Akamai traffic data via Splunk and produces a formatted
-  traffic report with LLM-driven analysis. Runs as a pre-compiled agent
-  binary from GitHub Releases.
+  traffic report with LLM-driven analysis. Publishes HTML and JSON reports
+  to GitLab Pages with a date-based index for historical browsing.
+  Runs as a pre-compiled agent binary from GitHub Releases.
 
 executable:
   url: https://github.com/pulp/pulp-service/releases/download/agent-akamai-report-20260716-8587c52/agent-akamai-report
-  args: ["--model", "claude-opus-4-6"]
+  args: ["--model", "claude-opus-4-6", "--gitlab-repo", "https://gitlab.cee.redhat.com/hyagi/akamai-report"]
   env:
     SPLUNK_INSECURE_SKIP_VERIFY: "true"
     SPLUNK_URL: "https://splunk-api.corp.redhat.com:8089/"
@@ -18,7 +19,8 @@ direct_outbound: true
 
 credentials:
   SPLUNK_TOKEN: splunk
+  GITLAB_TOKEN: AKAMAI_REPORT_GITLAB_TOKEN
 
 schedule:
-  cron: "0 3 * * 1"
+  cron: "0 3 * * *"
   enabled: true

--- a/.alcove/workflows/akamai-report-pipeline.yml
+++ b/.alcove/workflows/akamai-report-pipeline.yml
@@ -1,7 +1,7 @@
 name: Akamai Report Pipeline
 
 workflow:
-  - id: generate-report
+  - id: generate-and-publish-report
     type: agent
     agent: Akamai Report
-    outputs: [report_path, traffic_summary]
+    outputs: [report_path, traffic_summary, published_date]

--- a/tools/agents/agent-akamai-report/README.md
+++ b/tools/agents/agent-akamai-report/README.md
@@ -1,12 +1,15 @@
 # agent-akamai-report
 
-An AI agent that queries Akamai access logs in Splunk to produce 7-day traffic analysis reports for hosted Pulp. It fetches traffic data (reqHost, base_path, request count), saves the raw JSON, and uses an LLM (Claude or Gemini via Vertex AI) to produce a formatted report with analysis.
+An AI agent that queries Akamai access logs in Splunk to produce 7-day traffic analysis reports for hosted Pulp. It fetches traffic data (reqHost, base_path, request count), saves the raw JSON, generates an interactive HTML report, and uses an LLM (Claude or Gemini via Vertex AI) to produce analysis.
+
+When configured with `--gitlab-repo`, the agent automatically publishes reports to a GitLab repository for serving via GitLab Pages, with a date-based index for browsing historical reports.
 
 ## Prerequisites
 
 - Go 1.25+
 - Google Cloud credentials configured (for Vertex AI access), or an Anthropic API key (proxy mode)
 - Access to a Splunk instance with Akamai logs
+- (Optional) GitLab access token for publishing reports
 
 ## Environment Variables
 
@@ -14,6 +17,7 @@ An AI agent that queries Akamai access logs in Splunk to produce 7-day traffic a
 |---|---|---|
 | `SPLUNK_URL` | Yes | Splunk instance URL |
 | `SPLUNK_TOKEN` | Yes | Splunk bearer auth token |
+| `GITLAB_TOKEN` | With `--gitlab-repo` | GitLab personal access token for publishing reports |
 | `ANTHROPIC_API_KEY` | One of | API key for proxy mode |
 | `ANTHROPIC_BASE_URL` | No | Base URL for proxy mode |
 | `ANTHROPIC_VERTEX_PROJECT_ID` | One of | Google Cloud project ID for Vertex AI |
@@ -39,6 +43,9 @@ go build -o agent-akamai-report .
 # Run with a custom output directory
 ./agent-akamai-report -output-dir /tmp/my-report
 
+# Run and publish to GitLab Pages
+./agent-akamai-report -gitlab-repo https://gitlab.cee.redhat.com/hyagi/akamai-report
+
 # Run with a custom question about the data
 ./agent-akamai-report -question "which base paths have the most traffic on packages.redhat.com?"
 
@@ -58,5 +65,19 @@ podman run --env-file .env agent-akamai-report
 1. Queries Splunk for Akamai access logs from the last 7 days
 2. Aggregates traffic by `reqHost` and `base_path`, sorted by request count
 3. Saves the raw JSON results to `traffic.json` in the output directory
-4. Feeds the data to an LLM that produces a formatted table and analysis
-5. The LLM has access to the `splunk_search` tool for follow-up queries
+4. Generates an interactive HTML report with sorting, filtering, and dark mode
+5. Feeds the data to an LLM that produces a formatted table and analysis
+6. The LLM has access to the `splunk_search` tool for follow-up queries
+7. (Optional) Publishes HTML report and JSON data to a GitLab repository
+
+## GitLab Pages Publishing
+
+When `--gitlab-repo` is provided (along with `GITLAB_TOKEN`), the agent:
+
+1. Clones the target GitLab repository
+2. Copies `traffic.html` and `traffic.json` to `public/reports/YYYY-MM-DD/`
+3. Generates an `index.html` at `public/index.html` listing all available report dates
+4. Ensures a `.gitlab-ci.yml` exists for GitLab Pages deployment
+5. Commits and pushes changes
+
+Reports are organized by date and accessible through the index page. The agent is scheduled to run daily via Alcove, building up a browsable history of traffic reports.

--- a/tools/agents/agent-akamai-report/gitlab.go
+++ b/tools/agents/agent-akamai-report/gitlab.go
@@ -1,0 +1,192 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+type gitlabPublisher struct {
+	repoURL     string
+	token       string
+	cloneDir    string
+	askPassPath string
+}
+
+func newGitLabPublisher(repoURL, token string) *gitlabPublisher {
+	return &gitlabPublisher{
+		repoURL: repoURL,
+		token:   token,
+	}
+}
+
+func (g *gitlabPublisher) Publish(ctx context.Context, outputDir string) (string, error) {
+	askPass, err := g.createAskPassScript()
+	if err != nil {
+		return "", fmt.Errorf("create askpass script: %w", err)
+	}
+	g.askPassPath = askPass
+
+	cloneDir, err := os.MkdirTemp("", "akamai-report-repo-*")
+	if err != nil {
+		return "", fmt.Errorf("create temp dir: %w", err)
+	}
+	g.cloneDir = cloneDir
+
+	fmt.Fprintf(os.Stderr, "[gitlab] cloning repository...\n")
+	if err := g.gitCmd(ctx, "clone", "--depth=1", g.cloneURL(), cloneDir); err != nil {
+		return "", fmt.Errorf("git clone: %w", err)
+	}
+
+	if err := g.gitCmdInRepo(ctx, "config", "user.name", "Agent Akamai Report"); err != nil {
+		return "", fmt.Errorf("git config user.name: %w", err)
+	}
+	if err := g.gitCmdInRepo(ctx, "config", "user.email", "noreply@redhat.com"); err != nil {
+		return "", fmt.Errorf("git config user.email: %w", err)
+	}
+
+	dateStr := time.Now().UTC().Format("2006-01-02")
+	reportDir := filepath.Join(cloneDir, "public", "reports", dateStr)
+	if err := os.MkdirAll(reportDir, 0o755); err != nil {
+		return "", fmt.Errorf("create report dir: %w", err)
+	}
+
+	for _, name := range []string{"traffic.json", "traffic.html"} {
+		if err := copyFile(filepath.Join(outputDir, name), filepath.Join(reportDir, name)); err != nil {
+			return "", fmt.Errorf("copy %s: %w", name, err)
+		}
+	}
+	fmt.Fprintf(os.Stderr, "[gitlab] copied report files to public/reports/%s/\n", dateStr)
+
+	publicDir := filepath.Join(cloneDir, "public")
+	if err := generateIndexPage(publicDir); err != nil {
+		return "", fmt.Errorf("generate index page: %w", err)
+	}
+	fmt.Fprintf(os.Stderr, "[gitlab] generated index page\n")
+
+	if err := g.ensureGitLabCI(); err != nil {
+		return "", fmt.Errorf("ensure .gitlab-ci.yml: %w", err)
+	}
+
+	if err := g.gitCmdInRepo(ctx, "add", "-A"); err != nil {
+		return "", fmt.Errorf("git add: %w", err)
+	}
+
+	if err := g.gitCmdInRepo(ctx, "diff", "--cached", "--quiet"); err == nil {
+		fmt.Fprintf(os.Stderr, "[gitlab] no changes to commit (report already up to date)\n")
+		return dateStr, nil
+	}
+
+	commitMsg := fmt.Sprintf("Add Akamai traffic report for %s", dateStr)
+	if err := g.gitCmdInRepo(ctx, "commit", "-m", commitMsg); err != nil {
+		return "", fmt.Errorf("git commit: %w", err)
+	}
+
+	fmt.Fprintf(os.Stderr, "[gitlab] pushing to repository...\n")
+	if err := g.gitCmdInRepo(ctx, "push", "origin", "HEAD"); err != nil {
+		return "", fmt.Errorf("git push: %w", err)
+	}
+
+	fmt.Fprintf(os.Stderr, "[gitlab] report published for %s\n", dateStr)
+	return dateStr, nil
+}
+
+func (g *gitlabPublisher) Cleanup() {
+	if g.askPassPath != "" {
+		os.Remove(g.askPassPath)
+	}
+	if g.cloneDir != "" {
+		os.RemoveAll(g.cloneDir)
+	}
+}
+
+func (g *gitlabPublisher) createAskPassScript() (string, error) {
+	f, err := os.CreateTemp("", "git-askpass-*")
+	if err != nil {
+		return "", err
+	}
+	escapedToken := strings.ReplaceAll(g.token, "'", "'\\''")
+	fmt.Fprintf(f, "#!/bin/sh\nprintf '%%s\\n' '%s'\n", escapedToken)
+	f.Close()
+	if err := os.Chmod(f.Name(), 0o700); err != nil {
+		os.Remove(f.Name())
+		return "", err
+	}
+	return f.Name(), nil
+}
+
+func (g *gitlabPublisher) cloneURL() string {
+	url := g.repoURL
+	if !strings.HasSuffix(url, ".git") {
+		url += ".git"
+	}
+	return strings.Replace(url, "https://", "https://oauth2@", 1)
+}
+
+func (g *gitlabPublisher) gitEnv() []string {
+	env := append(os.Environ(), "GIT_TERMINAL_PROMPT=0")
+	if g.askPassPath != "" {
+		env = append(env, "GIT_ASKPASS="+g.askPassPath)
+	}
+	return env
+}
+
+func (g *gitlabPublisher) ensureGitLabCI() error {
+	ciPath := filepath.Join(g.cloneDir, ".gitlab-ci.yml")
+	if _, err := os.Stat(ciPath); err == nil {
+		return nil
+	}
+	return os.WriteFile(ciPath, []byte(gitlabCITemplate), 0o644)
+}
+
+func (g *gitlabPublisher) gitCmd(ctx context.Context, args ...string) error {
+	cmd := exec.CommandContext(ctx, "git", args...)
+	cmd.Env = g.gitEnv()
+	cmd.Stdout = os.Stderr
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
+func (g *gitlabPublisher) gitCmdInRepo(ctx context.Context, args ...string) error {
+	cmd := exec.CommandContext(ctx, "git", args...)
+	cmd.Dir = g.cloneDir
+	cmd.Env = g.gitEnv()
+	cmd.Stdout = os.Stderr
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
+func copyFile(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+
+	out, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+
+	_, err = io.Copy(out, in)
+	return err
+}
+
+const gitlabCITemplate = `pages:
+  stage: deploy
+  tags:
+    - itup-alm-x86
+  script:
+    - echo "Deploying Akamai reports to GitLab Pages"
+  artifacts:
+    paths:
+      - public
+  only:
+    - main
+`

--- a/tools/agents/agent-akamai-report/html.go
+++ b/tools/agents/agent-akamai-report/html.go
@@ -146,9 +146,13 @@ const htmlTemplate = `<!DOCTYPE html>
     .type-Other { background: var(--header-bg); color: var(--muted); }
   }
   #filter { padding: 0.5rem 0.75rem; border: 1px solid var(--border); border-radius: 0.375rem; background: var(--bg); color: var(--fg); font-size: 0.875rem; width: 20rem; max-width: 100%; margin-bottom: 1rem; }
+  .breadcrumb { margin-bottom: 1rem; }
+  .breadcrumb a { color: var(--accent); text-decoration: none; font-size: 0.875rem; }
+  .breadcrumb a:hover { text-decoration: underline; }
 </style>
 </head>
 <body>
+<nav class="breadcrumb"><a href="../../index.html">&larr; All Reports</a></nav>
 <h1>Akamai Traffic Report</h1>
 <p class="meta">Generated {{.GeneratedAt}} &middot; Last 7 days</p>
 

--- a/tools/agents/agent-akamai-report/index.go
+++ b/tools/agents/agent-akamai-report/index.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"fmt"
+	"html/template"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+)
+
+type reportEntry struct {
+	Date string
+}
+
+func generateIndexPage(publicDir string) error {
+	reportsDir := filepath.Join(publicDir, "reports")
+	entries, err := os.ReadDir(reportsDir)
+	if err != nil {
+		return fmt.Errorf("read reports dir: %w", err)
+	}
+
+	datePattern := regexp.MustCompile(`^\d{4}-\d{2}-\d{2}$`)
+	var reports []reportEntry
+	for _, entry := range entries {
+		if entry.IsDir() && datePattern.MatchString(entry.Name()) {
+			reports = append(reports, reportEntry{Date: entry.Name()})
+		}
+	}
+
+	sort.Slice(reports, func(i, j int) bool {
+		return reports[i].Date > reports[j].Date
+	})
+
+	indexPath := filepath.Join(publicDir, "index.html")
+	f, err := os.Create(indexPath)
+	if err != nil {
+		return fmt.Errorf("create index file: %w", err)
+	}
+	defer f.Close()
+
+	tmpl, err := template.New("index").Parse(indexTemplate)
+	if err != nil {
+		return fmt.Errorf("parse index template: %w", err)
+	}
+
+	return tmpl.Execute(f, reports)
+}
+
+const indexTemplate = `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Akamai Traffic Reports</title>
+<style>
+  :root { --bg: #ffffff; --fg: #1a1a2e; --muted: #6b7280; --border: #e5e7eb; --card-bg: #f9fafb; --hover: #f3f4f6; --accent: #2563eb; }
+  @media (prefers-color-scheme: dark) {
+    :root { --bg: #0f172a; --fg: #e2e8f0; --muted: #94a3b8; --border: #334155; --card-bg: #1e293b; --hover: #1e293b; --accent: #60a5fa; }
+  }
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; background: var(--bg); color: var(--fg); padding: 2rem; line-height: 1.5; max-width: 48rem; margin: 0 auto; }
+  h1 { font-size: 1.5rem; margin-bottom: 0.25rem; }
+  .subtitle { color: var(--muted); font-size: 0.875rem; margin-bottom: 2rem; }
+  .report-list { list-style: none; }
+  .report-list li { border: 1px solid var(--border); border-radius: 0.5rem; margin-bottom: 0.5rem; }
+  .report-item { display: flex; align-items: center; justify-content: space-between; padding: 1rem 1.25rem; }
+  .report-date { font-weight: 600; font-size: 1rem; }
+  .report-links { display: flex; gap: 0.5rem; align-items: center; }
+  .report-links a { padding: 0.25rem 0.75rem; font-size: 0.8125rem; border: 1px solid var(--border); border-radius: 0.375rem; text-decoration: none; color: var(--fg); transition: border-color 0.15s, color 0.15s; }
+  .report-links a:hover { border-color: var(--accent); color: var(--accent); }
+  .empty { color: var(--muted); font-style: italic; margin-top: 2rem; }
+</style>
+</head>
+<body>
+<h1>Akamai Traffic Reports</h1>
+<p class="subtitle">7-day traffic analysis for hosted Pulp services</p>
+{{if .}}
+<ul class="report-list">
+{{range .}}  <li>
+    <div class="report-item">
+      <span class="report-date">{{.Date}}</span>
+      <div class="report-links">
+        <a href="reports/{{.Date}}/traffic.html">Report</a>
+        <a href="reports/{{.Date}}/traffic.json">JSON</a>
+      </div>
+    </div>
+  </li>
+{{end}}</ul>
+{{else}}
+<p class="empty">No reports available yet.</p>
+{{end}}
+</body>
+</html>`

--- a/tools/agents/agent-akamai-report/main.go
+++ b/tools/agents/agent-akamai-report/main.go
@@ -45,6 +45,7 @@ func run() error {
 	inputModel := flag.String("model", llmModel, "LLM model (claude-opus-4-6, gemini-2.5-pro)")
 	inputQuestion := flag.String("question", "", "Question to ask the model about the traffic data")
 	inputOutputDir := flag.String("output-dir", "", "Output directory for results (default: /tmp/traffic-report-<timestamp>)")
+	inputGitLabRepo := flag.String("gitlab-repo", "", "GitLab repository URL to publish reports to")
 	flag.Parse()
 
 	supportedModels := map[string]struct{}{
@@ -53,6 +54,14 @@ func run() error {
 	}
 	if _, exists := supportedModels[*inputModel]; !exists {
 		return fmt.Errorf("unsupported model: %s. Supported models: claude-opus-4-6, gemini-2.5-pro", *inputModel)
+	}
+
+	gitlabToken := ""
+	if *inputGitLabRepo != "" {
+		gitlabToken = os.Getenv("GITLAB_TOKEN")
+		if gitlabToken == "" {
+			return fmt.Errorf("GITLAB_TOKEN is required when --gitlab-repo is set")
+		}
 	}
 
 	// Splunk is required for this agent.
@@ -137,5 +146,14 @@ func run() error {
 	}
 
 	fmt.Println(report)
+
+	if *inputGitLabRepo != "" {
+		publisher := newGitLabPublisher(*inputGitLabRepo, gitlabToken)
+		defer publisher.Cleanup()
+		if _, err := publisher.Publish(ctx, outputDir); err != nil {
+			return fmt.Errorf("publish to GitLab: %w", err)
+		}
+	}
+
 	return nil
 }


### PR DESCRIPTION
Adds automatic publishing of HTML and JSON traffic reports to a GitLab repository for serving via GitLab Pages. Reports are organized by date with a browsable index page. The schedule is changed from weekly to daily to build up historical data.

## Summary by Sourcery

Add automated GitLab Pages publishing for the Akamai traffic report agent and expose it in the scheduled Alcove workflow.

New Features:
- Introduce optional GitLab Pages publishing that clones a target repository, adds the latest HTML and JSON traffic report under a date-based path, generates an index page, and pushes changes.
- Add a browsable HTML index page listing historical Akamai traffic reports, with links to each day’s HTML report and JSON data.
- Enhance the HTML traffic report with a breadcrumb link back to the reports index for easier navigation.

Enhancements:
- Update the agent README and usage examples to describe HTML report generation and GitLab Pages publishing, including required GitLab credentials.
- Extend the Akamai Report Alcove agent and pipeline configuration to pass the GitLab repo URL and capture the published date in workflow outputs.
- Adjust the Akamai Report schedule from weekly to daily to accumulate historical traffic reports.

CI:
- Ensure a default GitLab Pages `.gitlab-ci.yml` is present in the target repository when publishing reports.