### PR TITLE
fix: skip SSL verification for internal GitLab in agent-akamai-report

### DIFF
--- a/.alcove/agents/akamai-report.yml
+++ b/.alcove/agents/akamai-report.yml
@@ -11,6 +11,7 @@ executable:
   env:
     SPLUNK_INSECURE_SKIP_VERIFY: "true"
     SPLUNK_URL: "https://splunk-api.corp.redhat.com:8089/"
+    GIT_SSL_NO_VERIFY: "true"
 
 timeout: 1800
 enforcement_mode: monitor


### PR DESCRIPTION
The alcove container lacks the Red Hat corporate CA, causing git clone to fail against gitlab.cee.redhat.com with a self-signed certificate error.

## Summary by Sourcery

Bug Fixes:
- Resolve git clone failures in the akamai-report agent caused by missing Red Hat corporate CA when accessing internal GitLab.