### PR TITLE
fix: add GitLab clone access for planner workflow

### DIFF
--- a/.alcove/security-profiles/pulp-service-reader.yml
+++ b/.alcove/security-profiles/pulp-service-reader.yml
@@ -1,6 +1,6 @@
 name: pulp-service-reader
 display_name: Pulp Service Reader
-description: Read-only access to pulp/pulp-service code and hosted-pulp/pulp-docs
+description: Read-only access to pulp/pulp-service (code, issues, PRs) and hosted-pulp/pulp-docs
 tools:
   github:
     rules:

--- a/.alcove/security-profiles/pulp-service-reader.yml
+++ b/.alcove/security-profiles/pulp-service-reader.yml
@@ -1,6 +1,6 @@
 name: pulp-service-reader
 display_name: Pulp Service Reader
-description: Read-only access to pulp/pulp-service code, issues, and PRs
+description: Read-only access to pulp/pulp-service code and hosted-pulp/pulp-docs
 tools:
   github:
     rules:
@@ -13,3 +13,8 @@ tools:
           - read_actions
           - read_commits
           - read_branches
+  gitlab:
+    rules:
+      - repos: ["hosted-pulp/pulp-docs"]
+        operations:
+          - clone

--- a/.alcove/workflows/planner.yml
+++ b/.alcove/workflows/planner.yml
@@ -119,7 +119,7 @@ workflow:
   - id: post_failure
     type: bridge
     action: jira-add-comment
-    depends: "detect.Failed || find_plan_task.Failed || create_plan_task.Failed || plan_epic.Failed || plan_standalone.Failed"
+    depends: "detect.Failed || find_plan_task.Failed || create_plan_task.Failed || plan_epic.Failed || update_plan_task.Failed || plan_standalone.Failed"
     inputs:
       issue_key: "{{trigger.issue_key}}"
       body: "Automated planning failed. Check the workflow logs for details."

--- a/.alcove/workflows/planner.yml
+++ b/.alcove/workflows/planner.yml
@@ -119,7 +119,7 @@ workflow:
   - id: post_failure
     type: bridge
     action: jira-add-comment
-    depends: "detect.Failed || find_plan_task.Failed || create_plan_task.Failed || plan_epic.Failed || update_plan_task.Failed || plan_standalone.Failed"
+    depends: "detect.Failed || find_plan_task.Failed || create_plan_task.Failed || plan_epic.Failed || update_plan_task.Failed || plan_changelog.Failed || notify_epic.Failed || plan_standalone.Failed"
     inputs:
       issue_key: "{{trigger.issue_key}}"
       body: "Automated planning failed. Check the workflow logs for details."


### PR DESCRIPTION
## Summary
- Add `gitlab` rules to `pulp-service-reader` security profile, allowing `clone` for `hosted-pulp/pulp-docs` — the Planner agent's `pulp-docs` repo clone was hanging because the profile lacked GitLab access
- Add `update_plan_task.Failed` to `post_failure` depends so failures after the agent step trigger the error comment

## Test plan
- [ ] Trigger Jira Planner on an Epic with `needs-planning` label
- [ ] Verify `pulp-docs` clones successfully (transcript events > 0)
- [ ] Verify `post_failure` fires when `update_plan_task` fails

Assisted-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

## Summary by Sourcery

Align planner workflow step identifiers and failure handling while extending pulp-service-reader access for planner GitLab clones.

New Features:
- Allow pulp-service-reader profile to clone the hosted-pulp/pulp-docs repository from GitLab for Planner workflows.

Bug Fixes:
- Ensure planner workflow failure comments are posted when the epic plan task update step fails.

Enhancements:
- Standardize planner workflow step IDs and dependency references to use snake_case naming for consistency.

Documentation:
- Update pulp-service-reader profile description to reflect access to hosted-pulp/pulp-docs in addition to pulp-service code.