### PR TITLE
fix: remove pulp-docs repo from Planner to isolate clone hang

### DIFF
--- a/.alcove/agents/planner.yml
+++ b/.alcove/agents/planner.yml
@@ -129,8 +129,6 @@ prompt: |
 repos:
   - name: pulp-service
     url: https://github.com/pulp/pulp-service.git
-  - name: pulp-docs
-    url: https://gitlab.cee.redhat.com/hosted-pulp/pulp-docs.git
 
 timeout: 900
 enforcement_mode: monitor


### PR DESCRIPTION
## Summary
- Remove `pulp-docs` (internal GitLab) repo from the Planner agent definition
- The Planner agent sessions hang with 0 transcript events for the full 15-minute timeout
- The agent worked previously with `pulp-service` (GitHub) only — this isolates whether the GitLab clone is the cause
- Related: alcove-ai/alcove#770 (skiff-init silent clone failures)

## Test plan
- [ ] Merge, sync, trigger planner on an Epic with `needs-planning`
- [ ] Verify transcript events > 0 and agent produces output

Assisted-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

## Summary by Sourcery

Bug Fixes:
- Remove the pulp-docs GitLab repository from the Planner agent configuration to mitigate hanging planner sessions with no transcript events.