### PR TITLE
fix: enable direct outbound for Planner to clone internal GitLab

### DIFF
--- a/.alcove/agents/planner.yml
+++ b/.alcove/agents/planner.yml
@@ -129,6 +129,8 @@ prompt: |
 repos:
   - name: pulp-service
     url: https://github.com/pulp/pulp-service.git
+  - name: pulp-docs
+    url: https://gitlab.cee.redhat.com/hosted-pulp/pulp-docs.git
 
 timeout: 900
 enforcement_mode: monitor

--- a/.alcove/workflows/planner.yml
+++ b/.alcove/workflows/planner.yml
@@ -37,6 +37,9 @@ workflow:
     agent: Planner
     depends: "detect.Succeeded"
     condition: "steps.detect.outputs.issue_type != 'Epic' && steps.detect.outputs.parent_key == ''"
+    direct_outbound: true
+    credentials:
+      GIT_SSL_NO_VERIFY: git-ssl-no-verify
     inputs:
       issue_key: "{{trigger.issue_key}}"
       issue_title: "{{trigger.issue_title}}"
@@ -81,6 +84,9 @@ workflow:
     type: agent
     agent: Planner
     depends: "create_plan_task.Succeeded || find_plan_task.Succeeded"
+    direct_outbound: true
+    credentials:
+      GIT_SSL_NO_VERIFY: git-ssl-no-verify
     inputs:
       issue_key: "{{trigger.issue_key}}"
       issue_title: "{{trigger.issue_title}}"


### PR DESCRIPTION
## Summary
- Re-add `pulp-docs` repo (internal GitLab) to Planner agent definition
- Add `direct_outbound: true` on both `plan_epic` and `plan_standalone` workflow steps to bypass Gate MITM for git traffic
- Add `GIT_SSL_NO_VERIFY` via credentials to skip TLS verification for the internal GitLab host

## Root cause
Gate's MITM `tls.Dial` to `gitlab.cee.redhat.com` fails because the UBI9 container image lacks Red Hat's internal CA (`2023 Certificate Authority RHCSv2`). With Gate MITM, the upstream TLS connection hangs silently causing a 15-minute session timeout with zero transcript events.

`direct_outbound` bypasses Gate for git traffic, and `GIT_SSL_NO_VERIFY` skips cert verification against the internal host.

## Prerequisites
- `git-ssl-no-verify` generic secret credential created on the Hosted Pulp team

## Test plan
- [ ] Trigger planner on an Epic with `needs-planning`
- [ ] Verify pulp-docs clones successfully (check `oc logs` for `cloned repo 2/2`)
- [ ] Verify agent produces transcript events and writes outputs

## Related
- alcove-ai/alcove#770 (skiff-init silent clone failures)
- PR #1350 (security profile fix — necessary but not sufficient)
- PR #1352 (temporary pulp-docs removal to unblock)

Assisted-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

## Summary by Sourcery

Enable Planner workflow to directly access the internal pulp-docs GitLab repository and bypass Gate MITM TLS issues.

New Features:
- Reintroduce the internal pulp-docs GitLab repository to the Planner agent's configured repos.

Enhancements:
- Configure Planner plan_epic and plan_standalone workflow steps to use direct outbound network access for git operations and supply a credential-based GIT_SSL_NO_VERIFY setting to work with the internal GitLab host.