### PR TITLE
chore: move akamai report GitLab repo to hosted-pulp namespace

### DIFF
--- a/.alcove/agents/akamai-report.yml
+++ b/.alcove/agents/akamai-report.yml
@@ -7,7 +7,7 @@ description: |
 
 executable:
   url: https://github.com/pulp/pulp-service/releases/download/agent-akamai-report-20260722-6849695/agent-akamai-report
-  args: ["--model", "claude-opus-4-6", "--gitlab-repo", "https://gitlab.cee.redhat.com/hyagi/akamai-report"]
+  args: ["--model", "claude-opus-4-6", "--gitlab-repo", "https://gitlab.cee.redhat.com/hosted-pulp/traffic-report"]
   env:
     SPLUNK_INSECURE_SKIP_VERIFY: "true"
     SPLUNK_URL: "https://splunk-api.corp.redhat.com:8089/"

--- a/tools/agents/agent-akamai-report/README.md
+++ b/tools/agents/agent-akamai-report/README.md
@@ -44,7 +44,7 @@ go build -o agent-akamai-report .
 ./agent-akamai-report -output-dir /tmp/my-report
 
 # Run and publish to GitLab Pages
-./agent-akamai-report -gitlab-repo https://gitlab.cee.redhat.com/hyagi/akamai-report
+./agent-akamai-report -gitlab-repo https://gitlab.cee.redhat.com/hosted-pulp/traffic-report
 
 # Run with a custom question about the data
 ./agent-akamai-report -question "which base paths have the most traffic on packages.redhat.com?"


### PR DESCRIPTION
ref: https://redhat.atlassian.net/browse/PULP-2061

## Summary by Sourcery

Update Akamai report agent configuration and documentation to use the new hosted-pulp GitLab traffic-report project instead of the previous repository.

Enhancements:
- Switch the Akamai report Alcove agent configuration to target the hosted-pulp/traffic-report GitLab repository for report publishing.

Documentation:
- Adjust agent-akamai-report README example to reference the hosted-pulp/traffic-report GitLab repository for publishing reports.