### PR TITLE
fix: pass epic comments to Planner for conversational refinement

### DIFF
--- a/.alcove/agents/planner.yml
+++ b/.alcove/agents/planner.yml
@@ -56,8 +56,10 @@ prompt: |
   ## Interaction Protocol
 
   1. Read the full ticket description above
-  2. If a previous plan exists, read the feedback comments and identify
-     what needs refinement
+  2. If a previous plan exists, read both the previous plan and the
+     feedback comments to identify what needs refinement. Ignore
+     bot-generated comments (from pulp-sre-agent) — focus on human
+     feedback only.
   3. Check /workspace/pulp-docs/ for relevant documented decisions,
      architecture notes, CLI guides, and past constraints. This is the
      team's institutional knowledge — do not contradict it without

--- a/.alcove/agents/planner.yml
+++ b/.alcove/agents/planner.yml
@@ -45,11 +45,19 @@ prompt: |
   If no previous plan is present (empty or placeholder), create a new
   plan from scratch.
 
+  ## Feedback (comments from the epic)
+
+  {{feedback}}
+
+  If feedback is present above, address it in your plan update. These
+  are comments from the team on the epic — they may request changes to
+  the plan, answer open questions, or provide additional context.
+
   ## Interaction Protocol
 
   1. Read the full ticket description above
-  2. If a previous plan exists, read it and identify what needs refinement
-     based on the latest feedback in the ticket
+  2. If a previous plan exists, read the feedback comments and identify
+     what needs refinement
   3. Check /workspace/pulp-docs/ for relevant documented decisions,
      architecture notes, CLI guides, and past constraints. This is the
      team's institutional knowledge — do not contradict it without

--- a/.alcove/workflows/planner.yml
+++ b/.alcove/workflows/planner.yml
@@ -108,6 +108,7 @@ workflow:
       new_plan_task_key: "{{steps.create_plan_task.outputs.issue_key}}"
       existing_plan_task_keys: "{{steps.find_plan_task.outputs.issue_keys}}"
       previous_plan: "{{steps.fetch_previous_plan.outputs.description}}"
+      feedback: "{{trigger.issue_comments}}"
     outputs: [plan, plan_task_key, spec_summary, verification_steps]
 
   - id: update_plan_task
@@ -144,7 +145,7 @@ workflow:
     condition: "steps.plan_epic.outputs.spec_summary != ''"
     inputs:
       issue_key: "{{trigger.issue_key}}"
-      body: "h3. Spec Summary\n\n{{steps.plan_epic.outputs.spec_summary}}\n\nh3. Verification Steps\n\n{{steps.plan_epic.outputs.verification_steps}}"
+      body: "Spec Summary\n\n{{steps.plan_epic.outputs.spec_summary}}\n\nVerification Steps\n\n{{steps.plan_epic.outputs.verification_steps}}"
 
   # --- Failure handling ---
   - id: post_failure


### PR DESCRIPTION
## Summary
- Pass `{{trigger.issue_comments}}` as `feedback` input to the Planner agent so it sees user comments when refining a plan
- Add `## Feedback` section to the agent prompt that displays the comments
- Fix wiki markup (`h3.`) in spec summary comment — use plain text

## Root cause
The Jira poller enrichment already provides `issue_comments` in the trigger context, but the workflow wasn't passing it to the agent. The planner was refining plans without seeing user feedback.

## Test plan
- [ ] Comment on an epic with `needs-planning` to request plan changes
- [ ] Verify the planner's updated plan reflects the comment feedback

Assisted-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

## Summary by Sourcery

Pass epic comments to the planner agent and adjust plan refinement behavior and spec summary formatting.

New Features:
- Expose Jira epic comments to the planner agent as feedback when refining plans.

Enhancements:
- Update the planner agent prompt to include a dedicated feedback section and explicitly incorporate comment-based refinement.
- Simplify spec summary and verification steps formatting in Jira comments by removing wiki heading markup.