### PR TITLE
Fix RedisWorker fetch_task() head-of-line blocking

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -156,6 +156,9 @@ RUN patch -p1 -d /usr/local/lib/pulp/lib/python${PYTHON_VERSION}/site-packages <
 COPY images/assets/patches/0060-Add-content_handler_json-to-PythonDistribution.patch /tmp/
 RUN patch -p1 -d /usr/local/lib/pulp/lib/python${PYTHON_VERSION}/site-packages < /tmp/0060-Add-content_handler_json-to-PythonDistribution.patch
 
+COPY images/assets/patches/0061-Fix-RedisWorker-fetch_task-head-of-line-blocking.patch /tmp/
+RUN patch -p1 -d /usr/local/lib/pulp/lib/python${PYTHON_VERSION}/site-packages < /tmp/0061-Fix-RedisWorker-fetch_task-head-of-line-blocking.patch
+
 RUN mkdir /licenses
 COPY LICENSE /licenses/LICENSE
 

--- a/images/assets/patches/0061-Fix-RedisWorker-fetch_task-head-of-line-blocking.patch
+++ b/images/assets/patches/0061-Fix-RedisWorker-fetch_task-head-of-line-blocking.patch
@@ -1,0 +1,629 @@
+From c99b617833d5437e09e60ed93ecf9eae977989c5 Mon Sep 17 00:00:00 2001
+From: Dennis Kliban <dkliban@redhat.com>
+Date: Fri, 24 Jul 2026 19:14:25 -0400
+Subject: [PATCH] Fix RedisWorker fetch_task() head-of-line blocking
+
+When the task queue head is dominated by tasks needing the same exclusive
+resource (e.g., 17,000 tasks for one repository), all workers scan the
+same blocked tasks and never reach tasks with free resources further down.
+
+Replace the exponential-doubling strategy with blocked-resource DB-level
+exclusion: after acquire_locks reports a resource is blocked, exclude
+tasks needing that resource (and its shared: variant) from subsequent
+queries using reserved_resources_record array overlap. The loop re-queries
+from position 0 with growing exclusions until no new blocked resources
+are discovered.
+
+In the incident scenario (2026-07-24), this reduces task selection from
+~10 exponentially growing queries to 2 queries: one to discover the
+blocked resource, one filtered query that skips all 17,000 blocked tasks
+and returns tasks with free resources.
+
+Fixes: https://github.com/pulp/pulpcore/issues/7900
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+---
+ CHANGES/7900.bugfix                      |   4 +
+ pulpcore/tasking/redis_worker.py         |  39 +-
+ pulpcore/tests/unit/test_redis_worker.py | 503 +++++++++++++++++++++++
+ 3 files changed, 531 insertions(+), 15 deletions(-)
+ create mode 100644 CHANGES/7900.bugfix
+ create mode 100644 pulpcore/tests/unit/test_redis_worker.py
+
+diff --git a/CHANGES/7900.bugfix b/CHANGES/7900.bugfix
+new file mode 100644
+index 000000000..8d62134ea
+--- /dev/null
++++ b/CHANGES/7900.bugfix
+@@ -0,0 +1,4 @@
++Fixed head-of-line blocking in RedisWorker task selection. When thousands of
++tasks need the same exclusive resource, workers now skip blocked resources at
++the database level instead of scanning past them repeatedly, allowing tasks
++with free resources to be picked up without delay.
+diff --git a/pulpcore/tasking/redis_worker.py b/pulpcore/tasking/redis_worker.py
+index d9449a885..9b6b96663 100644
+--- a/pulpcore/tasking/redis_worker.py
++++ b/pulpcore/tasking/redis_worker.py
+@@ -425,28 +425,34 @@ class RedisWorker:
+         """
+         Fetch an available waiting task using Redis locks.
+ 
+-        This method:
+-        1. Queries waiting tasks (sorted by creation time, limited)
+-        2. For each task, attempts to acquire Redis distributed locks for exclusive resources
+-        3. If resource locks acquired, attempts to claim the task
+-           with a Redis task lock (24h expiration)
+-        4. Returns the first task for which both locks can be acquired
+-        5. If no task found in the batch, doubles the fetch limit and retries from the oldest
++        Uses a resource-aware scanning strategy to avoid head-of-line blocking:
++        1. Queries waiting tasks sorted by creation time in fixed-size batches
++        2. For each task, attempts to acquire Redis distributed locks
++        3. When lock acquisition fails, records the blocked resources
++        4. Subsequent batch queries exclude tasks needing those blocked resources
++           at the DB level using reserved_resources_record array overlap
++        5. This prevents head-of-line blocking when many tasks need the same
++           exclusive resource while tasks for other resources are available
+ 
+         Returns:
+             Task: A task object if one was successfully locked, None otherwise
+         """
+-        fetch_limit = FETCH_TASK_LIMIT
++        blocked_resources = set()
++        prev_blocked_count = 0
+ 
+         while True:
+             taken_exclusive = set()
+             taken_shared = set()
+ 
++            qs = Task.objects.filter(state=TASK_STATES.WAITING, app_lock=None).exclude(
++                pk__in=self.ignored_task_ids
++            )
++
++            if blocked_resources:
++                qs = qs.exclude(reserved_resources_record__overlap=list(blocked_resources))
++
+             waiting_tasks = list(
+-                Task.objects.filter(state=TASK_STATES.WAITING, app_lock=None)
+-                .exclude(pk__in=self.ignored_task_ids)
+-                .order_by("pulp_created")
+-                .select_related("pulp_domain")[:fetch_limit]
++                qs.order_by("pulp_created").select_related("pulp_domain")[:FETCH_TASK_LIMIT]
+             )
+ 
+             if not waiting_tasks:
+@@ -482,6 +488,10 @@ class RedisWorker:
+                         shared_resources,
+                     )
+                     if blocked_resource_list:
++                        for res in blocked_resource_list:
++                            if res != "__task_lock__":
++                                blocked_resources.add(res)
++                                blocked_resources.add(f"shared:{res}")
+                         continue
+ 
+                     rows = Task.objects.filter(
+@@ -502,10 +512,9 @@ class RedisWorker:
+                     _logger.error("Error processing task %s: %s", task.pk, e)
+                     continue
+ 
+-            if len(waiting_tasks) < fetch_limit:
++            if len(blocked_resources) == prev_blocked_count:
+                 break
+-
+-            fetch_limit *= 2
++            prev_blocked_count = len(blocked_resources)
+ 
+         return None
+ 
+diff --git a/pulpcore/tests/unit/test_redis_worker.py b/pulpcore/tests/unit/test_redis_worker.py
+new file mode 100644
+index 000000000..3dc03eaa7
+--- /dev/null
++++ b/pulpcore/tests/unit/test_redis_worker.py
+@@ -0,0 +1,503 @@
++"""Tests for RedisWorker.fetch_task() blocked-resource skip optimization.
++
++These tests verify that when fetch_task() discovers a resource is blocked
++(via acquire_locks failure), subsequent batch queries exclude tasks needing
++that resource at the DB level.
++"""
++
++import os
++from unittest.mock import MagicMock, patch
++from uuid import uuid4
++
++import pytest
++
++os.environ.setdefault("DJANGO_SETTINGS_MODULE", "pulpcore.app.settings")
++
++
++def _make_task(pk=None, resources=None, domain_name="default"):
++    """Create a mock Task with the given resources."""
++    task = MagicMock()
++    task.pk = pk or uuid4()
++    task.reserved_resources_record = resources or []
++    task.pulp_domain = MagicMock()
++    task.pulp_domain.name = domain_name
++    task._all_locks_released = False
++    return task
++
++
++def _make_worker():
++    """Create a minimal RedisWorker-like object for testing fetch_task()."""
++    from pulpcore.tasking.redis_worker import RedisWorker
++
++    worker = object.__new__(RedisWorker)
++    worker.ignored_task_ids = []
++    worker.redis_conn = MagicMock()
++    worker.name = "1@test-worker"
++    worker.app_status = MagicMock()
++    return worker
++
++
++class ChainedQuerySet:
++    """A mock QuerySet that tracks filter/exclude calls and returns
++    pre-configured batches via slicing."""
++
++    def __init__(self, batches):
++        self.batches = list(batches)
++        self.batch_index = 0
++        self.calls = []
++
++    def filter(self, **kwargs):
++        self.calls.append(("filter", kwargs))
++        return self
++
++    def exclude(self, **kwargs):
++        self.calls.append(("exclude", kwargs))
++        return self
++
++    def order_by(self, *args):
++        return self
++
++    def select_related(self, *args):
++        return self
++
++    def __getitem__(self, key):
++        if self.batch_index < len(self.batches):
++            batch = self.batches[self.batch_index]
++            self.batch_index += 1
++            return batch
++        return []
++
++    def get_overlap_excludes(self):
++        return [
++            c[1]["reserved_resources_record__overlap"]
++            for c in self.calls
++            if c[0] == "exclude" and "reserved_resources_record__overlap" in c[1]
++        ]
++
++
++@pytest.fixture
++def patched_modules():
++    """Patch the module-level imports used by fetch_task."""
++    with (
++        patch("pulpcore.tasking.redis_worker.extract_task_resources") as mock_extract,
++        patch("pulpcore.tasking.redis_worker.get_task_lock_key") as mock_get_key,
++        patch("pulpcore.tasking.redis_worker.acquire_locks") as mock_acquire,
++        patch("pulpcore.tasking.redis_worker.safe_release_task_locks") as mock_release,
++        patch("pulpcore.tasking.redis_worker.Task") as MockTask,
++    ):
++        mock_get_key.side_effect = lambda pk: f"task:{pk}"
++        yield {
++            "extract": mock_extract,
++            "get_key": mock_get_key,
++            "acquire": mock_acquire,
++            "release": mock_release,
++            "Task": MockTask,
++        }
++
++
++class TestFetchTaskBlockedResourceSkip:
++    """Test that fetch_task skips tasks needing blocked resources."""
++
++    def test_skips_blocked_resource_in_next_batch(self, patched_modules):
++        """After discovering resource_a is blocked in batch 1, batch 2's
++        DB query should exclude tasks needing resource_a and shared:resource_a."""
++        resource_a = "prn:rpm.repository:aaa"
++        resource_b = "prn:rpm.repository:bbb"
++
++        task1 = _make_task(resources=[resource_a, "shared:prn:core.domain:ddd"])
++        task2 = _make_task(resources=[resource_b, "shared:prn:core.domain:ddd"])
++
++        patched_modules["extract"].side_effect = [
++            ([resource_a], ["prn:core.domain:ddd"]),
++            ([resource_b], ["prn:core.domain:ddd"]),
++        ]
++        patched_modules["acquire"].side_effect = [
++            [resource_a],  # task1 blocked
++            [],  # task2 locks acquired
++        ]
++
++        # Batch 1: task1 blocked → blocked_resources grows → loop re-queries.
++        # Batch 2: task2 claimable.
++        qs = ChainedQuerySet([[task1], [task2]])
++
++        claim_qs = MagicMock()
++        claim_qs.update.return_value = 1
++
++        def filter_side_effect(**kwargs):
++            if "pk" in kwargs:
++                return claim_qs
++            return qs
++
++        patched_modules["Task"].objects.filter = filter_side_effect
++
++        worker = _make_worker()
++        result = worker.fetch_task()
++
++        assert result is not None
++        assert result.pk == task2.pk
++
++        overlap_excludes = qs.get_overlap_excludes()
++        assert len(overlap_excludes) >= 1
++        assert resource_a in overlap_excludes[0]
++        assert f"shared:{resource_a}" in overlap_excludes[0]
++
++    def test_does_not_add_task_lock_sentinel(self, patched_modules):
++        """__task_lock__ from acquire_locks should not be added to
++        the blocked_resources exclusion set."""
++        resource_a = "prn:rpm.repository:aaa"
++        task1 = _make_task(resources=[resource_a])
++
++        patched_modules["extract"].return_value = ([resource_a], [])
++        patched_modules["acquire"].return_value = ["__task_lock__"]
++
++        # __task_lock__ doesn't grow blocked_resources, so loop terminates
++        qs = ChainedQuerySet([[task1]])
++        patched_modules["Task"].objects.filter.return_value = qs
++
++        worker = _make_worker()
++        result = worker.fetch_task()
++
++        assert result is None
++        overlap_excludes = qs.get_overlap_excludes()
++        for excl in overlap_excludes:
++            assert "__task_lock__" not in excl
++
++    def test_returns_none_when_all_blocked(self, patched_modules):
++        """When all tasks need the same blocked resource, returns None."""
++        resource_a = "prn:rpm.repository:aaa"
++        tasks = [_make_task(resources=[resource_a]) for _ in range(5)]
++
++        patched_modules["extract"].return_value = ([resource_a], [])
++        patched_modules["acquire"].return_value = [resource_a]
++
++        # Batch 1: discover blocked resource. Batch 2: exclusion filters all → empty.
++        qs = ChainedQuerySet([tasks, []])
++        patched_modules["Task"].objects.filter.return_value = qs
++
++        worker = _make_worker()
++        result = worker.fetch_task()
++
++        assert result is None
++        # Only 1 Redis call — rest skipped by taken_exclusive
++        assert patched_modules["acquire"].call_count == 1
++
++    def test_claims_first_available(self, patched_modules):
++        """Returns the first claimable task."""
++        resource_a = "prn:rpm.repository:aaa"
++        task1 = _make_task(resources=[resource_a])
++
++        patched_modules["extract"].return_value = ([resource_a], [])
++        patched_modules["acquire"].return_value = []
++
++        qs = ChainedQuerySet([[task1]])
++        claim_qs = MagicMock()
++        claim_qs.update.return_value = 1
++        patched_modules["Task"].objects.filter.side_effect = [qs, claim_qs]
++
++        worker = _make_worker()
++        result = worker.fetch_task()
++
++        assert result is not None
++        assert result.pk == task1.pk
++
++    def test_empty_queue(self, patched_modules):
++        """Returns None when no waiting tasks exist."""
++        qs = ChainedQuerySet([[]])
++        patched_modules["Task"].objects.filter.return_value = qs
++
++        worker = _make_worker()
++        result = worker.fetch_task()
++
++        assert result is None
++        patched_modules["acquire"].assert_not_called()
++
++    def test_multiple_blocked_resources_accumulated(self, patched_modules):
++        """blocked_resources accumulates across multiple acquire_locks failures."""
++        resource_a = "prn:rpm.repository:aaa"
++        resource_b = "prn:rpm.repository:bbb"
++        resource_c = "prn:rpm.repository:ccc"
++
++        task_a = _make_task(resources=[resource_a])
++        task_b = _make_task(resources=[resource_b])
++        task_c = _make_task(resources=[resource_c])
++
++        patched_modules["extract"].side_effect = [
++            ([resource_a], []),
++            ([resource_b], []),
++            ([resource_c], []),
++        ]
++        patched_modules["acquire"].side_effect = [
++            [resource_a],  # task_a blocked
++            [resource_b],  # task_b blocked → blocked_resources grows again → re-query
++            [],  # task_c locks acquired
++        ]
++
++        # Batch 1: task_a blocked. Batch 2: task_b blocked. Batch 3: task_c claimable.
++        qs = ChainedQuerySet(
++            [
++                [task_a],
++                [task_b],
++                [task_c],
++            ]
++        )
++        claim_qs = MagicMock()
++        claim_qs.update.return_value = 1
++
++        def filter_side_effect(**kwargs):
++            if "pk" in kwargs:
++                return claim_qs
++            return qs
++
++        patched_modules["Task"].objects.filter = filter_side_effect
++
++        worker = _make_worker()
++        result = worker.fetch_task()
++
++        assert result is not None
++        assert result.pk == task_c.pk
++
++        overlap_excludes = qs.get_overlap_excludes()
++        assert len(overlap_excludes) >= 2
++        # Second exclude should contain both resource_a and resource_b
++        last_exclude = overlap_excludes[-1]
++        assert resource_a in last_exclude
++        assert resource_b in last_exclude
++
++    def test_shared_variant_added_to_exclusion(self, patched_modules):
++        """When a resource is blocked, both the raw name and shared: prefix
++        variant are added to the exclusion set."""
++        resource_a = "prn:rpm.repository:aaa"
++        resource_b = "prn:rpm.repository:bbb"
++
++        task1 = _make_task(resources=[resource_a])
++        task2 = _make_task(resources=[resource_b])
++
++        patched_modules["extract"].side_effect = [
++            ([resource_a], []),
++            ([resource_b], []),
++        ]
++        patched_modules["acquire"].side_effect = [
++            [resource_a],  # blocked
++            [],  # task2 claimable
++        ]
++
++        qs = ChainedQuerySet([[task1], [task2]])
++        claim_qs = MagicMock()
++        claim_qs.update.return_value = 1
++
++        def filter_side_effect(**kwargs):
++            if "pk" in kwargs:
++                return claim_qs
++            return qs
++
++        patched_modules["Task"].objects.filter = filter_side_effect
++
++        worker = _make_worker()
++        result = worker.fetch_task()
++
++        assert result is not None
++
++        overlap_excludes = qs.get_overlap_excludes()
++        assert len(overlap_excludes) >= 1
++        assert resource_a in overlap_excludes[0]
++        assert f"shared:{resource_a}" in overlap_excludes[0]
++
++    def test_stops_when_no_new_blocked_resources(self, patched_modules):
++        """Loop terminates when no new blocked resources are discovered
++        (prevents infinite re-querying)."""
++        resource_a = "prn:rpm.repository:aaa"
++
++        task1 = _make_task(resources=[resource_a])
++        task2 = _make_task(resources=[resource_a])
++
++        patched_modules["extract"].return_value = ([resource_a], [])
++        patched_modules["acquire"].return_value = [resource_a]
++
++        # Batch 1: discover resource_a blocked. Batch 2: same resource_a blocked
++        # again (no growth) → should stop, not loop forever.
++        qs = ChainedQuerySet([[task1], [task2], []])
++        patched_modules["Task"].objects.filter.return_value = qs
++
++        worker = _make_worker()
++        result = worker.fetch_task()
++
++        assert result is None
++        # Should have queried at most 2 batches (initial + one retry)
++        assert qs.batch_index <= 2
++
++
++@pytest.mark.django_db(transaction=True)
++class TestFetchTaskIntegration:
++    """Integration tests that run fetch_task() against real DB records
++    with only Redis (acquire_locks) mocked."""
++
++    @pytest.fixture(autouse=True)
++    def setup_domain_and_worker(self):
++        from datetime import timedelta
++
++        from pulpcore.app.models import AppStatus, Domain
++        from pulpcore.app.util import set_domain
++
++        self.domain = Domain.objects.get_or_create(
++            name="test-integration",
++            defaults={"storage_class": "django.core.files.storage.FileSystemStorage"},
++        )[0]
++        set_domain(self.domain)
++
++        self.app_status = AppStatus.objects.create(
++            name="1@test-integration-worker",
++            app_type="worker",
++            versions={},
++            ttl=timedelta(seconds=30),
++        )
++
++    def _create_task(self, resources, state="waiting"):
++        from pulpcore.app.models import Task
++
++        return Task.objects.create(
++            state=state,
++            name="test.task",
++            logging_cid="test",
++            reserved_resources_record=resources,
++            pulp_domain=self.domain,
++        )
++
++    def _make_worker(self):
++        from pulpcore.tasking.redis_worker import RedisWorker
++
++        worker = object.__new__(RedisWorker)
++        worker.ignored_task_ids = []
++        worker.redis_conn = MagicMock()
++        worker.name = self.app_status.name
++        worker.app_status = self.app_status
++        return worker
++
++    @patch("pulpcore.tasking.redis_worker.acquire_locks")
++    @patch("pulpcore.tasking.redis_worker.safe_release_task_locks")
++    def test_skips_blocked_resource_claims_free_resource(self, mock_release, mock_acquire):
++        """With 25 tasks needing blocked resource A and 1 task needing
++        free resource B, fetch_task() should skip all A tasks and claim B."""
++        resource_a = "prn:rpm.repository:blocked-repo"
++        resource_b = "prn:rpm.repository:free-repo"
++
++        for i in range(25):
++            self._create_task([resource_a, "shared:prn:core.domain:ddd"])
++        task_b = self._create_task([resource_b, "shared:prn:core.domain:ddd"])
++
++        def acquire_side_effect(
++            redis_conn, lock_owner, task_lock_key, exclusive_resources, shared_resources
++        ):
++            if resource_a in exclusive_resources:
++                return [resource_a]
++            return []
++
++        mock_acquire.side_effect = acquire_side_effect
++
++        worker = self._make_worker()
++        result = worker.fetch_task()
++
++        assert result is not None
++        assert result.pk == task_b.pk
++        assert result.app_lock == self.app_status
++
++    @patch("pulpcore.tasking.redis_worker.acquire_locks")
++    @patch("pulpcore.tasking.redis_worker.safe_release_task_locks")
++    def test_returns_none_when_all_resources_blocked(self, mock_release, mock_acquire):
++        """When every task needs a blocked resource, returns None."""
++        resource_a = "prn:rpm.repository:blocked-repo"
++
++        for i in range(10):
++            self._create_task([resource_a, "shared:prn:core.domain:ddd"])
++
++        mock_acquire.return_value = [resource_a]
++
++        worker = self._make_worker()
++        result = worker.fetch_task()
++
++        assert result is None
++        assert mock_acquire.call_count == 1
++
++    @patch("pulpcore.tasking.redis_worker.acquire_locks")
++    @patch("pulpcore.tasking.redis_worker.safe_release_task_locks")
++    def test_multiple_blocked_resources_finds_free_task(self, mock_release, mock_acquire):
++        """With tasks needing 3 different blocked resources and 1 task
++        needing a free resource, fetch_task() finds the free one."""
++        blocked = [
++            "prn:rpm.repository:blocked-1",
++            "prn:rpm.repository:blocked-2",
++            "prn:rpm.repository:blocked-3",
++        ]
++        free = "prn:rpm.repository:free"
++
++        for res in blocked:
++            for _ in range(5):
++                self._create_task([res, "shared:prn:core.domain:ddd"])
++        task_free = self._create_task([free, "shared:prn:core.domain:ddd"])
++
++        def acquire_side_effect(
++            redis_conn, lock_owner, task_lock_key, exclusive_resources, shared_resources
++        ):
++            if any(r in blocked for r in exclusive_resources):
++                return [r for r in exclusive_resources if r in blocked]
++            return []
++
++        mock_acquire.side_effect = acquire_side_effect
++
++        worker = self._make_worker()
++        result = worker.fetch_task()
++
++        assert result is not None
++        assert result.pk == task_free.pk
++
++    @patch("pulpcore.tasking.redis_worker.acquire_locks")
++    @patch("pulpcore.tasking.redis_worker.safe_release_task_locks")
++    def test_shared_resource_exclusion_works(self, mock_release, mock_acquire):
++        """Tasks needing shared access to a blocked resource are also
++        excluded from subsequent queries."""
++        resource_a = "prn:rpm.repository:blocked-repo"
++        resource_b = "prn:rpm.repository:free-repo"
++
++        self._create_task([resource_a])
++        self._create_task(["shared:prn:rpm.repository:blocked-repo"])
++        task_free = self._create_task([resource_b])
++
++        def acquire_side_effect(
++            redis_conn, lock_owner, task_lock_key, exclusive_resources, shared_resources
++        ):
++            if resource_a in exclusive_resources:
++                return [resource_a]
++            return []
++
++        mock_acquire.side_effect = acquire_side_effect
++
++        worker = self._make_worker()
++        result = worker.fetch_task()
++
++        assert result is not None
++        assert result.pk == task_free.pk
++
++    @patch("pulpcore.tasking.redis_worker.acquire_locks")
++    @patch("pulpcore.tasking.redis_worker.safe_release_task_locks")
++    def test_fifo_order_preserved_for_free_resources(self, mock_release, mock_acquire):
++        """Among tasks with free resources, FIFO order is preserved."""
++        resource_blocked = "prn:rpm.repository:blocked"
++        resource_free = "prn:rpm.repository:free"
++
++        self._create_task([resource_blocked])
++        task_first = self._create_task([resource_free])
++        self._create_task([resource_free])
++
++        def acquire_side_effect(
++            redis_conn, lock_owner, task_lock_key, exclusive_resources, shared_resources
++        ):
++            if resource_blocked in exclusive_resources:
++                return [resource_blocked]
++            return []
++
++        mock_acquire.side_effect = acquire_side_effect
++
++        worker = self._make_worker()
++        result = worker.fetch_task()
++
++        assert result is not None
++        assert result.pk == task_first.pk
+-- 
+2.55.0
+


### PR DESCRIPTION
## Summary
- Applies pulpcore patch to fix head-of-line blocking in RedisWorker's `fetch_task()` method
- Patch sequence number: 0061

## Test plan
- [ ] Verify the Docker image builds successfully with the new patch
- [ ] Confirm workers process tasks without head-of-line blocking

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Apply new pulpcore patch to address RedisWorker head-of-line blocking and include it in the Docker image build.

Bug Fixes:
- Fix RedisWorker task fetching behavior to prevent head-of-line blocking via upstream pulpcore patch.

Build:
- Add patch 0061 to the Dockerfile so it is applied during image build to fix RedisWorker fetch_task() head-of-line blocking.