### PR TITLE
fix: detect and clean abandoned locks held by live workers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -159,6 +159,9 @@ RUN patch -p1 -d /usr/local/lib/pulp/lib/python${PYTHON_VERSION}/site-packages <
 COPY images/assets/patches/0061-Fix-RedisWorker-fetch_task-head-of-line-blocking.patch /tmp/
 RUN patch -p1 -d /usr/local/lib/pulp/lib/python${PYTHON_VERSION}/site-packages < /tmp/0061-Fix-RedisWorker-fetch_task-head-of-line-blocking.patch
 
+COPY images/assets/patches/0062-Release-locks-on-fetch_task-exception.patch /tmp/
+RUN patch -p1 -d /usr/local/lib/pulp/lib/python${PYTHON_VERSION}/site-packages < /tmp/0062-Release-locks-on-fetch_task-exception.patch
+
 RUN mkdir /licenses
 COPY LICENSE /licenses/LICENSE
 

--- a/images/assets/patches/0062-Release-locks-on-fetch_task-exception.patch
+++ b/images/assets/patches/0062-Release-locks-on-fetch_task-exception.patch
@@ -1,0 +1,39 @@
+From 1eb3eb0676db0f1904233cfa235a42b41e00b01e Mon Sep 17 00:00:00 2001
+From: Dennis Kliban <dkliban@redhat.com>
+Date: Sat, 25 Jul 2026 08:05:38 -0400
+Subject: [PATCH] Release Redis locks on fetch_task() exception
+
+When acquire_locks() succeeds but a subsequent operation (e.g., the
+app_lock DB update) throws an exception, the except handler previously
+did `continue` without releasing the acquired locks. This left both
+the task lock and resource locks orphaned in Redis with no TTL,
+permanently blocking other tasks that need the same resources.
+
+Add safe_release_task_locks() to the except handler so locks are
+always released when an exception occurs after acquisition.
+
+Fixes: https://github.com/pulp/pulpcore/issues/7902
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+---
+ pulpcore/tasking/redis_worker.py | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/pulpcore/tasking/redis_worker.py b/pulpcore/tasking/redis_worker.py
+index 9b6b96663..668093622 100644
+--- a/pulpcore/tasking/redis_worker.py
++++ b/pulpcore/tasking/redis_worker.py
+@@ -510,6 +510,10 @@ class RedisWorker:
+ 
+                 except Exception as e:
+                     _logger.error("Error processing task %s: %s", task.pk, e)
++                    try:
++                        safe_release_task_locks(task, lock_owner=self.name)
++                    except Exception:
++                        pass
+                     continue
+ 
+             if len(blocked_resources) == prev_blocked_count:
+-- 
+2.55.0
+

--- a/pulp_service/pulp_service/app/tasks/redis_lock_utils.py
+++ b/pulp_service/pulp_service/app/tasks/redis_lock_utils.py
@@ -8,8 +8,13 @@ Functions in this module are consumed by both the ``StaleLockScanView``
 """
 
 import logging
+from datetime import timedelta
+
+from django.utils import timezone
 
 _logger = logging.getLogger(__name__)
+
+TASK_TERMINAL_STATES = {"completed", "failed", "canceled", "skipped"}
 
 
 def scan_resource_locks(redis_conn, cursor=0, max_keys=None):
@@ -172,3 +177,149 @@ def check_lock_holder_liveness(lock_holders):
                 "verdict": ("alive" if app.online else "DEAD: AppStatus exists but is not online, lock is orphaned"),
             }
     return result
+
+
+def detect_abandoned_task_locks(task_locks, min_age_seconds=60):
+    """
+    Identify task locks that are abandoned despite the holder being alive.
+
+    A task lock is abandoned if:
+    - The task is ``waiting`` with no ``app_lock`` (worker acquired the lock
+      but failed to claim the task via DB, then moved on).
+    - The task is in a terminal state (lock was not released after completion).
+    - The task no longer exists in the database (purged).
+
+    A minimum age threshold avoids a race with the normal acquire-to-claim
+    window in ``fetch_task()``.
+
+    Args:
+        task_locks: List of task lock dicts from ``scan_task_locks()``.
+        min_age_seconds: Ignore locks for tasks created less than this many
+            seconds ago (default 60).
+
+    Returns:
+        A list of abandoned task lock dicts, each augmented with
+        ``task_state`` and ``reason`` keys.
+    """
+    from pulpcore.app.models import Task
+
+    if not task_locks:
+        return []
+
+    task_ids = [lock["task_id"] for lock in task_locks]
+    tasks_by_id = {
+        str(t.pk): t
+        for t in Task.objects.filter(pk__in=task_ids).select_related("app_lock")
+    }
+
+    age_cutoff = timezone.now() - timedelta(seconds=min_age_seconds)
+    abandoned = []
+
+    for lock_info in task_locks:
+        task_id = lock_info["task_id"]
+        task = tasks_by_id.get(task_id)
+
+        if task is None:
+            entry = dict(lock_info)
+            entry["task_state"] = "NOT_FOUND"
+            entry["reason"] = "Task does not exist in database; lock is orphaned"
+            abandoned.append(entry)
+            continue
+
+        if task.pulp_created > age_cutoff:
+            continue
+
+        if task.state == "waiting" and task.app_lock is None:
+            entry = dict(lock_info)
+            entry["task_state"] = task.state
+            entry["reason"] = (
+                "Task is waiting with no app_lock; worker acquired the Redis "
+                "lock but did not claim the task"
+            )
+            abandoned.append(entry)
+        elif task.state in TASK_TERMINAL_STATES:
+            entry = dict(lock_info)
+            entry["task_state"] = task.state
+            entry["reason"] = (
+                f"Task is in terminal state '{task.state}' but Redis lock "
+                f"was not released"
+            )
+            abandoned.append(entry)
+
+    return abandoned
+
+
+def detect_abandoned_resource_locks(abandoned_task_locks, resource_locks, redis_conn):
+    """
+    Identify resource locks that correspond to abandoned tasks.
+
+    Starts from abandoned task locks, looks up each task's
+    ``reserved_resources_record``, and checks whether the matching Redis
+    resource lock is still held by the same worker.
+
+    Args:
+        abandoned_task_locks: List of abandoned task lock dicts (output of
+            ``detect_abandoned_task_locks``).
+        resource_locks: List of resource lock dicts from
+            ``scan_resource_locks()``.
+        redis_conn: Active Redis connection (unused but kept for API
+            consistency; resource lock state comes from the pre-scanned list).
+
+    Returns:
+        A list of abandoned resource lock dicts, each augmented with
+        ``abandoned_by_task`` and ``reason`` keys.
+    """
+    from pulpcore.app.models import Task
+
+    if not abandoned_task_locks:
+        return []
+
+    resource_locks_by_key = {}
+    for lock_info in resource_locks:
+        resource_locks_by_key[lock_info["lock_key"]] = lock_info
+
+    task_ids = [
+        lock["task_id"]
+        for lock in abandoned_task_locks
+        if lock.get("task_state") != "NOT_FOUND"
+    ]
+    tasks_by_id = {
+        str(t.pk): t
+        for t in Task.objects.filter(pk__in=task_ids)
+    } if task_ids else {}
+
+    from pulpcore.tasking.redis_locks import REDIS_LOCK_PREFIX
+
+    abandoned = []
+    seen_keys = set()
+
+    for task_lock in abandoned_task_locks:
+        task_id = task_lock["task_id"]
+        holder = task_lock.get("holder")
+        task = tasks_by_id.get(task_id)
+
+        if task is None:
+            continue
+
+        for resource in task.reserved_resources_record:
+            clean_resource = resource.removeprefix("shared:")
+            lock_key = f"{REDIS_LOCK_PREFIX}{clean_resource}"
+
+            if lock_key in seen_keys:
+                continue
+
+            resource_lock = resource_locks_by_key.get(lock_key)
+            if resource_lock is None:
+                continue
+
+            if holder and holder in resource_lock.get("holders", []):
+                entry = dict(resource_lock)
+                entry["abandoned_by_task"] = task_id
+                entry["abandoned_holder"] = holder
+                entry["reason"] = (
+                    f"Resource lock held by worker that abandoned task {task_id}"
+                )
+                abandoned.append(entry)
+                seen_keys.add(lock_key)
+
+    return abandoned

--- a/pulp_service/pulp_service/app/tasks/stale_lock_cleanup.py
+++ b/pulp_service/pulp_service/app/tasks/stale_lock_cleanup.py
@@ -17,6 +17,8 @@ from pulpcore.app.redis_connection import get_redis_connection
 
 from pulp_service.app.tasks.redis_lock_utils import (
     check_lock_holder_liveness,
+    detect_abandoned_resource_locks,
+    detect_abandoned_task_locks,
     scan_resource_locks,
     scan_task_locks,
 )
@@ -128,7 +130,65 @@ def cleanup_stale_locks():
         )
         task_locks_cleaned += 1
 
-    # -- Phase 5: return summary --------------------------------------------
+    # -- Phase 5: detect and clean abandoned locks (live holder, bad state) ---
+    remaining_task_locks = [
+        lock for lock in task_locks
+        if not lock.get("holder") or lock["holder"] not in dead_holders
+    ]
+    remaining_resource_locks = [
+        lock for lock in resource_locks
+        if not any(h in dead_holders for h in lock["holders"])
+    ]
+
+    abandoned_task_lock_list = detect_abandoned_task_locks(remaining_task_locks)
+    abandoned_resource_lock_list = detect_abandoned_resource_locks(
+        abandoned_task_lock_list, remaining_resource_locks, redis_conn
+    )
+
+    abandoned_resource_locks_cleaned = 0
+    abandoned_task_locks_cleaned = 0
+
+    # Delete resource locks first (safe ordering)
+    for lock_info in abandoned_resource_lock_list:
+        lock_key = lock_info["lock_key"]
+        lock_type = lock_info["lock_type"]
+        abandoned_holder = lock_info.get("abandoned_holder")
+
+        if lock_type == "set" and abandoned_holder:
+            redis_conn.srem(lock_key, abandoned_holder)
+            healthy_holders = [
+                h for h in lock_info["holders"] if h != abandoned_holder
+            ]
+            if not healthy_holders:
+                redis_conn.delete(lock_key)
+            _logger.info(
+                "Removed abandoned holder '%s' from resource lock '%s' (task %s)",
+                abandoned_holder,
+                lock_key,
+                lock_info.get("abandoned_by_task"),
+            )
+        elif lock_type == "string":
+            redis_conn.delete(lock_key)
+            _logger.info(
+                "Deleted abandoned exclusive resource lock '%s' (task %s)",
+                lock_key,
+                lock_info.get("abandoned_by_task"),
+            )
+        abandoned_resource_locks_cleaned += 1
+
+    # Then delete task locks
+    for lock_info in abandoned_task_lock_list:
+        lock_key = lock_info["lock_key"]
+        redis_conn.delete(lock_key)
+        _logger.info(
+            "Deleted abandoned task lock '%s' (state=%s, reason=%s)",
+            lock_key,
+            lock_info.get("task_state"),
+            lock_info.get("reason"),
+        )
+        abandoned_task_locks_cleaned += 1
+
+    # -- Phase 6: return summary --------------------------------------------
     summary = {
         "resource_locks_scanned": resource_locks_scanned,
         "resource_locks_orphaned": resource_locks_orphaned,
@@ -136,6 +196,10 @@ def cleanup_stale_locks():
         "task_locks_scanned": task_locks_scanned,
         "task_locks_orphaned": task_locks_orphaned,
         "task_locks_cleaned": task_locks_cleaned,
+        "abandoned_task_locks_detected": len(abandoned_task_lock_list),
+        "abandoned_task_locks_cleaned": abandoned_task_locks_cleaned,
+        "abandoned_resource_locks_detected": len(abandoned_resource_lock_list),
+        "abandoned_resource_locks_cleaned": abandoned_resource_locks_cleaned,
         "dead_holders": sorted(dead_holders),
     }
 

--- a/pulp_service/pulp_service/app/viewsets.py
+++ b/pulp_service/pulp_service/app/viewsets.py
@@ -54,6 +54,8 @@ from pulp_service.app.serializers import (
 from pulp_service.app.tasks.package_scan import check_content_from_repo_version, check_npm_package
 from pulp_service.app.tasks.redis_lock_utils import (
     check_lock_holder_liveness,
+    detect_abandoned_resource_locks,
+    detect_abandoned_task_locks,
     scan_resource_locks,
     scan_task_locks,
 )
@@ -1749,7 +1751,29 @@ class StaleLockScanView(APIView):
                 else:
                     healthy_task_locks.append(lock_info)
 
-            # Phase 4: Correlate orphaned resource locks to tasks
+            # Phase 4: Detect abandoned locks (live holder, bad task state)
+            abandoned_task_lock_list = detect_abandoned_task_locks(healthy_task_locks)
+            abandoned_resource_lock_list = detect_abandoned_resource_locks(
+                abandoned_task_lock_list, healthy_resource_locks, redis_conn
+            )
+
+            # Remove abandoned locks from healthy lists
+            abandoned_task_ids = {
+                lock["task_id"] for lock in abandoned_task_lock_list
+            }
+            abandoned_resource_keys = {
+                lock["lock_key"] for lock in abandoned_resource_lock_list
+            }
+            healthy_task_locks = [
+                lock for lock in healthy_task_locks
+                if lock["task_id"] not in abandoned_task_ids
+            ]
+            healthy_resource_locks = [
+                lock for lock in healthy_resource_locks
+                if lock["lock_key"] not in abandoned_resource_keys
+            ]
+
+            # Phase 5: Correlate orphaned resource locks to tasks
             task_correlations = _correlate_orphaned_locks_to_tasks(orphaned_resource_locks)
 
             # Also correlate orphaned task locks -- check if the task still
@@ -1777,6 +1801,8 @@ class StaleLockScanView(APIView):
                 "total_task_locks": len(task_locks_list),
                 "orphaned_task_locks": len(orphaned_task_locks),
                 "healthy_task_locks": len(healthy_task_locks),
+                "abandoned_task_locks": len(abandoned_task_lock_list),
+                "abandoned_resource_locks": len(abandoned_resource_lock_list),
                 "unique_lock_holders": len(all_holders),
                 "dead_lock_holders": sum(1 for info in lock_holder_liveness.values() if not info.get("online", False)),
             }
@@ -1785,6 +1811,8 @@ class StaleLockScanView(APIView):
                 "summary": summary,
                 "orphaned_resource_locks": orphaned_resource_locks,
                 "orphaned_task_locks": orphaned_task_locks,
+                "abandoned_task_locks": abandoned_task_lock_list,
+                "abandoned_resource_locks": abandoned_resource_lock_list,
                 "lock_holder_liveness": lock_holder_liveness,
                 "task_correlations": task_correlations,
                 "worker_summary": worker_summary,
@@ -1797,6 +1825,12 @@ class StaleLockScanView(APIView):
             if include_healthy:
                 response_data["healthy_resource_locks"] = healthy_resource_locks
                 response_data["healthy_task_locks"] = healthy_task_locks
+
+            if has_more:
+                response_data["abandoned_locks_note"] = (
+                    "Abandoned lock detection in paginated mode is approximate; "
+                    "task locks and resource locks may be on different pages."
+                )
 
             return Response(response_data)
 

--- a/pulp_service/pulp_service/tests/functional/test_task_debug.py
+++ b/pulp_service/pulp_service/tests/functional/test_task_debug.py
@@ -325,6 +325,8 @@ class TestStaleLockScanView:
         assert "total_task_locks" in summary
         assert "orphaned_task_locks" in summary
         assert "healthy_task_locks" in summary
+        assert "abandoned_task_locks" in summary
+        assert "abandoned_resource_locks" in summary
         assert "unique_lock_holders" in summary
         assert "dead_lock_holders" in summary
 
@@ -333,11 +335,17 @@ class TestStaleLockScanView:
             assert isinstance(value, int), f"summary[{key}] should be int, got {type(value)}"
             assert value >= 0, f"summary[{key}] should be >= 0, got {value}"
 
-        # Total should equal orphaned + healthy
+        # Total should equal orphaned + healthy + abandoned
         assert summary["total_resource_locks"] == (
-            summary["orphaned_resource_locks"] + summary["healthy_resource_locks"]
+            summary["orphaned_resource_locks"]
+            + summary["healthy_resource_locks"]
+            + summary["abandoned_resource_locks"]
         )
-        assert summary["total_task_locks"] == (summary["orphaned_task_locks"] + summary["healthy_task_locks"])
+        assert summary["total_task_locks"] == (
+            summary["orphaned_task_locks"]
+            + summary["healthy_task_locks"]
+            + summary["abandoned_task_locks"]
+        )
 
         # --- orphaned locks sections ---
         assert "orphaned_resource_locks" in data
@@ -345,6 +353,13 @@ class TestStaleLockScanView:
 
         assert "orphaned_task_locks" in data
         assert isinstance(data["orphaned_task_locks"], list)
+
+        # --- abandoned locks sections ---
+        assert "abandoned_task_locks" in data
+        assert isinstance(data["abandoned_task_locks"], list)
+
+        assert "abandoned_resource_locks" in data
+        assert isinstance(data["abandoned_resource_locks"], list)
 
         # --- liveness section ---
         assert "lock_holder_liveness" in data


### PR DESCRIPTION
## Summary
- Add abandoned lock detection to the stale-locks scanner and cleanup task
- Abandoned locks are held by **live** workers that are no longer using them (worker acquired Redis locks, failed to claim the task, moved on without releasing)
- Detection criteria: task is waiting with no app_lock, task is in a terminal state, or task no longer exists in DB
- 60-second age threshold prevents false positives during the normal acquire-to-claim window
- Includes pulpcore patch (0062) fixing the root cause: `fetch_task()` except handler now releases locks

## Changes
- `redis_lock_utils.py`: `detect_abandoned_task_locks()` and `detect_abandoned_resource_locks()`
- `stale_lock_cleanup.py`: Phase 5 cleans abandoned locks (resource locks first, then task locks)
- `viewsets.py`: `StaleLockScanView` reports `abandoned_task_locks` and `abandoned_resource_locks`
- `Dockerfile` + patch `0062`: root cause fix in `fetch_task()` except handler
- Tests updated for new response fields

## Test plan
- [ ] Existing `test_task_debug.py` tests pass with updated assertions
- [ ] Stale-locks endpoint returns `abandoned_task_locks` and `abandoned_resource_locks` in summary
- [ ] Cleanup task detects and removes abandoned locks
- [ ] Patch 0062 applies cleanly on top of patch 0061

Fixes: https://redhat.atlassian.net/browse/PULP-2151
Fixes: https://github.com/pulp/pulpcore/issues/7902

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Detect and clean abandoned Redis locks held by live workers, and expose the new lock categorization in the stale-locks debug API.

New Features:
- Add detection of abandoned task locks based on task state, age, and database presence.
- Add detection of abandoned resource locks correlated to abandoned tasks and held by the same worker.
- Extend the stale-locks debug API to report counts and details for abandoned task and resource locks, including an approximate note for paginated responses.

Bug Fixes:
- Ensure Redis locks acquired during fetch_task() are released when an exception occurs via a new pulpcore patch.

Enhancements:
- Integrate abandoned lock detection and cleanup into the stale-lock cleanup task, with safe ordering of resource and task lock deletion.
- Augment stale-lock cleanup summaries with abandoned lock detection and cleanup metrics.

Build:
- Apply an additional pulpcore patch in the Docker image to release locks on fetch_task exceptions.

Tests:
- Update task debug functional tests to validate new summary fields, list sections, and total lock accounting including abandoned locks.