### PR TITLE
chore: update pulp_maven to version 0.25.0

### DIFF
--- a/pulp_service/requirements.txt
+++ b/pulp_service/requirements.txt
@@ -4,7 +4,7 @@ solv>=0.7.21,<0.7.38
 pulp-python==3.32.0
 pulp-npm==0.8.0
 pulp-container==2.28.0
-pulp-maven==0.24.0
+pulp-maven==0.25.0
 pulp-hugging-face==0.3.0
 pulp-cli
 requests


### PR DESCRIPTION
Update pulp_maven to 0.25.0 . 
Latest change for that version: https://github.com/pulp/pulp_maven/pull/424