### PR TITLE
fix: pin pulp_rpm test requirements to installed version

### DIFF
--- a/.tekton/pulp-deploy-and-test.yaml
+++ b/.tekton/pulp-deploy-and-test.yaml
@@ -788,8 +788,11 @@ spec:
 
               cmd_prefix bash -c "HOME=/tmp/home pip3 install pytest\<8 gnupg"
 
-              curl -o functest_requirements.txt https://raw.githubusercontent.com/pulp/pulp_rpm/main/functest_requirements.txt
-              curl -o unittest_requirements.txt https://raw.githubusercontent.com/pulp/pulp_rpm/main/unittest_requirements.txt
+              PULP_RPM_VERSION=$(cmd_prefix python3 -c "from importlib.metadata import version; print(version('pulp-rpm'))")
+              echo "Installed pulp_rpm version: $PULP_RPM_VERSION"
+
+              curl -o functest_requirements.txt https://raw.githubusercontent.com/pulp/pulp_rpm/${PULP_RPM_VERSION}/functest_requirements.txt
+              curl -o unittest_requirements.txt https://raw.githubusercontent.com/pulp/pulp_rpm/${PULP_RPM_VERSION}/unittest_requirements.txt
 
               ### Adapted from ./.github/workflows/scripts/script.sh
               cat unittest_requirements.txt | cmd_stdin_prefix bash -c "cat > /tmp/unittest_requirements.txt"

--- a/pulp_service/requirements.txt
+++ b/pulp_service/requirements.txt
@@ -1,5 +1,5 @@
 pulpcore==3.115.2
-pulp-rpm==3.38.3
+pulp-rpm==3.38.4
 solv>=0.7.21,<0.7.38
 pulp-python==3.32.1
 pulp-npm==0.9.0

--- a/pulp_service/requirements.txt
+++ b/pulp_service/requirements.txt
@@ -1,5 +1,5 @@
 pulpcore==3.115.2
-pulp-rpm==3.38.2
+pulp-rpm==3.38.3
 solv>=0.7.21,<0.7.38
 pulp-python==3.32.1
 pulp-npm==0.9.0


### PR DESCRIPTION
## Summary

- The bonfire pipeline fetched `functest_requirements.txt` and `unittest_requirements.txt` from pulp_rpm `main`, but ran tests against the released version in the container image
- This caused 3 test errors when `main` diverged (e.g. `rpm_package_api` fixture moved in main but not yet released in 3.38.2)
- Now queries the installed `pulp-rpm` version via `importlib.metadata` and fetches requirements from the matching GitHub tag

## Test plan

- [ ] Bonfire pipeline passes on this PR (the fix itself is exercised by the pipeline)

Assisted-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

## Summary by Sourcery

Bug Fixes:
- Prevent test failures caused by fetching functest and unittest requirements from pulp_rpm main instead of the installed release tag in the test container.

Closes PULP-2176