### PR TITLE
feat: add RBAC permissions to pulp-service viewsets

### DIFF
--- a/CHANGES/rbac.feature
+++ b/CHANGES/rbac.feature
@@ -1,0 +1,3 @@
+Added RBAC permissions to pulp-service model viewsets (VulnerabilityReport, PyPIYankMonitor,
+FeatureContentGuard, TaskViewSet, CreateDomainView, MigrateDomainView) using pulpcore's standard
+AccessPolicy framework layered on top of the existing DomainBasedPermission.

--- a/dev-container/settings.py
+++ b/dev-container/settings.py
@@ -44,6 +44,7 @@ REST_FRAMEWORK__DEFAULT_AUTHENTICATION_CLASSES = (
 
 REST_FRAMEWORK__DEFAULT_PERMISSION_CLASSES = (
     "pulp_service.app.authorization.DomainBasedPermission",
+    "pulpcore.app.access_policy.AccessPolicyFromDB",
 )
 
 AUTHENTICATION_JSON_HEADER = "HTTP_X_RH_IDENTITY"

--- a/pulp_service/pulp_service/app/__init__.py
+++ b/pulp_service/pulp_service/app/__init__.py
@@ -13,3 +13,29 @@ class PulpServicePluginAppConfig(PulpPluginAppConfig):
     def ready(self):
         super().ready()
         from . import signals  # noqa: F401
+
+        from django.db.models.signals import post_migrate
+
+        post_migrate.connect(_populate_domain_view_access_policies, sender=self)
+
+
+def _populate_domain_view_access_policies(sender, apps, **kwargs):  # noqa: ARG001
+    from pulp_service.app.viewsets import CreateDomainView, MigrateDomainView
+
+    try:
+        AccessPolicy = apps.get_model("core", "AccessPolicy")
+    except LookupError:
+        return
+
+    for view_cls in (CreateDomainView, MigrateDomainView):
+        access_policy = getattr(view_cls, "DEFAULT_ACCESS_POLICY", None)
+        if access_policy is None:
+            continue
+        viewset_name = view_cls.urlpattern()
+        db_access_policy, created = AccessPolicy.objects.get_or_create(
+            viewset_name=viewset_name, defaults=access_policy
+        )
+        if not created and not db_access_policy.customized:
+            for key, value in access_policy.items():
+                setattr(db_access_policy, key, value)
+            db_access_policy.save()

--- a/pulp_service/pulp_service/app/global_access_conditions.py
+++ b/pulp_service/pulp_service/app/global_access_conditions.py
@@ -1,0 +1,15 @@
+from pulpcore.plugin.util import get_domain_pk
+
+from pulp_service.app.authorization import DomainBasedPermission
+
+
+def has_domain_org_access(request, _view, _action):
+    user = request.user
+    if not user.is_authenticated:
+        return False
+
+    perm = DomainBasedPermission()
+    domain_pk = get_domain_pk()
+    decoded_header = perm.get_decoded_identity_header(request)
+    org_id = perm.get_org_id(decoded_header)
+    return perm._has_domain_access(domain_pk, org_id, user)

--- a/pulp_service/pulp_service/app/migrations/0018_add_rbac_permissions.py
+++ b/pulp_service/pulp_service/app/migrations/0018_add_rbac_permissions.py
@@ -1,0 +1,29 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("service", "0017_alter_pypiyankmonitor_pulp_id_and_more"),
+    ]
+
+    operations = [
+        migrations.AlterModelOptions(
+            name="vulnerabilityreport",
+            options={
+                "default_related_name": "%(app_label)s_%(model_name)s",
+                "permissions": [
+                    ("manage_roles_vulnerabilityreport", "Can manage roles on vulnerability reports"),
+                ],
+            },
+        ),
+        migrations.AlterModelOptions(
+            name="pypiyankmonitor",
+            options={
+                "default_related_name": "%(app_label)s_%(model_name)s",
+                "permissions": [
+                    ("manage_roles_pypiyankmonitor", "Can manage roles on PyPI yank monitors"),
+                ],
+            },
+        ),
+    ]

--- a/pulp_service/pulp_service/app/models.py
+++ b/pulp_service/pulp_service/app/models.py
@@ -118,7 +118,7 @@ class YankedPackageReport(BaseModel):
         default_related_name = "%(app_label)s_%(model_name)s"
 
 
-class PyPIYankMonitor(BaseModel):
+class PyPIYankMonitor(BaseModel, AutoAddObjPermsMixin):
     """
     Registers a Python repository or repository version for daily PyPI yank monitoring.
     Exactly one of repository or repository_version must be set.
@@ -144,9 +144,12 @@ class PyPIYankMonitor(BaseModel):
 
     class Meta:
         default_related_name = "%(app_label)s_%(model_name)s"
+        permissions = [
+            ("manage_roles_pypiyankmonitor", "Can manage roles on PyPI yank monitors"),
+        ]
 
 
-class VulnerabilityReport(BaseModel):
+class VulnerabilityReport(BaseModel, AutoAddObjPermsMixin):
     """
     Model used in vulnerability report.
     """
@@ -156,3 +159,6 @@ class VulnerabilityReport(BaseModel):
 
     class Meta:
         default_related_name = "%(app_label)s_%(model_name)s"
+        permissions = [
+            ("manage_roles_vulnerabilityreport", "Can manage roles on vulnerability reports"),
+        ]

--- a/pulp_service/pulp_service/app/settings.py
+++ b/pulp_service/pulp_service/app/settings.py
@@ -39,3 +39,8 @@ DOMAIN_ACCESS_POLICIES = {
         "subscription_endpoints": ["/api/v3/content/"],
     },
 }
+
+DRF_ACCESS_POLICY = {
+    "dynaconf_merge_unique": True,
+    "reusable_conditions": ["pulp_service.app.global_access_conditions"],
+}

--- a/pulp_service/pulp_service/app/viewsets.py
+++ b/pulp_service/pulp_service/app/viewsets.py
@@ -21,6 +21,7 @@ from rest_framework.permissions import BasePermission, IsAdminUser
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
+from pulpcore.app.access_policy import AccessPolicyFromDB
 from pulpcore.app.contexts import with_domain
 from pulpcore.app.models import Domain, Group, Task
 from pulpcore.app.serializers import DomainSerializer
@@ -149,6 +150,68 @@ class FeatureContentGuardViewSet(ContentGuardViewSet, RolesMixin):
     endpoint_name = "feature"
     queryset = FeatureContentGuard.objects.all()
     serializer_class = FeatureContentGuardSerializer
+    permission_classes = [DomainBasedPermission, AccessPolicyFromDB]
+    queryset_filtering_required_permission = "service.view_featurecontentguard"
+
+    DEFAULT_ACCESS_POLICY = {
+        "statements": [
+            {"action": ["list", "my_permissions"], "principal": "authenticated", "effect": "allow"},
+            {
+                "action": ["create"],
+                "principal": "authenticated",
+                "effect": "allow",
+                "condition": "has_model_or_domain_perms:service.add_featurecontentguard",
+            },
+            {
+                "action": ["retrieve"],
+                "principal": "authenticated",
+                "effect": "allow",
+                "condition": "has_model_or_domain_or_obj_perms:service.view_featurecontentguard",
+            },
+            {
+                "action": ["update", "partial_update"],
+                "principal": "authenticated",
+                "effect": "allow",
+                "condition": [
+                    "has_model_or_domain_or_obj_perms:service.change_featurecontentguard",
+                    "has_model_or_domain_or_obj_perms:service.view_featurecontentguard",
+                ],
+            },
+            {
+                "action": ["destroy"],
+                "principal": "authenticated",
+                "effect": "allow",
+                "condition": [
+                    "has_model_or_domain_or_obj_perms:service.delete_featurecontentguard",
+                    "has_model_or_domain_or_obj_perms:service.view_featurecontentguard",
+                ],
+            },
+            {
+                "action": ["list_roles", "add_role", "remove_role"],
+                "principal": "authenticated",
+                "effect": "allow",
+                "condition": "has_model_or_domain_or_obj_perms:service.manage_roles_featurecontentguard",
+            },
+        ],
+        "creation_hooks": [
+            {
+                "function": "add_roles_for_object_creator",
+                "parameters": {"roles": "service.featurecontentguard_owner"},
+            }
+        ],
+        "queryset_scoping": {"function": "scope_queryset"},
+    }
+
+    LOCKED_ROLES = {
+        "service.featurecontentguard_creator": ["service.add_featurecontentguard"],
+        "service.featurecontentguard_owner": [
+            "service.view_featurecontentguard",
+            "service.change_featurecontentguard",
+            "service.delete_featurecontentguard",
+            "service.manage_roles_featurecontentguard",
+        ],
+        "service.featurecontentguard_viewer": ["service.view_featurecontentguard"],
+    }
 
 
 class DebugAuthenticationHeadersView(APIView):
@@ -204,11 +267,31 @@ class DebugAuthenticationHeadersView(APIView):
 )
 class TaskViewSet(TaskViewSet):
     LOCKED_ROLES = {}
+    permission_classes = [DomainBasedPermission, AccessPolicyFromDB]
+
+    DEFAULT_ACCESS_POLICY = {
+        "statements": [
+            {"action": ["list"], "principal": "authenticated", "effect": "allow"},
+            {
+                "action": ["retrieve"],
+                "principal": "authenticated",
+                "effect": "allow",
+                "condition": "has_model_or_domain_or_obj_perms:core.view_task",
+            },
+            {
+                "action": ["destroy"],
+                "principal": "authenticated",
+                "effect": "allow",
+                "condition": "has_model_or_domain_or_obj_perms:core.delete_task",
+            },
+            {"action": ["purge"], "principal": "admin", "effect": "allow"},
+        ],
+        "queryset_scoping": {"function": "scope_queryset"},
+    }
 
     def get_queryset(self):
         qs = self.queryset
         if isinstance(qs, QuerySet):
-            # Ensure queryset is re-evaluated on each request.
             qs = qs.all()
 
         if self.parent_lookup_kwargs and self.kwargs:
@@ -224,10 +307,62 @@ class TaskViewSet(TaskViewSet):
         return "admintasks"
 
 
-class VulnerabilityReport(NamedModelViewSet, ListModelMixin, RetrieveModelMixin, DestroyModelMixin):
+class VulnerabilityReport(NamedModelViewSet, RolesMixin, ListModelMixin, RetrieveModelMixin, DestroyModelMixin):
     endpoint_name = "vuln_report_service"
     queryset = VulnReport.objects.all()
     serializer_class = VulnerabilityReportSerializer
+    permission_classes = [DomainBasedPermission, AccessPolicyFromDB]
+    queryset_filtering_required_permission = "service.view_vulnerabilityreport"
+
+    DEFAULT_ACCESS_POLICY = {
+        "statements": [
+            {"action": ["list", "my_permissions"], "principal": "authenticated", "effect": "allow"},
+            {
+                "action": ["create"],
+                "principal": "authenticated",
+                "effect": "allow",
+                "condition": "has_model_or_domain_perms:service.add_vulnerabilityreport",
+            },
+            {
+                "action": ["retrieve"],
+                "principal": "authenticated",
+                "effect": "allow",
+                "condition": "has_model_or_domain_or_obj_perms:service.view_vulnerabilityreport",
+            },
+            {
+                "action": ["destroy"],
+                "principal": "authenticated",
+                "effect": "allow",
+                "condition": [
+                    "has_model_or_domain_or_obj_perms:service.delete_vulnerabilityreport",
+                    "has_model_or_domain_or_obj_perms:service.view_vulnerabilityreport",
+                ],
+            },
+            {
+                "action": ["list_roles", "add_role", "remove_role"],
+                "principal": "authenticated",
+                "effect": "allow",
+                "condition": "has_model_or_domain_or_obj_perms:service.manage_roles_vulnerabilityreport",
+            },
+        ],
+        "creation_hooks": [
+            {
+                "function": "add_roles_for_object_creator",
+                "parameters": {"roles": "service.vulnerabilityreport_owner"},
+            }
+        ],
+        "queryset_scoping": {"function": "scope_queryset"},
+    }
+
+    LOCKED_ROLES = {
+        "service.vulnerabilityreport_creator": ["service.add_vulnerabilityreport"],
+        "service.vulnerabilityreport_owner": [
+            "service.view_vulnerabilityreport",
+            "service.delete_vulnerabilityreport",
+            "service.manage_roles_vulnerabilityreport",
+        ],
+        "service.vulnerabilityreport_viewer": ["service.view_vulnerabilityreport"],
+    }
 
     @extend_schema(
         request=ContentScanSerializer,
@@ -269,13 +404,89 @@ class PyPIYankMonitorFilter(BaseFilterSet):
 
 
 class PyPIYankMonitorViewSet(
-    NamedModelViewSet, CreateModelMixin, ListModelMixin, RetrieveModelMixin, DestroyModelMixin
+    NamedModelViewSet, RolesMixin, CreateModelMixin, ListModelMixin, RetrieveModelMixin, DestroyModelMixin
 ):
     endpoint_name = "pypi_yank_monitor"
     queryset = PyPIYankMonitor.objects.all()
     serializer_class = PyPIYankMonitorSerializer
     filterset_class = PyPIYankMonitorFilter
-    permission_classes = [DomainBasedPermission]
+    permission_classes = [DomainBasedPermission, AccessPolicyFromDB]
+    queryset_filtering_required_permission = "service.view_pypiyankmonitor"
+
+    DEFAULT_ACCESS_POLICY = {
+        "statements": [
+            {"action": ["list", "my_permissions"], "principal": "authenticated", "effect": "allow"},
+            {
+                "action": ["create"],
+                "principal": "authenticated",
+                "effect": "allow",
+                "condition": "has_model_or_domain_perms:service.add_pypiyankmonitor",
+            },
+            {
+                "action": ["retrieve"],
+                "principal": "authenticated",
+                "effect": "allow",
+                "condition": "has_model_or_domain_or_obj_perms:service.view_pypiyankmonitor",
+            },
+            {
+                "action": ["update", "partial_update"],
+                "principal": "authenticated",
+                "effect": "allow",
+                "condition": [
+                    "has_model_or_domain_or_obj_perms:service.change_pypiyankmonitor",
+                    "has_model_or_domain_or_obj_perms:service.view_pypiyankmonitor",
+                ],
+            },
+            {
+                "action": ["destroy"],
+                "principal": "authenticated",
+                "effect": "allow",
+                "condition": [
+                    "has_model_or_domain_or_obj_perms:service.delete_pypiyankmonitor",
+                    "has_model_or_domain_or_obj_perms:service.view_pypiyankmonitor",
+                ],
+            },
+            {
+                "action": ["check"],
+                "principal": "authenticated",
+                "effect": "allow",
+                "condition": [
+                    "has_model_or_domain_or_obj_perms:service.change_pypiyankmonitor",
+                    "has_model_or_domain_or_obj_perms:service.view_pypiyankmonitor",
+                ],
+            },
+            {
+                "action": ["report"],
+                "principal": "authenticated",
+                "effect": "allow",
+                "condition": "has_model_or_domain_or_obj_perms:service.view_pypiyankmonitor",
+            },
+            {
+                "action": ["list_roles", "add_role", "remove_role"],
+                "principal": "authenticated",
+                "effect": "allow",
+                "condition": "has_model_or_domain_or_obj_perms:service.manage_roles_pypiyankmonitor",
+            },
+        ],
+        "creation_hooks": [
+            {
+                "function": "add_roles_for_object_creator",
+                "parameters": {"roles": "service.pypiyankmonitor_owner"},
+            }
+        ],
+        "queryset_scoping": {"function": "scope_queryset"},
+    }
+
+    LOCKED_ROLES = {
+        "service.pypiyankmonitor_creator": ["service.add_pypiyankmonitor"],
+        "service.pypiyankmonitor_owner": [
+            "service.view_pypiyankmonitor",
+            "service.change_pypiyankmonitor",
+            "service.delete_pypiyankmonitor",
+            "service.manage_roles_pypiyankmonitor",
+        ],
+        "service.pypiyankmonitor_viewer": ["service.view_pypiyankmonitor"],
+    }
 
     @extend_schema(request=None, responses={202: AsyncOperationResponseSerializer})
     @action(detail=True, methods=["post"], url_path="check")
@@ -1888,10 +2099,22 @@ class StaleLockCleanupDispatcherView(APIView):
 
 
 class CreateDomainView(APIView):
-    permission_classes = [DomainBasedPermission]
     """
     Custom endpoint to create domains with service-specific logic.
     """
+
+    action = "create"
+    permission_classes = [DomainBasedPermission, AccessPolicyFromDB]
+
+    DEFAULT_ACCESS_POLICY = {
+        "statements": [
+            {"action": ["create"], "principal": "authenticated", "effect": "allow"},
+        ],
+    }
+
+    @classmethod
+    def urlpattern(cls):
+        return "domains/create"
 
     @extend_schema(
         request=DomainSerializer,
@@ -1991,7 +2214,23 @@ class MigrateDomainView(APIView):
     for domain creation.
     """
 
-    permission_classes = [DomainBasedPermission]
+    action = "create"
+    permission_classes = [DomainBasedPermission, AccessPolicyFromDB]
+
+    DEFAULT_ACCESS_POLICY = {
+        "statements": [
+            {
+                "action": ["create"],
+                "principal": "authenticated",
+                "effect": "allow",
+                "condition": "has_domain_org_access",
+            },
+        ],
+    }
+
+    @classmethod
+    def urlpattern(cls):
+        return "domains/migrate"
 
     @extend_schema(
         description=(

--- a/pulp_service/pulp_service/tests/functional/test_rbac.py
+++ b/pulp_service/pulp_service/tests/functional/test_rbac.py
@@ -1,0 +1,72 @@
+import pytest
+
+
+@pytest.mark.parallel
+class TestRBACAccessPoliciesRegistered:
+    """Verify that RBAC access policies, roles, and permissions are correctly registered."""
+
+    def test_vuln_report_access_policy_exists(self, pulpcore_bindings):
+        policies = pulpcore_bindings.AccessPoliciesApi.list(viewset_name="vuln_report_service")
+        assert policies.count == 1
+        policy = policies.results[0]
+        assert len(policy.statements) == 5
+        assert policy.creation_hooks is not None
+
+    def test_pypi_yank_monitor_access_policy_exists(self, pulpcore_bindings):
+        policies = pulpcore_bindings.AccessPoliciesApi.list(viewset_name="pypi_yank_monitor")
+        assert policies.count == 1
+        policy = policies.results[0]
+        assert len(policy.statements) == 8
+        assert policy.creation_hooks is not None
+
+    def test_feature_content_guard_access_policy_exists(self, pulpcore_bindings):
+        policies = pulpcore_bindings.AccessPoliciesApi.list(viewset_name="contentguards/service/feature")
+        assert policies.count == 1
+        policy = policies.results[0]
+        assert len(policy.statements) == 6
+        assert policy.creation_hooks is not None
+
+    def test_domain_create_access_policy_exists(self, pulpcore_bindings):
+        policies = pulpcore_bindings.AccessPoliciesApi.list(viewset_name="domains/create")
+        assert policies.count == 1
+
+    def test_domain_migrate_access_policy_exists(self, pulpcore_bindings):
+        policies = pulpcore_bindings.AccessPoliciesApi.list(viewset_name="domains/migrate")
+        assert policies.count == 1
+        policy = policies.results[0]
+        actions = [s["action"] for s in policy.statements]
+        assert ["create"] in actions
+
+
+@pytest.mark.parallel
+class TestRBACDeniesWithoutAuth:
+    """Verify that unauthenticated users are denied."""
+
+    def test_list_vuln_reports_denied_without_auth(self, service_bindings, anonymous_user):
+        with anonymous_user:
+            with pytest.raises(service_bindings.module.ApiException) as exc:
+                service_bindings.VulnReportServiceApi.list()
+            assert exc.value.status == 401
+
+    def test_list_pypi_monitors_denied_without_auth(self, service_bindings, anonymous_user):
+        with anonymous_user:
+            with pytest.raises(service_bindings.module.ApiException) as exc:
+                service_bindings.PypiYankMonitorApi.list()
+            assert exc.value.status == 401
+
+
+@pytest.mark.parallel
+class TestRBACAdminAccess:
+    """Verify that admin users can perform RBAC-gated operations (superuser bypasses both layers)."""
+
+    def test_admin_can_list_vuln_reports(self, vuln_report_service_api):
+        result = vuln_report_service_api.list()
+        assert result.count >= 0
+
+    def test_admin_can_list_pypi_monitors(self, pypi_yank_monitor_api):
+        result = pypi_yank_monitor_api.list()
+        assert result.count >= 0
+
+    def test_admin_can_list_content_guards(self, service_content_guards_api_client):
+        result = service_content_guards_api_client.list()
+        assert result.count >= 0


### PR DESCRIPTION
Add pulpcore's standard RBAC framework (access policies, locked roles, queryset scoping, RolesMixin) to model viewsets, layered on top of the existing DomainBasedPermission. Both permission gates must pass for a request to proceed.

Changes:
- Add AutoAddObjPermsMixin and manage_roles permissions to VulnerabilityReport and PyPIYankMonitor models
- Add DEFAULT_ACCESS_POLICY and LOCKED_ROLES (creator/owner/viewer) to FeatureContentGuardViewSet, TaskViewSet, VulnerabilityReport, and PyPIYankMonitorViewSet
- Add global_access_conditions.py with has_domain_org_access condition
- Register access policies for CreateDomainView and MigrateDomainView via post_migrate signal handler
- Add AccessPolicyFromDB to dev-container default permission classes
- Add RBAC functional tests

## Summary by Sourcery

Introduce pulpcore RBAC access policies across key pulp-service viewsets, layering AccessPolicy-based enforcement on top of existing domain-based permissions.

New Features:
- Add RBAC access policies, locked roles, and queryset scoping to FeatureContentGuard, Task, VulnerabilityReport, PyPIYankMonitor, and custom domain creation/migration views.
- Enable object-level role assignment and automatic creator role provisioning for PyPIYankMonitor and VulnerabilityReport records.
- Provide a reusable has_domain_org_access access condition integrating domain-based org checks into RBAC policies.

Enhancements:
- Wire AccessPolicyFromDB into the default REST permission classes for the dev container to honor database-backed access policies.
- Populate domain creation and migration access policies via a post-migrate signal to ensure policies exist and stay in sync when not customized.
- Configure DRF access policy settings to load reusable conditions from the pulp-service app.

Documentation:
- Document the new RBAC behavior in the changelog via a dedicated feature entry.

Tests:
- Add functional RBAC tests to verify access policy registration, unauthenticated access denial, and admin access behavior for service viewsets.